### PR TITLE
Remove unneeded/incorrect params in pagination links

### DIFF
--- a/app/views/kaminari/_paginator.html.erb
+++ b/app/views/kaminari/_paginator.html.erb
@@ -6,14 +6,9 @@
     remote:        data-remote
     paginator:     the paginator that renders the pagination tags inside
 -%>
-<% if per_page == 1000000 && !(params[:show_all] == false) %>
-  <%= link_to 'Show pages', params.merge(page_size: 5, page: 1), remote: remote %>
-<% end %>
 <%= paginator.render do -%>
   <nav class="pagination" role="navigation" aria-label="Pagination Navigation">
-    <% unless params[:show_all] == false %>
-      <%= link_to 'Show all', params.merge(page_size: '1000000', page: 1), remote: remote %>
-    <% end %>
+    <%#= link_to 'Show all', params.merge(page_size: '1000000', page: 1), remote: remote %>
 
     <%= first_page_tag unless current_page.first? %>
     <%= prev_page_tag unless current_page.first? %>
@@ -27,6 +22,8 @@
     <% end -%>
     
     <%= next_page_tag unless current_page.last? %>
-    <%= last_page_tag unless current_page.last? || params[:show_last_page] == false %>
+    <% if total_pages > 5 %>
+      <%= last_page_tag unless current_page.last? %>
+    <% end %>
   </nav>
 <% end -%>

--- a/app/views/stash_engine/admin_dataset_funders/index.html.erb
+++ b/app/views/stash_engine/admin_dataset_funders/index.html.erb
@@ -13,7 +13,7 @@
                 stash_url_helpers.ds_admin_funders_path(request.params.merge(format: :csv)) %>
 
     <div class="c-space-paginator">
-      <%= paginate @funder_table, params: { page_size: @page_size, show_all: false, show_last_page: false } %>
+      <%= paginate @funder_table, params: { page_size: @page_size } %>
       <div class="c-paginator-page_size">
         Page size:
         <%

--- a/app/views/stash_engine/admin_datasets/index.html.erb
+++ b/app/views/stash_engine/admin_datasets/index.html.erb
@@ -17,7 +17,7 @@
      stash_url_helpers.ds_admin_path(sortable_table_params.merge(format: :csv)) %>
 
   <div class="c-space-paginator">
-    <%= paginate @datasets, params: { page_size: @page_size, show_all: false, show_last_page: false } %>
+    <%= paginate @datasets, params: { page_size: @page_size } %>
     <div class="c-paginator-page_size">
       Page size:
       <%

--- a/app/views/stash_engine/journal_admin/index.html.erb
+++ b/app/views/stash_engine/journal_admin/index.html.erb
@@ -22,7 +22,7 @@
 
 <div class="search-results-footer">
   <div class="c-space-paginator">
-    <%= paginate @journals, params: {page_size: @page_size, show_all: false, show_last_page: false, remote: false} %>
+    <%= paginate @journals, params: { page_size: @page_size } %>
     <div class="c-paginator-page_size">
       Page size:
       <%

--- a/app/views/stash_engine/journal_organization_admin/index.html.erb
+++ b/app/views/stash_engine/journal_organization_admin/index.html.erb
@@ -22,7 +22,7 @@
 
 <div class="search-results-footer">
   <div class="c-space-paginator">
-    <%= paginate @orgs, params: {page_size: @page_size, show_all: false, show_last_page: false, remote: false} %>
+    <%= paginate @orgs, params: { page_size: @page_size } %>
     <div class="c-paginator-page_size">
       Page size:
       <%

--- a/app/views/stash_engine/publication_updater/index.html.erb
+++ b/app/views/stash_engine/publication_updater/index.html.erb
@@ -71,7 +71,7 @@
   </div>
 
   <div class="c-space-paginator">
-    <%= paginate @proposed_changes, params: { page_size: @page_size, show_all: false } %>
+    <%= paginate @proposed_changes, params: { page_size: @page_size } %>
         <div class="c-paginator-page_size">
       Page size:
       <%

--- a/app/views/stash_engine/tenant_admin/index.html.erb
+++ b/app/views/stash_engine/tenant_admin/index.html.erb
@@ -22,7 +22,7 @@
 
 <div class="search-results-footer">
   <div class="c-space-paginator">
-    <%= paginate @tenants, params: {page_size: @page_size, show_all: false, show_last_page: false, remote: false} %>
+    <%= paginate @tenants, params: { page_size: @page_size } %>
     <div class="c-paginator-page_size">
       Page size:
       <%

--- a/app/views/stash_engine/user_admin/index.html.erb
+++ b/app/views/stash_engine/user_admin/index.html.erb
@@ -32,7 +32,7 @@
     <% end %>
   <% end %>
   <div class="c-space-paginator">
-    <%= paginate @users, params: {page_size: @page_size, show_all: false, show_last_page: false, remote: false} %>
+    <%= paginate @users, params: { page_size: @page_size } %>
     <div class="c-paginator-page_size">
       Page size:
       <%

--- a/app/views/stash_engine/user_admin/user_profile.html.erb
+++ b/app/views/stash_engine/user_admin/user_profile.html.erb
@@ -92,7 +92,7 @@
     <%= render partial: 'stash_engine/user_admin/user_datasets', locals: { presenters: @page_presenters } %>
 
     <div class="c-space-paginator">
-      <%= paginate @page_presenters, params: {page_size: @page_size} %>
+      <%= paginate @page_presenters, params: { page_size: @page_size } %>
     </div>
   </div>
   <div class="o-admin-left">


### PR DESCRIPTION
These add ugly URL params for all page links, for settings that are either: fine to turn on, that we never turn on and can just remove, or are actually in the wrong location entirely. Modifying so we can remove them and have better urls.