### PR TITLE
fix: broken API download URLs

### DIFF
--- a/app/controllers/stash_api/datasets_controller.rb
+++ b/app/controllers/stash_api/datasets_controller.rb
@@ -390,7 +390,7 @@ module StashApi
     def download
       res = @stash_identifier.latest_downloadable_resource(user: @user)
       @version_presigned = Stash::Download::VersionPresigned.new(controller_context: self, resource: res)
-      if res&.may_download?(ui_user: @user) && @zip_version_presigned.valid_resource?
+      if res&.may_download?(ui_user: @user) && @version_presigned.valid_resource?
         @version_presigned.download(resource: res)
       else
         render plain: 'Download for this version of the dataset is unavailable', status: 404


### PR DESCRIPTION
Closes https://github.com/datadryad/dryad-product-roadmap/issues/3318

Happened to see the error causing this in our notifier emails, it was an easy fix!