### PR TITLE
chore: update `publicationISSN` usage to be load via `Identifier#publication_issn` where possible

### DIFF
--- a/app/helpers/stash_engine/publication_updater_helper.rb
+++ b/app/helpers/stash_engine/publication_updater_helper.rb
@@ -24,7 +24,12 @@ module StashEngine
     def fetch_identifier_metadata(resource:, data_type:)
       return nil unless resource.present? && data_type.present?
 
-      resource.identifier.internal_data.where(data_type: data_type).first&.value || 'Not available'
+      case data_type
+      when 'publicationISSN', 'publicationName'
+        resource.identifier.send(data_type.underscore)&.value || 'Not Available'
+      else
+        resource.identifier.internal_data.where(data_type: data_type).first&.value || 'Not available'
+      end
     end
 
     def fetch_related_primary_article(resource:)

--- a/app/models/stash_engine/internal_datum.rb
+++ b/app/models/stash_engine/internal_datum.rb
@@ -2,6 +2,8 @@ module StashEngine
   class InternalDatum < ApplicationRecord
     self.table_name = 'stash_engine_internal_data'
     belongs_to :stash_identifier, class_name: 'StashEngine::Identifier', foreign_key: 'identifier_id'
+
+    # TODO: these should be an enum
     validates :data_type, inclusion: {
       in: %w[manuscriptNumber mismatchedDOI duplicateItem formerManuscriptNumber publicationISSN
              publicationName pubmedID dansArchiveDate dansEditIRI],


### PR DESCRIPTION
This is part of the preparation to move `publicationISSN` out of `InternalData` and into `RelatedIdentifier`

ref https://github.com/CDL-Dryad/dryad-product-roadmap/issues/3019