### PR TITLE
fix: improve parsing of author list in journal metadata emails

### DIFF
--- a/app/services/stash_engine/email_parser.rb
+++ b/app/services/stash_engine/email_parser.rb
@@ -65,7 +65,7 @@ module StashEngine
         tag = transformed_tags[tag] if transformed_tags.keys.include?(tag)
         # if the line starts with a valid tag, add it to the hash
         if allowed_tags.include?(tag)
-          value = line[colon_index + 1..].strip
+          value = line[colon_index + 1..].strip.gsub(/\xC2|\xA0/n, '')
           value.downcase! if downcase_tags.include?(tag)
           @hash[tag] = value
         end
@@ -140,7 +140,7 @@ module StashEngine
 
         # although, if there was only one author and it was listed as lastname, firstname, it would have a comma too...
         if split_string.length == 2 && !split_string[1].include?(' and ')
-          authors << [split_string[0].strip, split_string[1].strip]
+          authors << parse_author_name(author_string)
           split_string = []
         end
       end


### PR DESCRIPTION
As a final fix for https://github.com/datadryad/dryad-product-roadmap/issues/3284
- remove extra "non-breaking space" characters that can get appended to each line (confusingly, these are not removed by the Ruby `strip`)
- when a single author is listed as "LastName, FirstName", ensure it goes through the parsing process 