### PR TITLE
fix: pubupdater page counts

### DIFF
--- a/app/controllers/stash_engine/publication_updater_controller.rb
+++ b/app/controllers/stash_engine/publication_updater_controller.rb
@@ -86,7 +86,11 @@ module StashEngine
 
     def setup_paging
       @page = params[:page] || '1'
-      @page_size = (params[:page_size].blank? || params[:page_size] != '1000000' ? '10' : '1000000')
+      @page_size = if params[:page_size].blank? || params[:page_size].to_i == 0
+                     10
+                   else
+                     params[:page_size].to_i
+                   end
     end
 
     def setup_filter

--- a/app/controllers/stash_engine/publication_updater_controller.rb
+++ b/app/controllers/stash_engine/publication_updater_controller.rb
@@ -114,13 +114,13 @@ module StashEngine
         proposed_changes = proposed_changes.where((['search_table.big_text LIKE ?'] * keys.size).join(' AND '), *keys.map { |key| "%#{key}%" })
       end
 
-      if params[:status]
+      if params[:status].present?
         proposed_changes = proposed_changes.joins(
           'JOIN stash_engine_curation_activities sa ON sa.id = stash_engine_resources.last_curation_activity_id'
         ).where('sa.status' => params[:status])
       end
 
-      if params[:match_type]
+      if params[:match_type].present?
         proposed_changes = proposed_changes.where(
           "stash_engine_proposed_changes.publication_issn is #{params[:match_type] == 'preprints' ? 'null' : 'not null'}"
         )

--- a/app/controllers/stash_engine/publication_updater_controller.rb
+++ b/app/controllers/stash_engine/publication_updater_controller.rb
@@ -26,8 +26,7 @@ module StashEngine
 
     # the admin datasets main page showing users and stats, but slightly different in scope for curators vs tenant admins
     def index
-      proposed_changes = authorize StashEngine::ProposedChange # .includes(identifier: :latest_resource)
-        .joins(identifier: :latest_resource).where(approved: false, rejected: false)
+      proposed_changes = authorize StashEngine::ProposedChange.unprocessed.joins(:latest_resource)
         .where("stash_engine_identifiers.pub_state != 'withdrawn'")
         .select('stash_engine_proposed_changes.*')
 
@@ -51,8 +50,6 @@ module StashEngine
 
       @proposed_changes = proposed_changes.order(ord).page(@page).per(@page_size)
       return unless @proposed_changes.present?
-
-      @resources = StashEngine::Resource.latest_per_dataset.where(identifier_id: @proposed_changes&.map(&:identifier_id))
 
       respond_to do |format|
         format.html

--- a/app/models/stash_engine/proposed_change.rb
+++ b/app/models/stash_engine/proposed_change.rb
@@ -36,7 +36,10 @@ module StashEngine
   class ProposedChange < ApplicationRecord
     self.table_name = 'stash_engine_proposed_changes'
     belongs_to :identifier, class_name: 'StashEngine::Identifier', foreign_key: 'identifier_id'
+    has_one :latest_resource, class_name: 'StashEngine::Resource', through: :identifier
     belongs_to :user, class_name: 'StashEngine::User', foreign_key: 'user_id', optional: true
+
+    scope :unprocessed, -> { where(approved: false, rejected: false) }
 
     CROSSREF_PUBLISHED_MESSAGE = 'reported that the related journal has been published'.freeze
     CROSSREF_UPDATE_MESSAGE = 'provided additional metadata'.freeze

--- a/app/views/stash_engine/publication_updater/index.html.erb
+++ b/app/views/stash_engine/publication_updater/index.html.erb
@@ -64,11 +64,7 @@
       </thead>
       <tbody>
       <% @proposed_changes.each do |proposed_change| %>
-        <% resource = @resources.select{ |r| r.identifier_id == proposed_change.identifier_id }.first %>
-        <% if resource.present? %>
-          <%= render partial: 'proposed_change_line',
-                     locals: { proposed_change: proposed_change, resource: resource } %>
-        <% end %>
+        <%= render partial: 'proposed_change_line',locals: { proposed_change: proposed_change, resource: proposed_change.latest_resource } %>
       <% end %>
       </tbody>
     </table>

--- a/app/views/stash_engine/publication_updater/index.html.erb
+++ b/app/views/stash_engine/publication_updater/index.html.erb
@@ -33,7 +33,7 @@
       <label for="status">Curation status:</label>
       <%= select_tag :status, options_from_collection_for_select(@statuses, "value", "label", params[:status]), class: 'c-input__text' %>
     </div>
-    <%= submit_tag('Search', class: 'o-button__submit' ) %>
+    <%= submit_tag('Search', class: 'o-button__submit', name: nil ) %>
     <%= button_tag "Reset", type: :reset, id: 'reset_button', class: "o-button__remove" %>
   </div>
   <% end %>


### PR DESCRIPTION
Closes https://github.com/datadryad/dryad-product-roadmap/issues/3395

I've fixed the weirdest issues (though I'm still not quite sure how!)

Currently, to adjust page content after accepting and rejecting matches, you have to reload (or go to another page). It would be better if accepting and rejecting reloaded the results and brought forward results from later pages. That would require reformatting the page to load results with javascript, which I've found is kind of complicated—we can do this in another sprint.