### PR TITLE
fix: tenant logo javascript & test

### DIFF
--- a/app/views/stash_engine/tenant_admin/_logo.html.erb
+++ b/app/views/stash_engine/tenant_admin/_logo.html.erb
@@ -10,6 +10,6 @@
 <% end %>
 <p><label for="file-select">Choose new logo:</label>
 <p><input id="file-select" type="file" accept="image/png, image/jpg, image/jpeg, image/svg+xml, .png, .jpg, .jpeg, .svg, .svgz" /></p>
-<div id="file-preview" style="max-height: 60px">
+<div id="file-preview">
 </div>
 <%= form.hidden_field :logo, value: @tenant.logo, id: 'logo_input' %>

--- a/app/views/stash_engine/tenant_admin/edit.js.erb
+++ b/app/views/stash_engine/tenant_admin/edit.js.erb
@@ -14,5 +14,5 @@ when 'ror_orgs'
 when 'logo'
   @tenant.logo.blank? ? '' : "<img src='#{@tenant.logo}' alt='#{@tenant.short_name} logo'/>".html_safe
 end %>";
-document.getElementById('<%= @field %>_button').setAttribute('aria-expanded', 'false');
+document.getElementById('<%= @field %>_button_<%= @tenant.id %>').setAttribute('aria-expanded', 'false');
 document.getElementById('genericModalDialog').close();

--- a/app/views/stash_engine/tenant_admin/popup.js.erb
+++ b/app/views/stash_engine/tenant_admin/popup.js.erb
@@ -16,7 +16,7 @@ document.getElementById('file-select').addEventListener('change', () => {
   const reader = new FileReader();
   reader.addEventListener('load', () => {
     document.getElementById('logo_input').value = reader.result;
-    document.getElementById('file-preview').innerHTML = `<img src="${reader.result}" aria-hidden="true"/>`;
+    document.getElementById('file-preview').innerHTML = `<img src="${reader.result}" style="max-height: 60px;" aria-hidden="true"/>`;
   });
   if (file) {
     reader.readAsDataURL(file);

--- a/spec/features/stash_engine/tenant_admin_spec.rb
+++ b/spec/features/stash_engine/tenant_admin_spec.rb
@@ -25,7 +25,7 @@ RSpec.feature 'TenantAdmin', type: :feature do
       expect(page).not_to have_content(@match.short_name)
     end
 
-    xit 'allows changing the logo as a superuser', js: true do
+    it 'allows changing the logo as a superuser', js: true do
       visit stash_url_helpers.tenant_admin_path
       expect(page).to have_content(@match.short_name)
       within(:css, "form[action=\"#{tenant_popup_path(id: @match.id, field: 'logo')}\"]") do


### PR DESCRIPTION
Doing things touching similar areas in different branches caused some small mismatches—here's a fix!