### PR TITLE
Improve speed of SQL queries & admin dashboard load

### DIFF
--- a/app/assets/stylesheets/scss/_admin-layout.scss
+++ b/app/assets/stylesheets/scss/_admin-layout.scss
@@ -122,13 +122,12 @@ button.c-admin-edit-icon {
   }
 
   #edit_fields-form {
-    columns: 6;
+    columns: 7;
 
-    &.extra-column {
-      columns: 7;
-      @media (max-width: 1070px) { columns: 5 }
-    }
-    
+    @media (max-width: 1070px) { columns: 5 }
+    @media (max-width: 920px) { columns: 3 }
+    @media (max-width: 480px) { columns: 2 }
+
     div {
       margin-bottom: 4px;
     }
@@ -144,11 +143,6 @@ button.c-admin-edit-icon {
         margin: .2rem 0 1rem 1.1rem;
       }
     }
-  }
-
-  #edit_fields-form, #edit_fields-form.extra-column {
-    @media (max-width: 920px) { columns: 3 }
-    @media (max-width: 480px) { columns: 2 }
   }
 
   #edit_filters-form {

--- a/app/controllers/stash_api/datasets_controller.rb
+++ b/app/controllers/stash_api/datasets_controller.rb
@@ -564,7 +564,8 @@ module StashApi
 
       unless @user.min_curator? ||
              params['userId'].to_i == @user.id || # or it is your own user
-             @user.journals_as_admin&.map(&:issn_array)&.flatten&.include?(params['dataset']['publicationISSN']) # or you admin the target journal
+             # or you admin the target journal
+             @user.journals_as_admin.map(&:issn_array)&.flatten&.reject(&:blank?)&.include?(params['dataset']['publicationISSN'])
         render json: { error: 'Unauthorized: only superusers and journal administrators may set a specific user' }.to_json, status: 401
         false
       end

--- a/app/controllers/stash_datacite/publications_controller.rb
+++ b/app/controllers/stash_datacite/publications_controller.rb
@@ -38,14 +38,11 @@ module StashDatacite
         # clean the partial_term of unwanted characters so it doesn't cause errors
         partial_term.gsub!(%r{[/\-\\()~!@%&"\[\]\^:]}, ' ')
 
-        matches = StashEngine::Journal.where('title like ?', "%#{partial_term}%").limit(40).to_a
-        matches.map do |m|
-          m.issn = m.single_issn
-          m
-        end
+        found = StashEngine::Journal.where('title like ?', "%#{partial_term}%").limit(40).to_a
+        matches = found.map { |m| { id: m.id, title: m.title, issn: m.single_issn } }
         alt_matches = StashEngine::JournalTitle.where('show_in_autocomplete=true and title like ?', "%#{partial_term}%").limit(10)
         alt_matches.each do |am|
-          matches << { title: am.title, issn: am.journal.single_issn }
+          matches << { id: am.journal.id, title: am.title, issn: am.journal.single_issn }
         end
         render json: bubble_up_exact_matches(result_list: matches, term: partial_term)
       end

--- a/app/controllers/stash_engine/admin_dashboard_controller.rb
+++ b/app/controllers/stash_engine/admin_dashboard_controller.rb
@@ -15,6 +15,10 @@ module StashEngine
       add_fields
       add_filters
 
+      if @page == 1 || session[:admin_search_count].blank?
+        session[:admin_search_count] = StashEngine::Resource.select('count(*) as total').from(@datasets).map(&:total).first
+      end
+
       if params[:sort].present? || @search_string.present?
         order_string = 'relevance desc'
         if params[:sort].present?
@@ -58,7 +62,7 @@ module StashEngine
         @page_size = 2_000
         return
       end
-      @page = params[:page] || '1'
+      @page = params[:page] || 1
       @page_size = if params[:page_size].blank? || params[:page_size].to_i == 0
                      10
                    else

--- a/app/controllers/stash_engine/admin_dashboard_controller.rb
+++ b/app/controllers/stash_engine/admin_dashboard_controller.rb
@@ -15,7 +15,7 @@ module StashEngine
       add_fields
       add_filters
 
-      if @page == 1 || session[:admin_search_count].blank?
+      if request.format.html? && (@page == 1 || session[:admin_search_count].blank?)
         session[:admin_search_count] = StashEngine::Resource.select('count(*) as total').from(@datasets).map(&:total).first
       end
 
@@ -59,7 +59,7 @@ module StashEngine
     def setup_paging
       if request.format.csv?
         @page = 1
-        @page_size = 2_000
+        @page_size = 1_000_000
         return
       end
       @page = params[:page] || 1

--- a/app/controllers/stash_engine/admin_dashboard_controller.rb
+++ b/app/controllers/stash_engine/admin_dashboard_controller.rb
@@ -212,10 +212,7 @@ module StashEngine
 
       return unless journal_ids.present?
 
-      @datasets = @datasets.joins("inner join stash_engine_internal_data jourissn on
-        jourissn.identifier_id = stash_engine_identifiers.id and jourissn.data_type = 'publicationISSN'")
-        .joins("inner join stash_engine_journals on stash_engine_journals.issn like CONCAT('%', jourissn.value ,'%')")
-        .where('stash_engine_journals.id': journal_ids)
+      @datasets = @datasets.joins(identifier: :journal).where('stash_engine_journals.id': journal_ids)
     end
 
     def sponsor_filter
@@ -254,8 +251,10 @@ module StashEngine
       @datasets = @datasets.preload(tenant: :ror_orgs).preload(authors: { affiliations: :ror_org }) if @fields.include?('countries')
       @datasets = @datasets.preload(:user) if @fields.include?('submitter')
       @datasets = @datasets.preload(identifier: :counter_stat) if @fields.include?('metrics')
+      @datasets = @datasets.preload(identifier: :journal) if @fields.include?('journal') || @fields.include?('sponsor')
+      @datasets = @datasets.preload(identifier: { journal: :sponsor }) if @fields.include?('sponsor')
       @datasets = @datasets.preload(:funders) if @fields.include?('funders')
-      @datasets = @datasets.preload(:related_identifiers) if @fields.include?('identifiers')
+      @datasets = @datasets.preload(:related_identifiers).preload(identifier: :manuscript_datum) if @fields.include?('identifiers')
     end
 
   end

--- a/app/controllers/stash_engine/admin_dashboard_controller.rb
+++ b/app/controllers/stash_engine/admin_dashboard_controller.rb
@@ -1,4 +1,5 @@
 module StashEngine
+  # rubocop:disable Metrics/ClassLength
   class AdminDashboardController < ApplicationController
     helper SortableTableHelper
     before_action :require_admin
@@ -8,52 +9,26 @@ module StashEngine
     before_action :collect_properties, only: %i[new_search save_search]
     # before_action :load, only: %i[popup note_popup edit]
 
-    # rubocop:disable Metrics/MethodLength
     def index
-      @datasets = authorize StashEngine::Resource.latest_per_dataset
-        .left_outer_joins(identifier: %i[counter_stat internal_data])
-        .preload(identifier: %i[counter_stat internal_data])
-        .left_outer_joins(:last_curation_activity)
-        .preload(:last_curation_activity)
-        .left_outer_joins(:authors)
-        .preload(:authors)
-        .joins("
-          left outer join stash_engine_curation_activities seca on seca.id = (
-            select ca.id from stash_engine_curation_activities ca where ca.resource_id = stash_engine_resources.id
-            and ca.status in ('submitted', 'peer_review')
-            order by ca.created_at limit 1
-          )")
-        .joins("left outer join (
-            select stash_engine_users.* from stash_engine_users
-            inner join stash_engine_roles on stash_engine_users.id = stash_engine_roles.user_id
-              and role in ('curator', 'superuser')
-          ) curator on curator.id = stash_engine_resources.current_editor_id")
-        .joins("left outer join stash_engine_journals on stash_engine_internal_data.data_type = 'publicationISSN'
-          and stash_engine_journals.issn like CONCAT('%', stash_engine_internal_data.value ,'%')")
-        .select("
-          distinct stash_engine_resources.*, stash_engine_curation_activities.status,
-          stash_engine_counter_stats.unique_investigation_count, stash_engine_counter_stats.citation_count,
-          stash_engine_counter_stats.unique_request_count, seca.created_at as submit_date,
-          stash_engine_journals.title as journal_title, stash_engine_journals.sponsor_id, stash_engine_journals.issn,
-          CONCAT_WS(' ', curator.first_name, curator.last_name) as curator_name,
-          (select GROUP_CONCAT(distinct CONCAT_WS(', ', sea.author_last_name, sea.author_first_name) ORDER BY sea.author_order, sea.id separator '; ')
-            from stash_engine_authors sea where sea.resource_id = stash_engine_resources.id limit 6) as author_string,
-          MATCH(stash_engine_identifiers.search_words) AGAINST('#{@search_string}') as relevance
-        ")
+      @datasets = authorize StashEngine::Resource.latest_per_dataset.select('distinct stash_engine_resources.*')
 
       add_fields
       add_filters
 
-      order_string = 'relevance desc'
-      if params[:sort].present?
-        order_list = %w[title author_string status total_file_size unique_investigation_count curator_name
-                        updated_at submit_date publication_date]
-        order_string = helpers.sortable_table_order(whitelist: order_list)
-        order_string += ', relevance desc' if @search_string.present?
+      if params[:sort].present? || @search_string.present?
+        order_string = 'relevance desc'
+        if params[:sort].present?
+          order_list = %w[title author_string status total_file_size unique_investigation_count curator_name
+                          updated_at submit_date publication_date]
+          order_string = helpers.sortable_table_order(whitelist: order_list)
+          order_string += ', relevance desc' if @search_string.present?
+        end
+        @datasets = @datasets.order(order_string)
       end
 
-      @datasets = @datasets.order(order_string)
       @datasets = @datasets.page(@page).per(@page_size)
+
+      add_subqueries
 
       respond_to do |format|
         format.html
@@ -62,7 +37,6 @@ module StashEngine
         end
       end
     end
-    # rubocop:enable Metrics/MethodLength
 
     def new_search
       respond_to(&:js)
@@ -110,6 +84,7 @@ module StashEngine
 
     # rubocop:disable Metrics/AbcSize, Metrics/CyclomaticComplexity, Metrics/PerceivedComplexity
     def setup_search
+      @sort = params[:sort]
       @saved_search = current_user.admin_searches[params[:search].to_i - 1] if params[:search]
       @saved_search ||= current_user.admin_searches.find_by(default: true)
 
@@ -119,8 +94,7 @@ module StashEngine
 
       session[:admin_search_filters] = params[:filters] if params[:filters].present?
       session[:admin_search_fields] = params[:fields] if params[:fields].present?
-      session[:admin_search_string] = params[:q] if params[:q].present?
-
+      session[:admin_search_string] = params[:q] if params.key?(:q)
       return unless @fields.blank?
 
       @search_string = ''
@@ -138,19 +112,41 @@ module StashEngine
       @properties = { fields: @fields, filters: @filters, search_string: @search_string }.to_json
     end
 
+    # rubocop:disable Metrics/MethodLength
     def add_fields
-      @datasets = @datasets.preload(:user) if @fields.include?('submitter')
-      @datasets = @datasets.preload(:funders) if @fields.include?('funders')
-      @datasets = @datasets.preload(:subjects) if @fields.include?('keywords')
-      @datasets = @datasets.preload(authors: :affiliations).preload(:tenant) if @fields.include?('affiliations')
-      @datasets = @datasets.preload(tenant: :ror_orgs).preload(authors: { affiliations: :ror_org }) if @fields.include?('countries')
-      @datasets = @datasets.preload(:related_identifiers) if @fields.include?('identifiers')
-      @datasets = @datasets.left_outer_joins(:related_identifiers) unless @filters[:identifiers].blank?
-      return unless @filters[:member].present? || @filters.dig(:funder, :value).present? || @filters.dig(:affiliation, :value).present? ||
-        @role_object.is_a?(StashEngine::Tenant) || @role_object.is_a?(StashEngine::Funder)
-
-      @datasets = @datasets.left_outer_joins(authors: :affiliations).left_outer_joins(:funders)
+      if @fields.include?('metrics')
+        @datasets = @datasets.joins('left outer join stash_engine_counter_stats stats ON stats.identifier_id = stash_engine_identifiers.id')
+          .select('stats.unique_investigation_count, stats.citation_count, stats.unique_request_count')
+      end
+      if @fields.include?('submit_date') || @filters[:submit_date]&.values&.any?(&:present?)
+        @datasets = @datasets.joins("#{@filters[:submit_date]&.values&.any?(&:present?) ? '' : 'left outer '}join
+          stash_engine_curation_activities subdate on subdate.id = (
+          select ca.id from stash_engine_curation_activities ca where ca.resource_id = stash_engine_resources.id
+          and ca.status in ('submitted', 'peer_review')
+          order by ca.created_at limit 1
+        )").select('subdate.created_at as submit_date')
+      end
+      if current_user.min_curator? && (@fields.include?('curator') || @filters[:curator].present?)
+        @datasets = @datasets.joins("left outer join (
+            select stash_engine_users.* from stash_engine_users
+            inner join stash_engine_roles on stash_engine_users.id = stash_engine_roles.user_id
+              and role in ('curator', 'superuser')
+          ) curator on curator.id = stash_engine_resources.current_editor_id")
+          .select("CONCAT_WS(' ', curator.first_name, curator.last_name) as curator_name")
+      end
+      if @fields.include?('authors') || @sort == 'author_string'
+        @datasets = @datasets.select("(
+          select GROUP_CONCAT(CONCAT_WS(', ', sea.author_last_name, sea.author_first_name) ORDER BY sea.author_order, sea.id separator '; ')
+            from stash_engine_authors sea where sea.resource_id = stash_engine_resources.id limit 6
+          ) as author_string")
+      end
+      @datasets = @datasets.select('stash_engine_curation_activities.status') if @sort == 'status'
+      @datasets = @datasets.select('stash_engine_counter_stats.unique_investigation_count') if @sort == 'unique_investigation_count'
+      @datasets = @datasets.select(
+        "MATCH(stash_engine_identifiers.search_words) AGAINST('#{@search_string}') as relevance"
+      ) if @search_string.present?
     end
+    # rubocop:enable Metrics/MethodLength
 
     def add_filters
       tenant_filter
@@ -159,25 +155,30 @@ module StashEngine
       funder_filter
 
       @datasets = @datasets.where('stash_engine_curation_activities.status': @filters[:status]) if @filters[:status].present?
-      @datasets = @datasets.where('dcs_affiliations.ror_id': @filters.dig(:affiliation, :value)) if @filters.dig(:affiliation, :value).present?
+      @datasets = @datasets.joins(authors: :affiliations).where('dcs_affiliations.ror_id': @filters.dig(:affiliation, :value)) if @filters.dig(
+        :affiliation, :value
+      ).present?
       @datasets = @datasets.where(
         'curator.id': Integer(@filters[:curator], exception: false) ? @filters[:curator] : nil
       ) if @filters[:curator].present? && current_user.min_curator?
       @datasets = @datasets.where("MATCH(stash_engine_identifiers.search_words) AGAINST('#{@search_string}') > 0") unless @search_string.blank?
-      @datasets = @datasets.where(
-        'dcs_related_identifiers.related_identifier like ? or stash_engine_internal_data.value like ?',
-        "%#{@filters[:identifiers]}%", "%#{@filters[:identifiers]}%"
-      ) unless @filters[:identifiers].blank?
+      @datasets = @datasets.left_outer_joins(:related_identifiers)
+        .joins("left outer join stash_engine_internal_data msnum on
+          msnum.idenmsnum.identifier_id = stash_engine_identifiers.id and msnum.data_type = 'manuscriptNumber'")
+        .where(
+          'dcs_related_identifiers.related_identifier like ? or msnum.value like ?',
+          "%#{@filters[:identifiers]}%", "%#{@filters[:identifiers]}%"
+        ) unless @filters[:identifiers].blank?
 
       date_filters
     end
 
     def date_filters
-      @datasets = @datasets.where(
+      @datasets = @datasets.joins(:last_curation_activity).where(
         "stash_engine_curation_activities.updated_at #{date_string(@filters[:updated_at])}"
       ) unless @filters[:updated_at].nil? || @filters[:updated_at].values.all?(&:blank?)
       @datasets = @datasets.where(
-        "seca.created_at #{date_string(@filters[:submit_date])}"
+        "subdate.created_at #{date_string(@filters[:submit_date])}"
       ) unless @filters[:submit_date].nil? || @filters[:submit_date].values.all?(&:blank?)
       @datasets = @datasets.where(
         "stash_engine_resources.publication_date #{date_string(@filters[:publication_date])}"
@@ -196,7 +197,7 @@ module StashEngine
         tenant_orgs = StashEngine::Tenant.find(@filters[:member]).ror_ids
       end
 
-      @datasets = @datasets.where(
+      @datasets = @datasets.left_outer_joins(authors: :affiliations).left_outer_joins(:funders).where(
         'stash_engine_resources.tenant_id in (?) or stash_engine_identifiers.payment_id in (?)
         or dcs_affiliations.ror_id in (?) or dcs_contributors.name_identifier_id in (?)',
         tenant_limit.map(&:id), tenant_limit.map(&:id), tenant_orgs, tenant_orgs
@@ -209,7 +210,12 @@ module StashEngine
       journal_ids = @filters.dig(:journal, :value)
       journal_ids = (@journal_limit.map(&:id).include?(journal_ids) ? journal_ids : @journal_limit.map(&:id)) if @journal_limit.present?
 
-      @datasets = @datasets.where('stash_engine_journals.id': journal_ids) if journal_ids.present?
+      return unless journal_ids.present?
+
+      @datasets = @datasets.joins("inner join stash_engine_internal_data jourissn on
+        jourissn.identifier_id = stash_engine_identifiers.id and jourissn.data_type = 'publicationISSN'")
+        .joins("inner join stash_engine_journals on stash_engine_journals.issn like CONCAT('%', jourissn.value ,'%')")
+        .where('stash_engine_journals.id': journal_ids)
     end
 
     def sponsor_filter
@@ -225,7 +231,10 @@ module StashEngine
       return unless @role_object.is_a?(StashEngine::Funder) || @filters.dig(:funder, :value).present?
 
       funder_ror = @role_object&.ror_id || @filters.dig(:funder, :value)
-      @datasets = @datasets.where('dcs_contributors.name_identifier_id': funder_ror)
+      @datasets = @datasets.joins(
+        "dcs_contributors on stash_engine_resources.id = dcs_contributors.resource_id
+        and contributor_type = 'funder' and dcs_contributors.name_identifier_id = #{funder_ror}"
+      )
     end
 
     def date_string(date_hash)
@@ -235,5 +244,20 @@ module StashEngine
 
       "BETWEEN '#{from}' AND #{to.blank? ? 'now()' : "'#{to}'"}"
     end
+
+    def add_subqueries
+      @datasets = @datasets.preload(:identifier)
+      @datasets = @datasets.preload(:last_curation_activity) if @fields.include?('status') || @fields.include?('updated_at')
+      @datasets = @datasets.preload(:subjects) if @fields.include?('keywords')
+      @datasets = @datasets.preload(:authors) if @fields.include?('authors')
+      @datasets = @datasets.preload(:tenant).preload(authors: :affiliations) if @fields.include?('affiliations')
+      @datasets = @datasets.preload(tenant: :ror_orgs).preload(authors: { affiliations: :ror_org }) if @fields.include?('countries')
+      @datasets = @datasets.preload(:user) if @fields.include?('submitter')
+      @datasets = @datasets.preload(identifier: :counter_stat) if @fields.include?('metrics')
+      @datasets = @datasets.preload(:funders) if @fields.include?('funders')
+      @datasets = @datasets.preload(:related_identifiers) if @fields.include?('identifiers')
+    end
+
   end
+  # rubocop:enable Metrics/ClassLength
 end

--- a/app/models/stash_datacite/publication.rb
+++ b/app/models/stash_datacite/publication.rb
@@ -11,6 +11,7 @@
 #
 # Indexes
 #
+#  index_internal_data_on_identifier_and_data_type          (identifier_id,data_type)
 #  index_stash_engine_internal_data_on_data_type_and_value  (data_type,value)
 #  index_stash_engine_internal_data_on_identifier_id        (identifier_id)
 #

--- a/app/models/stash_engine/identifier.rb
+++ b/app/models/stash_engine/identifier.rb
@@ -35,6 +35,7 @@ module StashEngine
   class Identifier < ApplicationRecord
     self.table_name = 'stash_engine_identifiers'
     has_many :resources, class_name: 'StashEngine::Resource', dependent: :destroy
+    has_one :process_date, as: :processable, dependent: :destroy
     has_many :orcid_invitations, class_name: 'StashEngine::OrcidInvitation', dependent: :destroy
     has_one :counter_stat, class_name: 'StashEngine::CounterStat', dependent: :destroy
     has_many :internal_data, class_name: 'StashEngine::InternalDatum', dependent: :destroy
@@ -54,6 +55,7 @@ module StashEngine
             foreign_key: 'id'
     belongs_to :software_license, class_name: 'StashEngine::SoftwareLicense', optional: true
 
+    after_create :create_process_date, unless: :process_date
     after_create :create_share
 
     # This makes the setting of the "preliminary information" and how something was imported explicit.  Default is other.

--- a/app/models/stash_engine/identifier.rb
+++ b/app/models/stash_engine/identifier.rb
@@ -557,70 +557,38 @@ module StashEngine
     # returns the date on which this identifier was initially approved for publication
     # (i.e., the date on which it entered the status 'published' or 'embargoed'
     def approval_date
-      return nil unless %w[published embargoed].include?(pub_state)
-
-      found_approval_date = nil
-      resources.reverse_each do |res|
-        res.curation_activities.each do |ca|
-          next unless %w[published embargoed].include?(ca.status)
-
-          found_approval_date = ca.created_at
-          break
-        end
-      end
-      found_approval_date
+      process_date.approved
     end
 
     # returns the date on which this identifier was initially referred for author action
     def aar_date
-      resources.map(&:curation_activities).flatten.each do |ca|
-        return ca.created_at if ca.action_required?
-      end
-      nil
+      resources.map(&:curation_activities).flatten.uniq(&:status)
+        .select { |ca| ca.status == 'action_required' }.pluck(&:created_at).first
     end
 
     # returns the date on which this identifier was returned to curators after action_required
     def aar_end_date
-      found_aar = false
-      resources.map(&:curation_activities).flatten.each do |ca|
-        found_aar = true if ca.action_required?
-        return ca.created_at if found_aar && !ca.action_required?
-      end
-      nil
+      return nil unless aar_date
+
+      changes = resources.map(&:curation_activities).flatten.pluck(:status, :created_at).uniq(&:first)
+      prev = changes.index { |c| c.first == 'aar_date' }
+      changes[prev + 1]&.last
     end
 
     def date_available_for_curation
-      resources.map(&:curation_activities).flatten.each do |ca|
-        return ca.created_at if ca.submitted?
-      end
-      nil
+      process_date.submitted
     end
 
     def curation_completed_date
-      return nil unless %w[action_required published embargoed withdrawn].include?(pub_state)
-
-      found_cc_date = nil
-      resources.map(&:curation_activities).flatten.each do |ca|
-        next unless %w[action_required published embargoed withdrawn].include?(ca.status)
-
-        found_cc_date = ca.created_at
-        break
-      end
-      found_cc_date
+      process_date.curation_end
     end
 
     def date_first_curated
-      resources.map(&:curation_activities).flatten.each do |ca|
-        return ca.created_at if ca.curation?
-      end
-      nil
+      process_date.curation_start
     end
 
     def date_last_curated
-      resources.map(&:curation_activities).flatten.reverse.each do |ca|
-        return ca.created_at if ca.curation?
-      end
-      nil
+      resources.map(&:process_date).pluck(:curation_start).reject(&:blank?)&.last || nil
     end
 
     def date_first_published

--- a/app/models/stash_engine/internal_datum.rb
+++ b/app/models/stash_engine/internal_datum.rb
@@ -17,7 +17,9 @@
 module StashEngine
   class InternalDatum < ApplicationRecord
     self.table_name = 'stash_engine_internal_data'
-    belongs_to :stash_identifier, class_name: 'StashEngine::Identifier', foreign_key: 'identifier_id'
+    belongs_to :stash_identifier, class_name: 'StashEngine::Identifier', foreign_key: :identifier_id
+    belongs_to :journal_issn, class_name: 'StashEngine::JournalIssn', foreign_key: :value, optional: true
+    belongs_to :manuscripts, class_name: 'StashEngine::Manuscript', primary_key: :manuscript_number, foreign_key: :value, optional: true
     validates :data_type, inclusion: {
       in: %w[manuscriptNumber mismatchedDOI duplicateItem formerManuscriptNumber publicationISSN
              publicationName pubmedID dansArchiveDate dansEditIRI],

--- a/app/models/stash_engine/internal_datum.rb
+++ b/app/models/stash_engine/internal_datum.rb
@@ -11,6 +11,7 @@
 #
 # Indexes
 #
+#  index_internal_data_on_identifier_and_data_type          (identifier_id,data_type)
 #  index_stash_engine_internal_data_on_data_type_and_value  (data_type,value)
 #  index_stash_engine_internal_data_on_identifier_id        (identifier_id)
 #

--- a/app/models/stash_engine/journal.rb
+++ b/app/models/stash_engine/journal.rb
@@ -30,7 +30,8 @@
 module StashEngine
   class Journal < ApplicationRecord
     self.table_name = 'stash_engine_journals'
-    validates :issn, uniqueness: { case_sensitive: false }
+    # validates :issn, uniqueness: { case_sensitive: false }
+    has_many :issns, -> { order(created_at: :asc) }, class_name: 'StashEngine::JournalIssn', dependent: :destroy
     has_many :alternate_titles, class_name: 'StashEngine::JournalTitle', dependent: :destroy
     has_many :roles, class_name: 'StashEngine::Role', as: :role_object
     has_many :users, through: :roles
@@ -53,20 +54,20 @@ module StashEngine
     # Return the single ISSN that is representative of this journal,
     # even if the journal contains multiple ISSNs
     def single_issn
-      return nil unless issn.present?
-      return issn.first if issn.is_a?(Array)
-      return JSON.parse(issn)&.first if issn.start_with?('[')
+      # return nil unless issn.present?
+      # return issn.first if issn.is_a?(Array)
+      # return JSON.parse(issn)&.first if issn.start_with?('[')
 
-      issn
+      issns.map(&:id)&.first
     end
 
     # Return an array of ISSNs, even if the journal contains a single ISSN
     def issn_array
-      return nil unless issn.present?
-      return issn if issn.is_a?(Array)
-      return JSON.parse(issn) if issn.start_with?('[')
+      # return nil unless issn.present?
+      # return issn if issn.is_a?(Array)
+      # return JSON.parse(issn) if issn.start_with?('[')
 
-      [issn]
+      issns.map(&:id)
     end
 
     def notify_contacts
@@ -93,7 +94,7 @@ module StashEngine
     def self.find_by_issn(issn)
       return nil if issn.blank? || issn.size < 9
 
-      StashEngine::Journal.where("issn like '%#{issn}%'")&.first
+      StashEngine::JournalIssn.find_by(id: issn)&.journal
     end
 
     # Replace an uncontrolled journal name (typically containing '*')

--- a/app/models/stash_engine/journal.rb
+++ b/app/models/stash_engine/journal.rb
@@ -8,7 +8,6 @@
 #  allow_review_workflow   :boolean
 #  default_to_ppr          :boolean          default(FALSE)
 #  description             :text(65535)
-#  issn                    :string(191)
 #  journal_code            :string(191)
 #  manuscript_number_regex :string(191)
 #  notify_contacts         :text(65535)
@@ -24,7 +23,6 @@
 #
 # Indexes
 #
-#  index_stash_engine_journals_on_issn   (issn)
 #  index_stash_engine_journals_on_title  (title)
 #
 module StashEngine

--- a/app/models/stash_engine/journal_issn.rb
+++ b/app/models/stash_engine/journal_issn.rb
@@ -1,0 +1,9 @@
+module StashEngine
+  class JournalIssn < ApplicationRecord
+    self.table_name = 'stash_engine_journal_issns'
+    belongs_to :journal, class_name: 'StashEngine::Journal'
+    ISSN = /\A[0-9]{4}-[0-9]{3}[0-9X]\z/
+
+    validates :id, format: ISSN
+  end
+end

--- a/app/models/stash_engine/journal_issn.rb
+++ b/app/models/stash_engine/journal_issn.rb
@@ -1,3 +1,20 @@
+# == Schema Information
+#
+# Table name: stash_engine_journal_issns
+#
+#  id         :string(191)      not null, primary key
+#  created_at :datetime         not null
+#  updated_at :datetime         not null
+#  journal_id :integer
+#
+# Indexes
+#
+#  fk_rails_f3f01a3cbd  (journal_id)
+#
+# Foreign Keys
+#
+#  fk_rails_...  (journal_id => stash_engine_journals.id)
+#
 module StashEngine
   class JournalIssn < ApplicationRecord
     self.table_name = 'stash_engine_journal_issns'

--- a/app/models/stash_engine/process_date.rb
+++ b/app/models/stash_engine/process_date.rb
@@ -1,0 +1,6 @@
+module StashEngine
+  class ProcessDate < ApplicationRecord
+    self.table_name = 'stash_engine_process_dates'
+    belongs_to :processable, polymorphic: true, optional: false
+  end
+end

--- a/app/models/stash_engine/resource.rb
+++ b/app/models/stash_engine/resource.rb
@@ -499,13 +499,13 @@ module StashEngine
 
     # Date on which the user first submitted this resource
     def submitted_date
-      curation_activities.order(:id).where("status = 'submitted' OR status = 'peer_review'")&.first&.created_at
+      process_date.submitted || process_date.peer_review
     end
 
     # Date on which the curators first received this resource
     # (for peer_review datasets, the date at which it came out of peer_review)
     def curation_start_date
-      curation_activities.order(:id).where("status = 'submitted' OR status = 'curation'")&.first&.created_at
+      process_date.curation_start
     end
 
     # ------------------------------------------------------------

--- a/app/models/stash_engine/resource.rb
+++ b/app/models/stash_engine/resource.rb
@@ -50,7 +50,7 @@ module StashEngine
     self.table_name = 'stash_engine_resources'
     # ------------------------------------------------------------
     # Relations
-
+    has_one :process_date, as: :processable, dependent: :destroy
     has_many :authors, class_name: 'StashEngine::Author', dependent: :destroy
     has_many :generic_files, class_name: 'StashEngine::GenericFile', dependent: :destroy
     has_many :data_files, class_name: 'StashEngine::DataFile', dependent: :destroy
@@ -97,6 +97,8 @@ module StashEngine
     has_many :formats, class_name: 'StashDatacite::Format', dependent: :destroy
     has_one :version, class_name: 'StashDatacite::Version', dependent: :destroy
     has_many :processor_results, class_name: 'StashEngine::ProcessorResult', dependent: :destroy
+
+    after_create :create_process_date, unless: :process_date
 
     # self.class.reflect_on_all_associations(:has_many).select{ |i| i.name.to_s.include?('file') }.map{ |i| [i.name, i.class_name] }
     ASSOC_TO_FILE_CLASS = reflect_on_all_associations(:has_many).select { |i| i.name.to_s.include?('file') }

--- a/app/views/stash_engine/admin_dashboard/_fields.html.erb
+++ b/app/views/stash_engine/admin_dashboard/_fields.html.erb
@@ -53,6 +53,10 @@ end
     <span class="help" id="metrics-desc">View, download, and citation statistics.</span>
   </div>
   <div>
+    <%= check('funders').html_safe %>
+     <span class="help" id="funders-desc">Funding organizations matched with a <a href="https://ror.org/" target="_blank">ROR ID</a>.</span>
+  </div>
+  <div>
     <%= check('journal').html_safe %>
     <span class="help" id="journal-desc">Journal of the manuscript or primary article associated with the dataset.</span>
   </div>
@@ -63,10 +67,6 @@ end
   <div>
     <%= check('identifiers').html_safe %>
     <span class="help" id="identifiers-desc">Up to 6 related work identifiers, including manuscripts.</span>
-  </div>
-  <div>
-    <%= check('funders').html_safe %>
-     <span class="help" id="funders-desc">Funding organizations matched with a <a href="https://ror.org/" target="_blank">ROR ID</a>.</span>
   </div>
   <div>
     <%= check('awards', true).html_safe %>

--- a/app/views/stash_engine/admin_dashboard/_fields.html.erb
+++ b/app/views/stash_engine/admin_dashboard/_fields.html.erb
@@ -1,10 +1,10 @@
 <%
-def check(id)
+def check(id, indent = false)
   h = {funders: 'Grant funders', awards: 'Award IDs', sponsor: 'Journal sponsor', dpc: 'DPC paid by', updated_at: 'Last modified', submit_date: 'Submitted', publication_date: 'Published', identifiers: 'Publication IDs'}
   label = h[id.to_sym]
   label ||= id.length < 4 ? id.upcase : id.capitalize
 
-  '<span class="field-pair">' +
+  '<span class="field-pair">' + (indent ? '<i class="fa-solid fa-arrow-turn-up fa-rotate-90" style="font-size:.85em; margin-left: .2em" aria-hidden="true"></i>' : '') +
   check_box_tag('fields[]', id, @fields.include?(id), {id: id, 'aria-describedby': "#{id}-desc"}) +
   label_tag('fields[]', label, {for: id})+
   '</span>'
@@ -14,13 +14,14 @@ end
   <b role="heading" aria-level="3" id="edit_fields">Display fields</b>
   <button type="button" class="o-button__plain-text7" id="edit_fields-help" aria-hidden="true"><i class="fa fa-info-circle"></i> Display field help</button>
 </div>
-<fieldset id="edit_fields-form" aria-labelledby="edit_fields" <%if current_user.min_curator?%>class="extra-column"<%end%>>
+<fieldset id="edit_fields-form" aria-labelledby="edit_fields">
+  <div>Description</div>
   <div>
-    <%= check('doi').html_safe %>
+    <%= check('doi', true).html_safe %>
     <span class="help" id="doi-desc"><a href="https://www.doi.org/" target="_blank">Identifier</a> assigned to the dataset. Appears under Description.</span>
   </div>
   <div>
-    <%= check('keywords').html_safe %>
+    <%= check('keywords', true).html_safe %>
     <span class="help" id="keywords-desc">Subjects entered by the submitter. Appear under Description.</span>
   </div>
   <div>
@@ -32,8 +33,8 @@ end
     <span class="help" id="affiliations-desc">Up to 6 author affiliations matched with a <a href="https://ror.org/" target="_blank">ROR ID</a>.</span>
   </div>
   <div>
-    <%= check('countries').html_safe %>
-    <span class="help" id="countries-desc">Up to 6 countries associated with author affiliations.</span>
+    <%= check('countries', true).html_safe %>
+    <span class="help" id="countries-desc">Up to 6 countries associated with author affiliations. Appear with Affiliations.</span>
   </div>
   <div>
     <%= check('submitter').html_safe %>
@@ -44,12 +45,12 @@ end
     <span class="help" id="status-desc">Status of the submission in Dryad processing.</span>
   </div>
   <div>
-    <%= check('metrics').html_safe %>
-    <span class="help" id="metrics-desc">View, download, and citation statistics.</span>
-  </div>
-  <div>
     <%= check('size').html_safe %>
     <span class="help" id="help-desc">Total size of the uploaded data files.</span>
+  </div>
+  <div>
+    <%= check('metrics').html_safe %>
+    <span class="help" id="metrics-desc">View, download, and citation statistics.</span>
   </div>
   <div>
     <%= check('journal').html_safe %>
@@ -61,19 +62,19 @@ end
   </div>
   <div>
     <%= check('identifiers').html_safe %>
-    <span class="help" id="identifiers-desc">Up to 6 identifiers of related publications.</span>
-  </div>
-  <div>
-    <%= check('dpc').html_safe %>
-    <span class="help" id="dpc-desc">Party responsible for the <a href="/stash/requirements#cost" target="_blank">Dryad Data Publishing Charge</a>.</span>
+    <span class="help" id="identifiers-desc">Up to 6 related work identifiers, including manuscripts.</span>
   </div>
   <div>
     <%= check('funders').html_safe %>
      <span class="help" id="funders-desc">Funding organizations matched with a <a href="https://ror.org/" target="_blank">ROR ID</a>.</span>
   </div>
   <div>
-    <%= check('awards').html_safe %>
-    <span class="help" id="awards-desc">Grant and other funder identifiers.</span>
+    <%= check('awards', true).html_safe %>
+    <span class="help" id="awards-desc">Grant and other funder identifiers. Appear with Funders.</span>
+  </div>
+  <div>
+    <%= check('dpc').html_safe %>
+    <span class="help" id="dpc-desc">Party responsible for the <a href="/stash/requirements#cost" target="_blank">Dryad Data Publishing Charge</a>.</span>
   </div>
   <% if current_user.min_curator? %>
     <div>

--- a/app/views/stash_engine/admin_dashboard/_table_header.html.erb
+++ b/app/views/stash_engine/admin_dashboard/_table_header.html.erb
@@ -29,6 +29,9 @@
         <%= sortable_column_head sort_field: 'unique_investigation_count', title: 'Metrics' %>
       </th>
     <% end %>
+    <% if @fields.include?('funders') || @fields.include?('awards') %>
+      <th><%= @fields.include?('funders') ? 'Grant funders' : 'Award IDs' %></th>
+    <% end %>
     <% if @fields.include?('journal') %>
       <th>Journal</th>
     <% end %>
@@ -37,9 +40,6 @@
     <% end %>
     <% if @fields.include?('identifiers') %>
       <th>Publication IDs</th>
-    <% end %>
-    <% if @fields.include?('funders') || @fields.include?('awards') %>
-      <th><%= @fields.include?('funders') ? 'Grant funders' : 'Award IDs' %></th>
     <% end %>
     <% if @fields.include?('dpc') %>
       <th>DPC paid by</th>

--- a/app/views/stash_engine/admin_dashboard/_table_header.html.erb
+++ b/app/views/stash_engine/admin_dashboard/_table_header.html.erb
@@ -29,9 +29,6 @@
         <%= sortable_column_head sort_field: 'unique_investigation_count', title: 'Metrics' %>
       </th>
     <% end %>
-    <% if @fields.include?('funders') || @fields.include?('awards') %>
-      <th><%= @fields.include?('funders') ? 'Grant funders' : 'Award IDs' %></th>
-    <% end %>
     <% if @fields.include?('journal') %>
       <th>Journal</th>
     <% end %>
@@ -41,13 +38,16 @@
     <% if @fields.include?('identifiers') %>
       <th>Publication IDs</th>
     <% end %>
+    <% if @fields.include?('funders') || @fields.include?('awards') %>
+      <th><%= @fields.include?('funders') ? 'Grant funders' : 'Award IDs' %></th>
+    <% end %>
+    <% if @fields.include?('dpc') %>
+      <th>DPC paid by</th>
+    <% end %>
     <% if @fields.include?('curator') %>
       <th class="c-lined-table__sort <%= sort_display('curator_name') %>">
         <%= sortable_column_head sort_field: 'curator_name', title: 'Curator' %>
       </th>
-    <% end %>
-    <% if @fields.include?('dpc') %>
-      <th>DPC paid by</th>
     <% end %>
     <% if @fields.include?('updated_at') %>
       <th class="c-lined-table__sort <%= sort_display('updated_at') %>">

--- a/app/views/stash_engine/admin_dashboard/_table_row.html.erb
+++ b/app/views/stash_engine/admin_dashboard/_table_row.html.erb
@@ -32,7 +32,7 @@
       </td>
     <% end %>
     <% if @fields.include?('status') %>
-      <td><%= StashEngine::CurationActivity.readable_status(dataset.status) %></td>
+      <td><%= StashEngine::CurationActivity.readable_status(dataset.last_curation_activity.status) %></td>
     <% end %>
     <% if @fields.include?('size') %>
       <td class="c-lined-table__digits"><%= filesize(dataset.total_file_size) %></td>
@@ -47,10 +47,10 @@
       <td><%= dataset.funders.map { |f| ([@fields.include?('funders') ? f.contributor_name : nil] + [@fields.include?('awards') ? f.award_number : nil]).reject(&:blank?).join(', ')}.uniq.reject(&:blank?).join('; ') %></td>
     <% end %>
     <% if @fields.include?('journal') %>
-      <td><%= dataset.journal_title %></td>
+      <td><%= dataset.identifier&.journal&.title %></td>
     <% end %>
     <% if @fields.include?('sponsor') %>
-      <td><%= dataset.sponsor_id && StashEngine::JournalOrganization.where(id: dataset.sponsor_id).first&.name %></td>
+      <td><%= dataset.identifier&.journal&.sponsor_id && StashEngine::JournalOrganization.find_by(id: dataset.identifier.journal.sponsor_id)&.name %></td>
     <% end %>
     <% if @fields.include?('identifiers') %>
       <td><%= ([dataset.identifier.manuscript_number] + dataset.related_identifiers.map {|id| id.related_identifier.partition('//doi.org/').last}).reject(&:blank?).first(6).join(', ') %></td>
@@ -62,7 +62,7 @@
       <td>
         <% dpc = ''
           dpc = dataset.tenant&.short_name if dataset.identifier.payment_id = dataset.tenant_id
-          dpc = dataset.journal_title if dataset&.issn&.include?(dataset.identifier.payment_id)
+          dpc = dataset.identifier&.journal&.journal_title if dataset.identifier&.journal&.issn&.include?(dataset.identifier.payment_id)
           dpc = dataset.identifier.payment_id.split("funder:").last.split("|").first if dataset.identifier.payment_id.starts_with?('funder')
         %>
         <%= dpc %>

--- a/app/views/stash_engine/admin_dashboard/_table_row.html.erb
+++ b/app/views/stash_engine/admin_dashboard/_table_row.html.erb
@@ -43,9 +43,6 @@
         <%= dataset.citation_count || 0 %> citations
       </td>
     <% end %>
-    <% if @fields.include?('funders') || @fields.include?('awards') %>
-      <td><%= dataset.funders.map { |f| ([@fields.include?('funders') ? f.contributor_name : nil] + [@fields.include?('awards') ? f.award_number : nil]).reject(&:blank?).join(', ')}.uniq.reject(&:blank?).join('; ') %></td>
-    <% end %>
     <% if @fields.include?('journal') %>
       <td><%= dataset.identifier&.journal&.title %></td>
     <% end %>
@@ -55,8 +52,8 @@
     <% if @fields.include?('identifiers') %>
       <td><%= ([dataset.identifier.manuscript_number] + dataset.related_identifiers.map {|id| id.related_identifier.partition('//doi.org/').last}).reject(&:blank?).first(6).join(', ') %></td>
     <% end %>
-    <% if @fields.include?('curator') %>
-      <td><%= dataset.curator_name %></td>
+    <% if @fields.include?('funders') || @fields.include?('awards') %>
+      <td><%= dataset.funders.map { |f| ([@fields.include?('funders') ? f.contributor_name : nil] + [@fields.include?('awards') ? f.award_number : nil]).reject(&:blank?).join(', ')}.uniq.reject(&:blank?).join('; ') %></td>
     <% end %>
     <% if @fields.include?('dpc') %>
       <td>
@@ -67,6 +64,9 @@
         %>
         <%= dpc %>
       </td>
+    <% end %>
+    <% if @fields.include?('curator') %>
+      <td><%= dataset.curator_name %></td>
     <% end %>
     <% if @fields.include?('updated_at') %>
       <td class="c-lined-table__digits"><%= formatted_datetime(dataset.last_curation_activity.updated_at) %></span></td>

--- a/app/views/stash_engine/admin_dashboard/_table_row.html.erb
+++ b/app/views/stash_engine/admin_dashboard/_table_row.html.erb
@@ -43,6 +43,9 @@
         <%= dataset.citation_count || 0 %> citations
       </td>
     <% end %>
+    <% if @fields.include?('funders') || @fields.include?('awards') %>
+      <td><%= dataset.funders.map { |f| ([@fields.include?('funders') ? f.contributor_name : nil] + [@fields.include?('awards') ? f.award_number : nil]).reject(&:blank?).join(', ')}.uniq.reject(&:blank?).join('; ') %></td>
+    <% end %>
     <% if @fields.include?('journal') %>
       <td><%= dataset.identifier&.journal&.title %></td>
     <% end %>
@@ -51,9 +54,6 @@
     <% end %>
     <% if @fields.include?('identifiers') %>
       <td><%= ([dataset.identifier.manuscript_number] + dataset.related_identifiers.map {|id| id.related_identifier.partition('//doi.org/').last}).reject(&:blank?).first(6).join(', ') %></td>
-    <% end %>
-    <% if @fields.include?('funders') || @fields.include?('awards') %>
-      <td><%= dataset.funders.map { |f| ([@fields.include?('funders') ? f.contributor_name : nil] + [@fields.include?('awards') ? f.award_number : nil]).reject(&:blank?).join(', ')}.uniq.reject(&:blank?).join('; ') %></td>
     <% end %>
     <% if @fields.include?('dpc') %>
       <td>

--- a/app/views/stash_engine/admin_dashboard/_table_row.html.erb
+++ b/app/views/stash_engine/admin_dashboard/_table_row.html.erb
@@ -72,7 +72,7 @@
       <td class="c-lined-table__digits"><%= formatted_datetime(dataset.last_curation_activity.updated_at) %></span></td>
     <% end %>
     <% if @fields.include?('submit_date') %>
-      <td class="c-lined-table__digits"><%= formatted_datetime(dataset.submit_date) %></td>
+      <td class="c-lined-table__digits"><%= formatted_datetime(dataset.process_date.submitted || dataset.process_date.peer_review) %></td>
     <% end %>
     <% if @fields.include?('publication_date') %>
       <td class="c-lined-table__digits"><%= formatted_datetime(dataset.publication_date) %></td>

--- a/app/views/stash_engine/admin_dashboard/_table_row.html.erb
+++ b/app/views/stash_engine/admin_dashboard/_table_row.html.erb
@@ -50,7 +50,7 @@
       <td><%= dataset.identifier&.journal&.title %></td>
     <% end %>
     <% if @fields.include?('sponsor') %>
-      <td><%= dataset.identifier&.journal&.sponsor_id && StashEngine::JournalOrganization.find_by(id: dataset.identifier.journal.sponsor_id)&.name %></td>
+      <td><%= dataset.identifier&.journal&.sponsor&.name %></td>
     <% end %>
     <% if @fields.include?('identifiers') %>
       <td><%= ([dataset.identifier.manuscript_number] + dataset.related_identifiers.map {|id| id.related_identifier.partition('//doi.org/').last}).reject(&:blank?).first(6).join(', ') %></td>
@@ -62,7 +62,7 @@
       <td>
         <% dpc = ''
           dpc = dataset.tenant&.short_name if dataset.identifier.payment_id = dataset.tenant_id
-          dpc = dataset.identifier&.journal&.journal_title if dataset.identifier&.journal&.issn&.include?(dataset.identifier.payment_id)
+          dpc = dataset.identifier&.journal&.journal_title if dataset.identifier&.journal&.issn_array&.include?(dataset.identifier.payment_id)
           dpc = dataset.identifier.payment_id.split("funder:").last.split("|").first if dataset.identifier.payment_id.starts_with?('funder')
         %>
         <%= dpc %>

--- a/app/views/stash_engine/admin_dashboard/index.csv.erb
+++ b/app/views/stash_engine/admin_dashboard/index.csv.erb
@@ -39,7 +39,7 @@ head += ',Published' if @fields.include?('publication_date')
   if @fields.include?('submitter')
     row << "#{dataset.user.first_name} #{dataset.user.last_name}#{dataset.user.orcid ? " ORCID: #{dataset.user.orcid}" : ''}"
   end
-  row << StashEngine::CurationActivity.readable_status(dataset.status) if @fields.include?('status')
+  row << StashEngine::CurationActivity.readable_status(dataset.last_curation_activity.status) if @fields.include?('status')
   row << filesize(dataset.total_file_size) if @fields.include?('size')
   if @fields.include?('metrics')
     row << "#{dataset.unique_investigation_count.blank? || dataset.unique_investigation_count < dataset.unique_request_count ? dataset.unique_request_count || 0 : dataset.unique_investigation_count} views, #{dataset.unique_request_count || 0} downloads, #{dataset.citation_count || 0} citations"
@@ -47,8 +47,8 @@ head += ',Published' if @fields.include?('publication_date')
   if @fields.include?('funders') || @fields.include?('awards')
     row << dataset.funders.map { |f| ([@fields.include?('funders') ? f.contributor_name : nil] + [@fields.include?('awards') ? f.award_number : nil]).reject(&:blank?).join(', ')}.uniq.reject(&:blank?).join('; ') 
   end
-  row << dataset.journal_title if @fields.include?('journal')
-  row << dataset.sponsor_id && StashEngine::JournalOrganization.where(id: dataset.sponsor_id).first&.name if @fields.include?('sponsor')
+  row << dataset.identifier&.journal&.title if @fields.include?('journal')
+  row << (dataset.identifier&.journal&.sponsor_id&.present? ? StashEngine::JournalOrganization.find_by(id: dataset.identifier.journal.sponsor_id).name : '') if @fields.include?('sponsor')
   if @fields.include?('identifiers')
     row << ([dataset.identifier.manuscript_number] + dataset.related_identifiers.map {|id| id.related_identifier.partition('//doi.org/').last}).reject(&:blank?).first(6).join(', ')
   end
@@ -56,7 +56,7 @@ head += ',Published' if @fields.include?('publication_date')
   if @fields.include?('dpc')
     dpc = ''
     dpc = dataset.tenant&.short_name if dataset.identifier.payment_id = dataset.tenant_id
-    dpc = dataset.journal_title if dataset&.issn&.include?(dataset.identifier.payment_id)
+    dpc = dataset.identifier&.journal&.journal_title if dataset.identifier&.journal&.issn&.include?(dataset.identifier.payment_id)
     dpc = dataset.identifier.payment_id.split("funder:").last.split("|").first if dataset.identifier.payment_id.starts_with?('funder')
     row << dpc
   end

--- a/app/views/stash_engine/admin_dashboard/index.csv.erb
+++ b/app/views/stash_engine/admin_dashboard/index.csv.erb
@@ -48,7 +48,7 @@ head += ',Published' if @fields.include?('publication_date')
     row << dataset.funders.map { |f| ([@fields.include?('funders') ? f.contributor_name : nil] + [@fields.include?('awards') ? f.award_number : nil]).reject(&:blank?).join(', ')}.uniq.reject(&:blank?).join('; ') 
   end
   row << dataset.identifier&.journal&.title if @fields.include?('journal')
-  row << (dataset.identifier&.journal&.sponsor_id&.present? ? StashEngine::JournalOrganization.find_by(id: dataset.identifier.journal.sponsor_id).name : '') if @fields.include?('sponsor')
+  row << dataset.identifier&.journal&.sponsor&.name if @fields.include?('sponsor')
   if @fields.include?('identifiers')
     row << ([dataset.identifier.manuscript_number] + dataset.related_identifiers.map {|id| id.related_identifier.partition('//doi.org/').last}).reject(&:blank?).first(6).join(', ')
   end
@@ -56,7 +56,7 @@ head += ',Published' if @fields.include?('publication_date')
   if @fields.include?('dpc')
     dpc = ''
     dpc = dataset.tenant&.short_name if dataset.identifier.payment_id = dataset.tenant_id
-    dpc = dataset.identifier&.journal&.journal_title if dataset.identifier&.journal&.issn&.include?(dataset.identifier.payment_id)
+    dpc = dataset.identifier&.journal&.journal_title if dataset.identifier&.journal&.issn_array&.include?(dataset.identifier.payment_id)
     dpc = dataset.identifier.payment_id.split("funder:").last.split("|").first if dataset.identifier.payment_id.starts_with?('funder')
     row << dpc
   end

--- a/app/views/stash_engine/admin_dashboard/index.csv.erb
+++ b/app/views/stash_engine/admin_dashboard/index.csv.erb
@@ -61,7 +61,7 @@ head += ',Published' if @fields.include?('publication_date')
     row << dpc
   end
   row << dataset.last_curation_activity.updated_at if @fields.include?('updated_at') 
-  row << dataset.submit_date if @fields.include?('submit_date')
+  row << (dataset.process_date.submitted || dataset.process_date.peer_review) if @fields.include?('submit_date')
   row << dataset.publication_date if @fields.include?('publication_date')
 %>
 <%= row.to_csv(row_sep: nil).html_safe %>

--- a/app/views/stash_engine/admin_dashboard/index.html.erb
+++ b/app/views/stash_engine/admin_dashboard/index.html.erb
@@ -14,7 +14,7 @@
     <button type="button" class="o-button__plain-text7" id="search_open" aria-controls="search_form" aria-expanded="<%= keepopen %>" <% if keepopen %>hidden<% end %>><i class="fa fa-sliders" aria-hidden="true"></i>Fields and filters</button>
   </div>
   <div id="search_form" <% unless params[:filters] || params[:fields] || params[:search_string] %>hidden<% end %>>
-    <%= form_with(url: admin_dashboard_path(search: params[:search]), method: 'post', class: 'admin-dashboard-form') do %>
+    <%= form_with(url: admin_dashboard_path(search: params[:search], page_size: @page_size), method: 'post', class: 'admin-dashboard-form') do %>
       <%= render partial: 'fields' %>
       <%= render partial: 'filters' %>
       <div class="admin-dashboard-buttons" style="column-gap: 3ch; row-gap: 2ch">
@@ -47,7 +47,7 @@
     <% end %>
   </div>  
   <div class="admin-dashboard-results" style="font-size: .9em;">
-    <span><b><%= number_with_delimiter(@datasets.total_count) %></b> results</span>
+    <span><b><%= number_with_delimiter(session[:admin_search_count]) %></b> results</span>
     <%= link_to 'Export all as CSV', stash_url_helpers.admin_dashboard_path(request.parameters.except(:action, :controller, :fields, :authenticity_token, :fields, :filters).merge(format: :csv)), class: 'o-link__buttonlink' %>
   </div>
 </div>
@@ -62,14 +62,12 @@
 
 <div class="search-results-footer">
   <div class="c-space-paginator">
-    <%= paginate @datasets, params: {fields: nil, filters: nil, q: nil, page_size: @page_size} %>
+    <% pagination = Kaminari.paginate_array([], total_count: session[:admin_search_count]).page(@page).per(@page_size) %>
+    <%= paginate pagination, params: {fields: nil, filters: nil, q: nil, page_size: @page_size} %>
     <div class="c-paginator-page_size">
       Page size:
-      <%
-        current_ps = params[:page_size].to_i
-        current_ps = 10 if current_ps == 0
-        [10, 50, 100].each do |ps| %>
-        <% if ps == current_ps %>
+      <%[10, 50, 100].each do |ps| %>
+        <% if ps == @page_size %>
           <span class="page-current"><%= ps %></span>
         <% else %>
           <%= link_to(ps, stash_url_helpers.admin_dashboard_path(request.parameters.except(:action, :controller, :authenticity_token, :fields, :filters, :q).merge(page_size: ps, page: 1))) %>

--- a/app/views/stash_engine/journal_admin/_admin_journal_table.html.erb
+++ b/app/views/stash_engine/journal_admin/_admin_journal_table.html.erb
@@ -5,8 +5,8 @@
       <th class="c-lined-table__sort <%= sort_display('title') %>">
         <%= sortable_column_head sort_field: 'title', title: 'Title' %>
       </th>
-      <th class="c-lined-table__sort <%= sort_display('issn') %>">
-        <%= sortable_column_head sort_field: 'issn', title: 'ISSN(s)' %>
+      <th class="c-admin-table">
+        ISSNs
       </th>
       <th class="c-lined-table__sort <%= sort_display('payment_plan_type') %>">
         <%= sortable_column_head sort_field: 'payment_plan_type', title: 'Payment plan' %>

--- a/app/views/stash_engine/shared/_search_select.html.erb
+++ b/app/views/stash_engine/shared/_search_select.html.erb
@@ -39,11 +39,11 @@
             }
           }
         }
+        status.innerHTML = 'Results loaded'
       } else {
         status.innerHTML = 'Loading results'
         list.innerHTML = '<li><i class="fa fa-circle-o-notch fa-spin" aria-hidden="true"></i></li>'
       }
-      status.innerHTML = 'Results loaded'
     }
     const select = ({label, value}) => {
       v.value = value

--- a/app/views/stash_engine/shared/_search_select.html.erb
+++ b/app/views/stash_engine/shared/_search_select.html.erb
@@ -17,8 +17,6 @@
     const v = document.getElementById(itemId + '__value')
     const l = document.getElementById(itemId + '__label')
     const fill = async () => {
-      status.innerHTML = 'Loading results'
-      list.innerHTML = '<li><i class="fa fa-circle-o-notch fa-spin" aria-hidden="true"></i></li>'
       if (textbox.value.length > 2) {
         const response = await fetch('<%= options_path %>' + textbox.value)
         const json = await response.json()
@@ -41,8 +39,11 @@
             }
           }
         }
-        status.innerHTML = 'Results loaded'
+      } else {
+        status.innerHTML = 'Loading results'
+        list.innerHTML = '<li><i class="fa fa-circle-o-notch fa-spin" aria-hidden="true"></i></li>'
       }
+      status.innerHTML = 'Results loaded'
     }
     const select = ({label, value}) => {
       v.value = value

--- a/app/views/stash_engine/shared/_search_select.html.erb
+++ b/app/views/stash_engine/shared/_search_select.html.erb
@@ -42,7 +42,7 @@
         status.innerHTML = 'Results loaded'
       } else {
         status.innerHTML = 'Loading results'
-        list.innerHTML = '<li><i class="fa fa-circle-o-notch fa-spin" aria-hidden="true"></i></li>'
+        list.innerHTML = '<li><i class="fa fa-circle-notch fa-spin" aria-hidden="true"></i></li>'
       }
     }
     const select = ({label, value}) => {

--- a/db/migrate/20240619163957_journal_issn_table.rb
+++ b/db/migrate/20240619163957_journal_issn_table.rb
@@ -1,0 +1,31 @@
+class JournalIssnTable < ActiveRecord::Migration[7.0]
+  def change
+    add_index :stash_engine_internal_data, [:identifier_id, :data_type], unique: false, name: 'index_internal_data_on_identifier_and_data_type'
+    create_table :stash_engine_journal_issns, id: :string do |t|
+      t.integer :journal_id
+      t.timestamps
+    end
+    add_foreign_key :stash_engine_journal_issns, :stash_engine_journals, column: :journal_id
+    reversible do |dir|
+      dir.up do
+        StashEngine::Journal.find_each do |j|
+          issns = j.issn if j.issn.present? && j.issn.is_a?(Array)
+          issns ||= JSON.parse(j.issn) if j.issn.present? && j.issn.start_with?('[')
+          issns ||= [j.issn]
+          issns.flatten.reject(&:blank?).each do |issn|
+            StashEngine::JournalIssn.create(id: issn, journal_id: j.id)
+          end
+        end
+        remove_index :stash_engine_journals, :issn
+        remove_column :stash_engine_journals, :issn
+      end
+      dir.down do
+        add_column :stash_engine_journals, :issn, :string
+        StashEngine::Journal.find_each do |j|
+          j.update(issn: j.issns.map(&:id).to_json)
+        end
+        add_index :stash_engine_journals, :issn
+      end
+    end
+  end
+end

--- a/db/migrate/20240619163957_journal_issn_table.rb
+++ b/db/migrate/20240619163957_journal_issn_table.rb
@@ -16,15 +16,15 @@ class JournalIssnTable < ActiveRecord::Migration[7.0]
             StashEngine::JournalIssn.create(id: issn, journal_id: j.id)
           end
         end
-        remove_index :stash_engine_journals, :issn
-        remove_column :stash_engine_journals, :issn
+        # remove_index :stash_engine_journals, :issn
+        # remove_column :stash_engine_journals, :issn
       end
       dir.down do
-        add_column :stash_engine_journals, :issn, :string
+        # add_column :stash_engine_journals, :issn, :string
+        # add_index :stash_engine_journals, :issn
         StashEngine::Journal.find_each do |j|
           j.update(issn: j.issns.map(&:id).to_json)
         end
-        add_index :stash_engine_journals, :issn
       end
     end
   end

--- a/db/migrate/20240619214848_add_dates_table.rb
+++ b/db/migrate/20240619214848_add_dates_table.rb
@@ -1,0 +1,49 @@
+class AddDatesTable < ActiveRecord::Migration[7.0]
+  ALL_IDENTIFIERS = <<-SQL.freeze
+    INSERT IGNORE INTO stash_engine_process_dates (processable_id, processable_type, created_at) SELECT id, 'StashEngine::Identifier', created_at FROM stash_engine_identifiers
+  SQL
+  ALL_RESOURCES = <<-SQL.freeze
+    INSERT IGNORE INTO stash_engine_process_dates (processable_id, processable_type, created_at) SELECT id, 'StashEngine::Resource', created_at FROM stash_engine_resources
+  SQL
+  def change
+    create_table :stash_engine_process_dates do |t|
+      t.integer :processable_id
+      t.string :processable_type
+      t.datetime :processing
+      t.datetime :peer_review
+      t.datetime :submitted
+      t.datetime :curation_start
+      t.datetime :curation_end
+      t.datetime :approved
+      t.datetime :withdrawn
+      t.timestamps
+    end
+    add_index :stash_engine_process_dates, [:processable_id, :processable_type], unique: true, name: 
+    'index_process_dates_on_processable_id_and_type'
+    reversible do |dir|
+      dir.up do
+        execute ALL_IDENTIFIERS
+        execute ALL_RESOURCES
+        StashEngine::Identifier.joins(:latest_resource).find_each do |identifier|
+          identifier.resources.each do |resource|
+            dates = {}
+            status_changes = resource.curation_activities.pluck(:status, :created_at).uniq(&:first)
+            status_changes.each_with_index do |c, i|
+              dates[c.first.to_sym] = c.last if ['processing', 'peer_review', 'submitted', 'withdrawn'].include?(c.first)
+              dates[:curation_start] = c.last if c.first == 'curation'
+              dates[:curation_end] = c.last if status_changes[i - 1].first == 'curation'
+              dates[:approved] = c.last if ['embargoed', 'published'].include?(c.first) 
+            end
+            resource.process_date.update(dates)
+            id_dates = dates.delete_if { |k, _v| identifier.process_date.send(k).present? }
+            unless id_dates.empty?
+              identifier.process_date.update(id_dates)
+              identifier.reload
+            end
+          end
+        end
+      end
+      dir.down do; end
+    end
+  end
+end

--- a/lib/stash/import/crossref.rb
+++ b/lib/stash/import/crossref.rb
@@ -200,7 +200,7 @@ module Stash
         def title_author_query_params(resource)
           return [nil, nil, nil] unless resource.present?
 
-          issn = resource.identifier.internal_data.where(data_type: 'publicationISSN').first&.value
+          issn = resource.identifier&.publication_issn
           issn = CGI.escape(issn) if issn.present?
           title_query = resource.title&.gsub(/\s+/, ' ')&.strip
           title_query = CGI.escape(title_query)&.gsub(/\s/, '+') if title_query.present?

--- a/lib/tasks/migration.rake
+++ b/lib/tasks/migration.rake
@@ -44,7 +44,7 @@ namespace :dryad_migration do
       # is the primary ISSN. We don't want to use a secondary ISSN if it was
       # present in the input file.
       j = StashEngine::Journal.find_or_create_by(issn: pr['issn'])
-      puts "migrating journal #{j.id} -- #{j.issn} -- #{pr['fullName']}"
+      puts "migrating journal #{j.id} -- #{j.single_issn} -- #{pr['fullName']}"
 
       j.update(title: pr['fullName'],
                issn: pr['issn'],

--- a/spec/factories/stash_engine/internal_data.rb
+++ b/spec/factories/stash_engine/internal_data.rb
@@ -11,6 +11,7 @@
 #
 # Indexes
 #
+#  index_internal_data_on_identifier_and_data_type          (identifier_id,data_type)
 #  index_stash_engine_internal_data_on_data_type_and_value  (data_type,value)
 #  index_stash_engine_internal_data_on_identifier_id        (identifier_id)
 #

--- a/spec/factories/stash_engine/internal_data.rb
+++ b/spec/factories/stash_engine/internal_data.rb
@@ -18,7 +18,7 @@ FactoryBot.define do
 
   factory :internal_datum, class: StashEngine::InternalDatum do
     identifier_id { Faker::Number.number(digits: 3).to_i }
-    data_type { 'publicationISSN' }
-    value { "#{Faker::Number.number(digits: 4)}-#{Faker::Number.number(digits: 4)}" }
+    data_type { 'publicationName' }
+    value { Faker::Company.industry }
   end
 end

--- a/spec/factories/stash_engine/journal_issn.rb
+++ b/spec/factories/stash_engine/journal_issn.rb
@@ -1,0 +1,9 @@
+FactoryBot.define do
+
+  factory :journal_issn, class: StashEngine::JournalIssn do
+
+    id { "#{Faker::Number.number(digits: 4)}-#{Faker::Number.number(digits: 4)}" }
+
+  end
+
+end

--- a/spec/factories/stash_engine/journals.rb
+++ b/spec/factories/stash_engine/journals.rb
@@ -30,14 +30,27 @@
 FactoryBot.define do
 
   factory :journal, class: StashEngine::Journal do
+    transient do
+      issn { nil }
+    end
 
     title { Faker::Company.industry }
-    issn do
-      ["#{Faker::Number.number(digits: 4)}-#{Faker::Number.number(digits: 4)}",
-       "#{Faker::Number.number(digits: 4)}-#{Faker::Number.number(digits: 4)}"]
-    end
     journal_code { Faker::Name.initials(number: 4) }
     sponsor_id { nil }
+
+    after(:create) do |journal, e|
+      if e.issn.present?
+        if e.issn.is_a?(Array)
+          e.issn.each { |id| create(:journal_issn, journal_id: journal.id, id: id) }
+        else
+          create(:journal_issn, journal_id: journal.id, id: e.issn)
+        end
+      else
+        create(:journal_issn, journal_id: journal.id)
+      end
+      journal.reload
+    end
+
   end
 
 end

--- a/spec/factories/stash_engine/journals.rb
+++ b/spec/factories/stash_engine/journals.rb
@@ -8,7 +8,6 @@
 #  allow_review_workflow   :boolean
 #  default_to_ppr          :boolean          default(FALSE)
 #  description             :text(65535)
-#  issn                    :string(191)
 #  journal_code            :string(191)
 #  manuscript_number_regex :string(191)
 #  notify_contacts         :text(65535)
@@ -24,7 +23,6 @@
 #
 # Indexes
 #
-#  index_stash_engine_journals_on_issn   (issn)
 #  index_stash_engine_journals_on_title  (title)
 #
 FactoryBot.define do

--- a/spec/features/stash_engine/journal_admin_spec.rb
+++ b/spec/features/stash_engine/journal_admin_spec.rb
@@ -28,12 +28,12 @@ RSpec.feature 'JournalAdmin', type: :feature do
         find('.c-admin-edit-icon').click
       end
       within(:css, '#genericModalDialog') do
-        find('#issn').set('1A1A-Y2Y2')
+        find('#issn').set('1111-2222')
         find('input[name=commit]').click
       end
-      expect(page.find("#issn_#{@journal.id}")).to have_text('1A1A-Y2Y2')
+      expect(page.find("#issn_#{@journal.id}")).to have_text('1111-2222')
       changed = StashEngine::Journal.find(@journal.id)
-      expect(changed.issn_array).to include('1A1A-Y2Y2')
+      expect(changed.issn_array).to include('1111-2222')
     end
 
     it 'allows changing notify contacts as a superuser', js: true do

--- a/spec/lib/stash_datacite/crossref_spec.rb
+++ b/spec/lib/stash_datacite/crossref_spec.rb
@@ -439,7 +439,7 @@ module Stash
 
         before(:each) do
           identifier = StashEngine::Identifier.create(identifier: 'ABCD')
-          identifier.internal_data << StashEngine::InternalDatum.new(data_type: 'publicationISSN', value: '123-456')
+          identifier.internal_data << StashEngine::InternalDatum.new(data_type: 'publicationISSN', value: '1234-5678')
           identifier.save
           @resource = StashEngine::Resource.create(title: ' Testing  Again\\', identifier: identifier)
           @resource.authors = [
@@ -586,7 +586,7 @@ module Stash
 
           it 'returns an array containing the [ISSN, TITLE, AUTHOR LAST NAMES]' do
             issn, title_query, author_query = Crossref.send(:title_author_query_params, @resource)
-            expect(issn).to eql('123-456')
+            expect(issn).to eql('1234-5678')
             expect(title_query).to eql('Testing+Again%5C')
             expect(author_query).to eql('Doe+Van-jones')
           end

--- a/spec/models/stash_engine/curation_activity_spec.rb
+++ b/spec/models/stash_engine/curation_activity_spec.rb
@@ -137,7 +137,7 @@ module StashEngine
       end
     end
 
-    describe '#latest_curation_status_changed?' do
+    describe '#curation_status_changed?' do
 
       before(:each) do
         @user = create(:user)
@@ -148,20 +148,20 @@ module StashEngine
       it 'considers things changed if there is only one curation status for this resource' do
         StashEngine::CurationActivity.destroy_all
         @curation_activity = create(:curation_activity, resource: @resource)
-        expect(@curation_activity.latest_curation_status_changed?).to be true
+        expect(@curation_activity.curation_status_changed?).to be true
       end
 
       it 'considers changed to be true if the last two curation statuses are unequal' do
         @curation_activity1 = create(:curation_activity, status: 'in_progress', resource: @resource)
         @curation_activity2 = create(:curation_activity, status: 'embargoed', resource: @resource)
-        expect(@curation_activity2.latest_curation_status_changed?).to be true
+        expect(@curation_activity2.curation_status_changed?).to be true
       end
 
       it 'considers changed to be false if the last two curation statuses are equal' do
         @curation_activity1 = create(:curation_activity, status: :embargoed, resource: @resource)
         @curation_activity2 = create(:curation_activity, status: :embargoed, resource: @resource,
                                                          note: 'We need more about cats')
-        expect(@curation_activity2.latest_curation_status_changed?).to be false
+        expect(@curation_activity2.curation_status_changed?).to be false
       end
     end
 

--- a/spec/models/stash_engine/identifier_spec.rb
+++ b/spec/models/stash_engine/identifier_spec.rb
@@ -64,7 +64,7 @@ module StashEngine
         allow_any_instance_of(StashEngine::CurationActivity).to receive(:copy_to_zenodo).and_return(true)
       end
 
-      @fake_issn = 'bogus-issn-value'
+      @fake_issn = '1234-000X'
       @int_datum_issn = InternalDatum.new(identifier_id: @identifier.id, data_type: 'publicationISSN', value: @fake_issn)
       @int_datum_issn.save!
       @fake_manuscript_number = 'bogus-manuscript-number'
@@ -358,7 +358,7 @@ module StashEngine
 
           it 'returns the latest non-published for an admin from journal' do
             user2 = create(:user, tenant_id: 'localhost')
-            journal = Journal.create(title: 'Test Journal', issn: @fake_issn)
+            journal = create(:journal, title: 'Test Journal', issn: @fake_issn)
             create(:role, role_object: journal, user: user2, role: 'admin')
             user2.reload
             InternalDatum.create(identifier_id: @identifier.id, data_type: 'publicationISSN', value: @fake_issn)
@@ -445,7 +445,7 @@ module StashEngine
       end
 
       it 'returns false if journal will pay' do
-        Journal.create(issn: @fake_issn, payment_plan_type: 'SUBSCRIPTION')
+        create(:journal, issn: @fake_issn, payment_plan_type: 'SUBSCRIPTION')
         expect(@identifier.user_must_pay?).to eq(false)
       end
 
@@ -463,16 +463,17 @@ module StashEngine
       end
 
       it 'records a journal payment' do
-        Journal.create(issn: @fake_issn, payment_plan_type: 'SUBSCRIPTION')
+        create(:journal, issn: @fake_issn, payment_plan_type: 'SUBSCRIPTION')
         @identifier.record_payment
         expect(@identifier.payment_type).to match(/journal/)
       end
 
       it 'replaces a journal payment when the associated journal has changed' do
-        Journal.create(issn: @fake_issn, payment_plan_type: 'SUBSCRIPTION')
+        create(:journal, issn: @fake_issn, payment_plan_type: 'SUBSCRIPTION')
         @identifier.record_payment
         expect(@identifier.payment_type).to match(/journal/)
-        @int_datum_issn.update(value: 'not the journal issn')
+        @int_datum_issn.update(value: '0000-0000')
+        @identifier.reload
         @identifier.record_payment
         expect(@identifier.payment_type).to match(/unknown/)
       end
@@ -550,7 +551,7 @@ module StashEngine
     describe '#journal' do
       it 'retrieves the associated journal' do
         @bogus_title = 'Some Bogus Title'
-        Journal.create(issn: @fake_issn, title: @bogus_title)
+        create(:journal, issn: @fake_issn, title: @bogus_title)
         expect(@identifier.journal.title).to eq(@bogus_title)
       end
 
@@ -559,12 +560,12 @@ module StashEngine
       end
 
       it 'allows review when the journal allows review' do
-        Journal.create(issn: @fake_issn, allow_review_workflow: true)
+        create(:journal, issn: @fake_issn, allow_review_workflow: true)
         expect(@identifier.allow_review?).to be(true)
       end
 
       it 'disallows review when the journal disallows review' do
-        Journal.create(issn: @fake_issn, allow_review_workflow: false)
+        create(:journal, issn: @fake_issn, allow_review_workflow: false)
         expect(@identifier.allow_review?).to be(false)
       end
 
@@ -574,7 +575,7 @@ module StashEngine
       end
 
       it 'allows review when the curation status is review, regardless of journal settings' do
-        Journal.create(issn: @fake_issn, allow_review_workflow: false)
+        create(:journal, issn: @fake_issn, allow_review_workflow: false)
         allow_any_instance_of(Resource).to receive(:current_curation_status).and_return('peer_review')
         expect(@identifier.allow_review?).to be(true)
       end
@@ -584,7 +585,7 @@ module StashEngine
       end
 
       it 'allows blackout when the journal allows blackout' do
-        Journal.create(issn: @fake_issn, allow_blackout: true)
+        create(:journal, issn: @fake_issn, allow_blackout: true)
         expect(@identifier.allow_blackout?).to be(true)
       end
     end

--- a/spec/models/stash_engine/internal_datum_spec.rb
+++ b/spec/models/stash_engine/internal_datum_spec.rb
@@ -11,6 +11,7 @@
 #
 # Indexes
 #
+#  index_internal_data_on_identifier_and_data_type          (identifier_id,data_type)
 #  index_stash_engine_internal_data_on_data_type_and_value  (data_type,value)
 #  index_stash_engine_internal_data_on_identifier_id        (identifier_id)
 #

--- a/spec/models/stash_engine/journal_spec.rb
+++ b/spec/models/stash_engine/journal_spec.rb
@@ -8,7 +8,6 @@
 #  allow_review_workflow   :boolean
 #  default_to_ppr          :boolean          default(FALSE)
 #  description             :text(65535)
-#  issn                    :string(191)
 #  journal_code            :string(191)
 #  manuscript_number_regex :string(191)
 #  notify_contacts         :text(65535)
@@ -24,7 +23,6 @@
 #
 # Indexes
 #
-#  index_stash_engine_journals_on_issn   (issn)
 #  index_stash_engine_journals_on_title  (title)
 #
 require 'rails_helper'

--- a/spec/models/stash_engine/journal_spec.rb
+++ b/spec/models/stash_engine/journal_spec.rb
@@ -70,10 +70,10 @@ module StashEngine
         @issn2 = "#{Faker::Number.number(digits: 4)}-#{Faker::Number.number(digits: 4)}"
         @issn3 = "#{Faker::Number.number(digits: 4)}-#{Faker::Number.number(digits: 4)}"
         @issn_distractor = "#{Faker::Number.number(digits: 4)}-#{Faker::Number.number(digits: 4)}"
+        @journal = create(:journal, issn: @issn1)
       end
 
       it 'finds by issn' do
-        @journal.update(issn: @issn1)
         j = StashEngine::Journal.find_by_issn(@issn1)
         expect(j).to eq(@journal)
 
@@ -88,7 +88,8 @@ module StashEngine
       end
 
       it 'finds by issn when there are multiples' do
-        @journal.update(issn: [@issn1, @issn2, @issn3])
+        [@issn2, @issn3].each { |id| create(:journal_issn, journal: @journal, id: id) }
+        @journal.reload
         j = StashEngine::Journal.find_by_issn(@issn1)
         expect(j).to eq(@journal)
         j = StashEngine::Journal.find_by_issn(@issn2)
@@ -100,25 +101,31 @@ module StashEngine
       end
 
       it 'gets single_issn' do
-        @journal.update(issn: @issn1)
         expect(@journal.single_issn).to eq(@issn1)
 
-        @journal.update(issn: [@issn2, @issn3])
+        @journal.issns.destroy_all
+        create(:journal_issn, journal: @journal, id: @issn2)
+        create(:journal_issn, journal: @journal, id: @issn3)
+        @journal.reload
         expect(@journal.single_issn).to eq(@issn2)
 
-        @journal.update(issn: nil)
+        @journal.issns.destroy_all
+        @journal.reload
         expect(@journal.single_issn).to be(nil)
       end
 
       it 'gets issn_array' do
-        @journal.update(issn: @issn1)
         expect(@journal.issn_array).to eq([@issn1])
 
-        @journal.update(issn: [@issn2, @issn3])
+        @journal.issns.destroy_all
+        create(:journal_issn, journal: @journal, id: @issn2)
+        create(:journal_issn, journal: @journal, id: @issn3)
+        @journal.reload
         expect(@journal.issn_array).to eq([@issn2, @issn3])
 
-        @journal.update(issn: nil)
-        expect(@journal.issn_array).to be(nil)
+        @journal.issns.destroy_all
+        @journal.reload
+        expect(@journal.issn_array).to be_empty
       end
     end
 

--- a/spec/models/stash_engine/resources_spec.rb
+++ b/spec/models/stash_engine/resources_spec.rb
@@ -214,7 +214,7 @@ module StashEngine
       end
 
       it 'returns true if admin for same journal' do
-        journal = Journal.create(title: 'Test Journal', issn: '1234-4321')
+        journal = create(:journal, title: 'Test Journal', issn: '1234-4321')
         identifier = Identifier.create(identifier: 'cat/dog', identifier_type: 'DOI')
         InternalDatum.create(identifier_id: identifier.id, data_type: 'publicationISSN', value: journal.single_issn)
         resource = Resource.create(user_id: @user.id + 1, tenant_id: 'ucop', identifier_id: identifier.id)
@@ -224,7 +224,7 @@ module StashEngine
       end
 
       it 'returns true if admin for a journal, and the item has no journal set' do
-        journal = Journal.create(title: 'Test Journal', issn: '1234-4321')
+        journal = create(:journal, title: 'Test Journal', issn: '1234-4321')
         identifier = Identifier.create(identifier: 'cat/dog', identifier_type: 'DOI')
         resource = Resource.create(user_id: @user.id + 1, tenant_id: 'ucop', identifier_id: identifier.id)
         create(:role, role_object: journal, user: @user, role: 'admin')
@@ -444,7 +444,7 @@ module StashEngine
       end
 
       it 'returns true if being viewed by a journal admin' do
-        journal = Journal.create(title: 'Test Journal', issn: '1234-4321')
+        journal = create(:journal, title: 'Test Journal', issn: '1234-4321')
         identifier = Identifier.create(identifier: 'cat/dog', identifier_type: 'DOI')
         identifier.update(pub_state: 'unpublished')
         InternalDatum.create(identifier_id: identifier.id, data_type: 'publicationISSN', value: journal.single_issn)
@@ -1549,7 +1549,7 @@ module StashEngine
           end
 
           it 'shows all resources to an admin for this journal' do
-            journal = Journal.create(title: 'Test Journal', issn: '1234-4321')
+            journal = create(:journal, title: 'Test Journal', issn: '1234-4321')
             InternalDatum.create(identifier_id: @identifier.id, data_type: 'publicationISSN', value: journal.single_issn)
             create(:role, role_object: journal, user: @user2, role: 'admin')
             resources = StashEngine::ResourcePolicy::VersionScope.new(@user2, @identifier.resources).resolve

--- a/spec/models/stash_engine/resources_spec.rb
+++ b/spec/models/stash_engine/resources_spec.rb
@@ -1407,14 +1407,15 @@ module StashEngine
           res = create(:resource, user_id: @user.id, tenant_id: @user.tenant_id)
           create(:curation_activity_no_callbacks, resource: res, created_at: '2020-01-01', status: 'in_progress')
           create(:curation_activity_no_callbacks, resource: res, created_at: '2020-01-02', status: 'submitted')
-          create(:curation_activity_no_callbacks, resource: res, created_at: '2020-01-03', status: 'submitted')
+          create(:curation_activity_no_callbacks, resource: res, created_at: '2020-01-03', status: 'curation')
           create(:curation_activity_no_callbacks, resource: res, created_at: '2020-01-04', status: 'published')
           expect(res.submitted_date.to_date).to eql(Date.parse('2020-01-02'))
-          expect(res.curation_start_date.to_date).to eql(Date.parse('2020-01-02'))
+          expect(res.curation_start_date.to_date).to eql(Date.parse('2020-01-03'))
         end
 
         it 'returns the correct dates when an item went straight from peer_review to curation' do
           res = create(:resource, user_id: @user.id, tenant_id: @user.tenant_id)
+          p res.id
           create(:curation_activity_no_callbacks, resource: res, created_at: '2020-01-01', status: 'in_progress')
           create(:curation_activity_no_callbacks, resource: res, created_at: '2020-01-02', status: 'peer_review')
           create(:curation_activity_no_callbacks, resource: res, created_at: '2020-01-03', status: 'curation')
@@ -1427,6 +1428,16 @@ module StashEngine
           res = create(:resource, user_id: @user.id, tenant_id: @user.tenant_id)
           create(:curation_activity_no_callbacks, resource: res, created_at: '2020-01-01', status: 'in_progress')
           expect(res.submitted_date).to be_nil
+          expect(res.curation_start_date).to be_nil
+        end
+
+        it 'returns no curation date without curation' do
+          res = create(:resource, user_id: @user.id, tenant_id: @user.tenant_id)
+          create(:curation_activity_no_callbacks, resource: res, created_at: '2020-01-01', status: 'in_progress')
+          create(:curation_activity_no_callbacks, resource: res, created_at: '2020-01-02', status: 'submitted')
+          create(:curation_activity_no_callbacks, resource: res, created_at: '2020-01-03', status: 'submitted')
+          create(:curation_activity_no_callbacks, resource: res, created_at: '2020-01-04', status: 'published')
+          expect(res.submitted_date.to_date).to eql(Date.parse('2020-01-02'))
           expect(res.curation_start_date).to be_nil
         end
       end

--- a/spec/requests/stash_api/datasets_controller_spec.rb
+++ b/spec/requests/stash_api/datasets_controller_spec.rb
@@ -924,6 +924,7 @@ module StashApi
                                   'Content-Type' =>  'application/json-patch+json', 'Authorization' => "Bearer #{@access_token}"
                                 )
           expect(response_code).to eq(200)
+          @identifier.reload
           expect(@identifier.publication_issn).to eq(issn_target)
           expect(@identifier.publication_name).to eq(journal.title)
         end
@@ -940,6 +941,7 @@ module StashApi
                                 headers: default_json_headers.merge(
                                   'Content-Type' =>  'application/json-patch+json', 'Authorization' => "Bearer #{@access_token}"
                                 )
+          @identifier.reload
           expect(response_code).to eq(200)
           expect(@identifier.publication_issn).to eq(nil)
         end


### PR DESCRIPTION
Through careful changing of how and when (and what kind of) joins are loaded, I've been able to increase the speed of queries for this page dramatically (on dev).

In addition to the changes directly to the page, I've created migrations & changes for new tables which should expand our ability to use associations instead of complicated query calculations or methods generally—the dates table should make it much easier to calculate curation stats, though I am waiting until the reporting and stats decisions are made to make those changes.