### PR TITLE
chore: update bots list

### DIFF
--- a/config/initializers/rack_attack.rb
+++ b/config/initializers/rack_attack.rb
@@ -13,10 +13,7 @@ Rack::Attack.safelist_ip('::1')
 # -------------------
 
 # IPs to block outright
-Rack::Attack.blocklist_ip("172.31.26.170")
-Rack::Attack.blocklist_ip("172.31.57.28")
-Rack::Attack.blocklist_ip("172.31.34.97")
-Rack::Attack.blocklist_ip("172.31.15.82")
+# Rack::Attack.blocklist_ip("17.31.15.82")
 
 
 # Set a long block period for any client that is explicitly looking for security holes
@@ -27,6 +24,8 @@ Rack::Attack.blocklist('malicious_clients') do |req|
       req.path.include?('wp-admin') ||
       req.path.include?('wp-login') ||
       (req.ip.start_with?('172.31') && req.path.start_with?('/stash/downloads')) ||
+      (req.ip.start_with?('64.233') && req.path.start_with?('/stash/downloads')) ||
+      (req.ip.start_with?('47.76') && req.path.start_with?('/stash/downloads')) ||
       /\S+\.php/.match?(req.path)
   end
 end

--- a/script/server-utils/heavy_downloaders.sh
+++ b/script/server-utils/heavy_downloaders.sh
@@ -3,8 +3,9 @@
 # Lists the IP addresses that have downloaded the most in the most recent log file, and their frequency
 
 echo "=== Heavy downloads of individual files ==="
-grep "downloads/file" /var/log/httpd/datadryad.org-access_log | awk '{ print $1 } ' | sort | uniq -c |sort -r | head
+grep "downloads/file" /home/ec2-user/deploy/shared/log/v3_production.log | awk '{ print $6 } ' | sort | uniq -c |sort -r | head
 
 echo "=== Heavy downloads of ZIP files ==="
-grep "downloads/zip" /var/log/httpd/datadryad.org-access_log | awk '{ print $1 } ' | sort | uniq -c |sort -r | head
+grep "downloads/zip" /home/ec2-user/deploy/shared/log/v3_production.log | awk '{ print $6 } ' | sort | uniq -c |sort -r | head
+
 


### PR DESCRIPTION
- Update list of bad bot prefixes to block
- Don't outright ban "172.31" addresses, since these belong to the load balancer!
- When looking for bad actors, use the Rails log instead of the Apache log, since Apache only shows the IP of the load balancer. 