### PR TITLE
Allow external redirects for return_url

### DIFF
--- a/app/controllers/stash_engine/resources_controller.rb
+++ b/app/controllers/stash_engine/resources_controller.rb
@@ -101,7 +101,7 @@ module StashEngine
             return_url = session["return_url_#{@resource.identifier_id}"] || session[:returnURL]
             session["return_url_#{@resource.identifier_id}"] = nil
             session[:returnURL] = nil
-            redirect_to return_url, notice: notice
+            redirect_to(return_url, allow_other_host: true, notice: notice)
           elsif current_user
             redirect_to return_to_path_or(dashboard_path), notice: notice
           else


### PR DESCRIPTION
Followup to #1694 -- we were getting errors about this issue when redirecting back to publishers' manuscript systems. 

(Yes, I put this on production, too, since the publishers can get very unhappy when the return urls don't work correctly.)