### PR TITLE
Increase size limit of files to use with Frictionless to 50MB

### DIFF
--- a/config/app_config.yml
+++ b/config/app_config.yml
@@ -87,7 +87,7 @@ test:
     api_zip_size: 200
     files: 100
   frictionless:
-    size_limit: 6291456
+    size_limit: 1_000_000
   rate_limit:
     # number of requests allowed per minute
     # these rates are low to facilitate quick testing of the rate limiter,
@@ -221,9 +221,8 @@ defaults: &DEFAULTS
     zip_size: 11_000_000_000
     api_zip_size: 200_000_000
     files: 1000
-  frictionless:
-    # 150 MB and below
-    size_limit: 10_000_000
+  frictionless:    
+    size_limit: 50_000_000
     missing_values: ",NA,na,N/A,n/a,N.A.,n.a.,-,.,empty,blank"
   rate_limit:
     file_downloads_per_hour: 100


### PR DESCRIPTION
Based on testing in https://github.com/datadryad/dryad-product-roadmap/issues/2880, we are updating the size of files to use with the Frictionless testing. New limits are 50MB for production and 1MB for test servers.