### PR TITLE
feat: auto-publish (approve) resources based on different criteria

### DIFF
--- a/app/controllers/stash_datacite/subjects_controller.rb
+++ b/app/controllers/stash_datacite/subjects_controller.rb
@@ -54,18 +54,11 @@ module StashDatacite
     private
 
     def ensure_subject(subject_str)
-      subject = find_or_create_subject(subject_str)
+      subject = StashDatacite::Subject.find_or_create_subject(subject_str)
       subjects = @resource.subjects
       return if subjects.exists?(subject.id)
 
       subjects << subject
-    end
-
-    def find_or_create_subject(subject)
-      existing = Subject.where('subject LIKE ?', subject).non_fos.first
-      return existing if existing
-
-      Subject.create(subject: subject)
     end
 
     def set_subject

--- a/app/models/stash_api/dataset_parser/keywords.rb
+++ b/app/models/stash_api/dataset_parser/keywords.rb
@@ -19,7 +19,7 @@ module StashApi
         @hash['keywords'].each do |kw|
           next if kw.blank?
 
-          @resource.subjects << find_or_create_subject(keyword: kw)
+          @resource.subjects << StashDatacite::Subject.find_or_create_subject(kw, exact: true)
         end
       end
 
@@ -27,13 +27,6 @@ module StashApi
 
       def clear
         @resource.subjects.delete(@resource.subjects.non_fos)
-      end
-
-      def find_or_create_subject(keyword:)
-        subs = StashDatacite::Subject.where(subject: keyword)
-        return subs.first unless subs.blank?
-
-        StashDatacite::Subject.create(subject: keyword)
       end
     end
   end

--- a/app/models/stash_datacite/subject.rb
+++ b/app/models/stash_datacite/subject.rb
@@ -31,5 +31,12 @@ module StashDatacite
     scope :fos, -> { where("subject_scheme = 'fos'") }
     scope :permissive_fos, -> { where("subject_scheme IN ('fos', 'bad_fos')") }
     scope :bad_fos, -> { where("subject_scheme = 'bad_fos'") }
+
+    def find_or_create_subject(subject, exact: false)
+      existing = exact ? where(subject: subject) : where('subject LIKE ?', subject).non_fos.first
+      return existing if existing
+
+      create(subject: subject)
+    end
   end
 end

--- a/app/models/stash_datacite/subject.rb
+++ b/app/models/stash_datacite/subject.rb
@@ -32,7 +32,7 @@ module StashDatacite
     scope :permissive_fos, -> { where("subject_scheme IN ('fos', 'bad_fos')") }
     scope :bad_fos, -> { where("subject_scheme = 'bad_fos'") }
 
-    def find_or_create_subject(subject, exact: false)
+    def self.find_or_create_subject(subject, exact: false)
       existing = exact ? where(subject: subject) : where('subject LIKE ?', subject).non_fos.first
       return existing if existing
 

--- a/lib/stash/repo/repository.rb
+++ b/lib/stash/repo/repository.rb
@@ -199,7 +199,7 @@ module Stash
 
       def should_auto_publish(resource)
         identifier = resource.identifier
-        previous_resource = identifier.resources.publicly_viewable.by_version_desc.second
+        previous_resource = identifier.publicly_viewable.resources.by_version_desc.second
 
         changed_fields = resource.changed_fields(previous_resource)
 


### PR DESCRIPTION
Items left TO DO:
- [ ] do some testing in sandbox and check how the changed fields look like when making certain changes to a dataset
- [ ] add spec coverage
- [ ] record activity entry

Questions:
- how do you set a primary article on a dataset? I've only been able to add `article` type relationships, not `primary_article`
- what activity log should we generate for auto-approvals?