### PR TITLE
Allow external redirects for return_url

### DIFF
--- a/app/controllers/stash_datacite/resources_controller.rb
+++ b/app/controllers/stash_datacite/resources_controller.rb
@@ -64,7 +64,7 @@ module StashDatacite
         return_url = session["return_url_#{@resource.identifier_id}"] || session[:returnURL]
         session["return_url_#{@resource.identifier_id}"] = nil
         session[:returnURL] = nil
-        redirect_to return_url, notice: "Submitted updates for #{@resource.identifier}, title: #{@resource.title}"
+        redirect_to(return_url, notice: "Submitted updates for #{@resource.identifier}, title: #{@resource.title}", allow_other_host: true)
       else
         redirect_to(stash_url_helpers.dashboard_path(doi: @resource.identifier.identifier), notice: resource_submitted_message(@resource))
       end


### PR DESCRIPTION
One more addition to the `return_url` settings... following #1694 and #1696.