### PR TITLE
fix: zip downloads in chrome browser

### DIFF
--- a/app/controllers/stash_engine/downloads_controller.rb
+++ b/app/controllers/stash_engine/downloads_controller.rb
@@ -38,8 +38,8 @@ module StashEngine
 
     def zip_assembly_info
       # input is resource_id and output is json with keys size, filename and url for each entry
-      @resource = nil
-      @resource = Resource.where(id: params[:resource_id]).first if params[:share].nil?
+      @resource = Resource.where(id: params[:resource_id]).first
+      @resource = nil if params[:share]
       check_for_sharing
       return render json: ['unauthorized'], status: :unauthorized unless @resource&.may_download?(ui_user: current_user) || @sharing_link
 
@@ -63,8 +63,8 @@ module StashEngine
     # for downloading the full version
     # uses presigned
     def download_resource
-      @resource = nil
-      @resource = Resource.where(id: params[:resource_id]).first if params[:share].nil?
+      @resource = Resource.where(id: params[:resource_id]).first
+      @resource = nil if params[:share]
       check_for_sharing
 
       @version_presigned = Stash::Download::VersionPresigned.new(controller_context: self, resource: @resource)


### PR DESCRIPTION
Closes https://github.com/datadryad/dryad-product-roadmap/issues/3206
Closes https://github.com/datadryad/dryad-product-roadmap/issues/3186

There seems to be some issue with how chrome sends parameters and how they are received by our code, that is keeping the resource from being discovered in the zip_assembly_info method—my theory is the share param is not always received as 'nil' when it is not included. Using the sharing link instead of the normal URL makes the zip assembly work for these downloads. Therefore I want to attempt changing the order of operations for looking up the resource by parameters to match what happens in the 'check_for_sharing' method. 

The most mysterious thing is why it only affects some datasets, not all.