### PR TITLE
feat: add links from admin page to stripe invoice page

### DIFF
--- a/app/helpers/stash_engine/admin_datasets_helper.rb
+++ b/app/helpers/stash_engine/admin_datasets_helper.rb
@@ -33,6 +33,9 @@ module StashEngine
     def format_external_references(instring)
       return '' unless instring.present?
 
+      # Stripe invoice references
+      return render inline: link_to(instring, "https://dashboard.stripe.com/invoices/#{instring}", target: :_blank) if instring.start_with?('in_')
+
       # Turn salesforce references into hyperlinks
       matchdata = instring.match(/(.*)SF ?#? ?(\d+)(.*)/)
       return instring unless matchdata

--- a/app/views/stash_engine/admin_datasets/_payment_info_table.html.erb
+++ b/app/views/stash_engine/admin_datasets/_payment_info_table.html.erb
@@ -17,7 +17,7 @@
           <%= @identifier.payment_type %>
         <% end %>
       </td>
-      <td><%= @identifier.payment_id %></td>
+      <td><%= format_external_references(@identifier.payment_id) %></td>
       <% if policy([:stash_engine, :admin_datasets]).waiver_add? %>
         <td><%= @identifier.waiver_basis %></td>
       <% end %>


### PR DESCRIPTION
Ok, I'm not certain whether this is a good idea. This updates rendering in the "Payment info" box, so Stripe invoice IDs are linked to the relevant invoice in Stripe. 

Only a handful of Dryad staff actually have permissions within Stripe, so the link won't work for a lot of the people who see it. Should we wrap this link in some permissions logic?