### PR TITLE
Only create ORCID invites for authors with emails

### DIFF
--- a/app/models/stash_engine/author.rb
+++ b/app/models/stash_engine/author.rb
@@ -90,8 +90,9 @@ module StashEngine
     after_save :init_user_orcid
 
     def orcid_invite_path
-      orcid_invite = StashEngine::OrcidInvitation.where(email: author_email, identifier_id: resource.identifier_id)&.first
+      return nil if author_email.blank?
 
+      orcid_invite = StashEngine::OrcidInvitation.where(email: author_email, identifier_id: resource.identifier_id)&.first
       # Ensure an invite exists -- it may not for a legacy dataset that never received invites,
       # or if the author_email has changed since the original creation.
       orcid_invite ||= StashEngine::OrcidInvitation.create(

--- a/app/models/stash_engine/curation_activity.rb
+++ b/app/models/stash_engine/curation_activity.rb
@@ -302,7 +302,7 @@ module StashEngine
       # Do not send an invitation to users who have no email address or have an
       # existing invitation for the identifier
       existing_invites = StashEngine::OrcidInvitation.where(identifier_id: resource.identifier_id).pluck(:email).uniq
-      authors = resource.authors.where.not(author_email: existing_invites).where.not(author_email: nil)
+      authors = resource.authors.where.not(author_email: existing_invites).where.not(author_email: nil).to_a
       authors = authors.delete_if { |au| au&.author_email.blank? }
 
       return if authors.empty?


### PR DESCRIPTION
Closes https://github.com/datadryad/dryad-product-roadmap/issues/3374

May also improve https://github.com/datadryad/dryad-product-roadmap/issues/2595 —it looks like this was only sending emails if there was more than 1 author needing an invitation previously! Can't explain this.