### PR TITLE
Change API logs from rolling daily to a limited size

### DIFF
--- a/config/initializers/api_logger.rb
+++ b/config/initializers/api_logger.rb
@@ -1,8 +1,4 @@
-api_logger = ActiveSupport::Logger.new(
-  Rails.root.join('log', 'api_requests.log'),
-  'daily',
-  7
-)
+api_logger = ActiveSupport::Logger.new(Rails.root.join('log', 'api_requests.log'), 5, 10.megabytes)
 api_logger.formatter = Logger::Formatter.new
 api_logger.level = :debug
 Rails.application.config.api_logger = api_logger


### PR DESCRIPTION
Closes https://github.com/datadryad/dryad-product-roadmap/issues/3414

Make these files roll at a set size, similar to the other logs. This probably isn't the best rolling method, since it doesn't guarantee us any particular number of days of history. The default Ruby logging doesn't support a number of days by default; it would be something we need to custom code or set up with an external tool.