### PR TITLE
fix: impose an order on curation stats CSV

### DIFF
--- a/app/views/stash_engine/curation_stats/index.csv.erb
+++ b/app/views/stash_engine/curation_stats/index.csv.erb
@@ -1,5 +1,5 @@
 <%= "Date,Curated,QueueSize,New,NewToSubmitted,NewToPPR,PPRToSubmitted,CurationToAAR,CurationToPublished,Embargoed,Withdrawn,AuthorRevised,AuthorVersioned" %>
-<% @all_stats.each do |stat|
+<% @all_stats.order(:date).each do |stat|
     row = [
 	formatted_date(stat.date),
 	stat.datasets_curated,


### PR DESCRIPTION
When downloading the curation stats as a CSV, ensure they are ordered by date. The default ordering by id is no longer useful, since they were generated in a somewhat arbitrary sequence.