### PR TITLE
Exclude already matched DOIs from PubUpdater

### DIFF
--- a/app/controllers/stash_engine/publication_updater_controller.rb
+++ b/app/controllers/stash_engine/publication_updater_controller.rb
@@ -27,6 +27,7 @@ module StashEngine
     # the admin datasets main page showing users and stats, but slightly different in scope for curators vs tenant admins
     def index
       proposed_changes = authorize StashEngine::ProposedChange.unmatched
+        .preload(:latest_resource)
         .where("stash_engine_identifiers.pub_state != 'withdrawn'")
         .select('stash_engine_proposed_changes.*')
 

--- a/app/controllers/stash_engine/publication_updater_controller.rb
+++ b/app/controllers/stash_engine/publication_updater_controller.rb
@@ -26,7 +26,7 @@ module StashEngine
 
     # the admin datasets main page showing users and stats, but slightly different in scope for curators vs tenant admins
     def index
-      proposed_changes = authorize StashEngine::ProposedChange.unmatched.joins(:latest_resource)
+      proposed_changes = authorize StashEngine::ProposedChange.unmatched
         .where("stash_engine_identifiers.pub_state != 'withdrawn'")
         .select('stash_engine_proposed_changes.*')
 

--- a/app/controllers/stash_engine/publication_updater_controller.rb
+++ b/app/controllers/stash_engine/publication_updater_controller.rb
@@ -26,7 +26,7 @@ module StashEngine
 
     # the admin datasets main page showing users and stats, but slightly different in scope for curators vs tenant admins
     def index
-      proposed_changes = authorize StashEngine::ProposedChange.unprocessed.joins(:latest_resource)
+      proposed_changes = authorize StashEngine::ProposedChange.unmatched.joins(:latest_resource)
         .where("stash_engine_identifiers.pub_state != 'withdrawn'")
         .select('stash_engine_proposed_changes.*')
 

--- a/app/models/stash_engine/proposed_change.rb
+++ b/app/models/stash_engine/proposed_change.rb
@@ -40,6 +40,13 @@ module StashEngine
     belongs_to :user, class_name: 'StashEngine::User', foreign_key: 'user_id', optional: true
 
     scope :unprocessed, -> { where(approved: false, rejected: false) }
+    # Unprocessed and the DOI is not already in the resource
+    scope :unmatched, -> {
+                        unprocessed.joins(:latest_resource).joins("
+                          LEFT OUTER JOIN `dcs_related_identifiers` ON `dcs_related_identifiers`.`resource_id` = `stash_engine_resources`.`id` AND
+                          REGEXP_SUBSTR(`dcs_related_identifiers`.`related_identifier`, '(10..+)') = `stash_engine_proposed_changes`.`publication_doi`
+                        ").where('`dcs_related_identifiers`.`id` IS NULL')
+                      }
 
     CROSSREF_PUBLISHED_MESSAGE = 'reported that the related journal has been published'.freeze
     CROSSREF_UPDATE_MESSAGE = 'provided additional metadata'.freeze

--- a/app/views/stash_engine/publication_updater/_proposed_change_line.html.erb
+++ b/app/views/stash_engine/publication_updater/_proposed_change_line.html.erb
@@ -4,15 +4,9 @@
   existing_pubdoi = fetch_related_primary_article(resource: resource)
 %>
 
-<% unless existing_pubname == proposed_change.publication_name &&
-            (existing_pubissn == proposed_change.publication_issn || proposed_change.publication_issn.blank?) &&
-            existing_pubdoi == proposed_change.publication_doi
-%>
-
-  <tr class="c-lined-table__row" id="current_<%= proposed_change.id %>">
-    <%= render partial: 'current_metadata', locals: { resource: resource, existing_pubdoi: existing_pubdoi, existing_pubissn: existing_pubissn, existing_pubname: existing_pubname } %>
-  </tr>
-  <tr class="c-lined-table__row" id="proposed_<%= proposed_change.id %>">
-    <%= render partial: 'proposed_metadata', locals: { proposed_change: proposed_change, existing_pubdoi: existing_pubdoi, existing_pubissn: existing_pubissn, existing_pubname: existing_pubname, resource: resource } %>
-  </tr>
-<% end %>
+<tr class="c-lined-table__row" id="current_<%= proposed_change.id %>">
+  <%= render partial: 'current_metadata', locals: { resource: resource, existing_pubdoi: existing_pubdoi, existing_pubissn: existing_pubissn, existing_pubname: existing_pubname } %>
+</tr>
+<tr class="c-lined-table__row" id="proposed_<%= proposed_change.id %>">
+  <%= render partial: 'proposed_metadata', locals: { proposed_change: proposed_change, existing_pubdoi: existing_pubdoi, existing_pubissn: existing_pubissn, existing_pubname: existing_pubname, resource: resource } %>
+</tr>


### PR DESCRIPTION
This closes the bug ticket https://github.com/datadryad/dryad-product-roadmap/issues/3395

it also makes a general improvement by checking the proposed change DOI against _any_ related identifier DOI of the suggested submission. This will keep non-primary related articles and preprint matches from being suggested when they already exist in the submission metadata.

We can make a separate checking screen in the pubupdater to suggest promoting related articles to primary articles, if the reports etc. indicate this is needed.