### PR TITLE
feat: allow both `POST` and `PUT` for `/datasets/:id/files/:filename`

### DIFF
--- a/config/routes.rb
+++ b/config/routes.rb
@@ -118,9 +118,9 @@ Rails.application.routes.draw do
     end
   
     # this one doesn't follow the pattern since it gloms filename on the end, so manual route
-    # This should be PUT, not POST because of filename, see https://stackoverflow.com/questions/630453/put-vs-post-in-rest for example
-    put '/datasets/:id/files/:filename', id: %r{[^\s/]+?}, filename: %r{[^\s/]+?}, to: 'files#update', as: 'dataset_file', format: false
-    
+    # supporting both POST and PUT for updating the file to ensure as many clients as possible can use this end point
+    match '/datasets/:id/files/:filename', to: 'files#update', as: 'dataset_file', constraints: { id: %r{[^\s/]+?}, filename: %r{[^\s/]+?} }, format: false, via: %i[post put]
+
     resources :users, path: '/users', only: %i[index show]
     
     get '/queue_length', to: 'submission_queue#length'


### PR DESCRIPTION
_keeping as draft until we test it out on sandbox_