### PR TITLE
fix: update authorization to read GMail account

### DIFF
--- a/app/mailers/stash_engine/user_mailer.rb
+++ b/app/mailers/stash_engine/user_mailer.rb
@@ -28,7 +28,7 @@ module StashEngine
 
       mail(to: user_email(@user),
            bcc: @resource&.tenant&.campus_contacts,
-           template_name: withdrawn_by_journal,
+           template_name: 'withdrawn_by_journal',
            subject: "#{rails_env}Dryad Submission \"#{@resource.title}\"")
 
       update_activities(resource: resource, message: 'Withdrawal by journal', status: status)

--- a/config/app_config.yml
+++ b/config/app_config.yml
@@ -90,7 +90,7 @@ defaults: &DEFAULTS
   google:
     gmail_client_id: <%= Rails.application.credentials[Rails.env.to_sym][:gmail_client_id] %>
     gmail_client_secret: <%= Rails.application.credentials[Rails.env.to_sym][:gmail_client_secret] %>
-    token_path: '../google_token.json'
+    token_path: '/home/ec2-user/deploy/shared/google_token.json'
     journal_account_name: journal-submit-app@datadryad.org
     journal_processing_label: dev-journal-submit
     journal_error_label: dev-journal-submit-error
@@ -283,7 +283,7 @@ production: &PRODUCTION
   google:
     gmail_client_id: <%= Rails.application.credentials[Rails.env.to_sym][:gmail_client_id] %>
     gmail_client_secret: <%= Rails.application.credentials[Rails.env.to_sym][:gmail_client_secret] %>
-    token_path: '../google_token.json'
+    token_path: '/home/ec2-user/deploy/shared/google_token.json'
     journal_account_name: journal-submit-app@datadryad.org
     journal_processing_label: journal-submit-v2
     journal_error_label: journal-submit-error-v2

--- a/documentation/apis/journals.md
+++ b/documentation/apis/journals.md
@@ -290,14 +290,19 @@ Several settings need to be in the server's settings to connect with GMail.
 
 Rails reads the GMail credentials from the credentials file, but it also needs a token that
 will allow it to read from a specific GMail account. The token is stored in a
-file called `google_token.json`, one directory above the codebase, so it is not
+file called `google_token.json`, outside the codebase, so it is not
 affected by updates to the codebase. You can test whether the
 token is valid and/or reset the token by running:
 `rails journal_email:validate_gmail_connection`
 
-If something is wrong with the authorization, you can delete the `token.yaml`
+If something is wrong with the authorization, you can delete the `google_token.json`
 file and generate it again. To generate it, login to Dryad as a superuser and navigate to
 `/stash/gmail_auth`. Follow the instructions there.
+
+If you get an error about "Credentials do not contain a refresh_token.", You
+will need to de-authorize Dryad for this account (because it only sends the
+refresh token on the first authorization). Go to
+https://myaccount.google.com/u/0/permissions and remove the Dryad application.
 
 Rarely, if the validation process above produces an error, you may need to regenerate
 the application-level GMail credentials:


### PR DESCRIPTION
closes https://github.com/datadryad/dryad-product-roadmap/issues/3277

- update config and instructions for email processing
- fix issue with incorrectly defined template name