### PR TITLE
updated Github raw URLs regex and original_url handling

### DIFF
--- a/Gemfile
+++ b/Gemfile
@@ -58,6 +58,7 @@ gem 'concurrent-ruby', '~> 1.1.10'
 gem 'daemons', '~> 1.4.1'
 gem 'database_cleaner', '~> 2.0.1'
 gem 'datacite-mapping', git: 'https://github.com/CDLUC3/datacite-mapping.git'
+gem 'data_migrate'
 gem 'delayed_job_active_record', '~> 4.1.7'
 gem 'devise', '~> 4.8.0' # I don't believe we are using it directly
 gem 'devise-guests', '~> 0.6' # I don't believe we're using it directly

--- a/Gemfile.lock
+++ b/Gemfile.lock
@@ -189,6 +189,9 @@ GEM
       rexml
     crass (1.0.6)
     daemons (1.4.1)
+    data_migrate (9.4.0)
+      activerecord (>= 6.1)
+      railties (>= 6.1)
     database_cleaner (2.0.2)
       database_cleaner-active_record (>= 2, < 3)
     database_cleaner-active_record (2.1.0)
@@ -829,6 +832,7 @@ DEPENDENCIES
   colorize
   concurrent-ruby (~> 1.1.10)
   daemons (~> 1.4.1)
+  data_migrate
   database_cleaner (~> 2.0.1)
   datacite-mapping!
   delayed_job_active_record (~> 4.1.7)

--- a/app/models/stash_api/dataset_parser.rb
+++ b/app/models/stash_api/dataset_parser.rb
@@ -86,8 +86,10 @@ module StashApi
       if owning_user.nil?
         # check if any authors listed in the dataset have this orcid
         found_author = nil
-        @hash['authors'].each do |a|
-          found_author = a if a['orcid']&.match(@hash['userId'])
+        if @hash['authors']
+          @hash['authors'].each do |a|
+            found_author = a if a['orcid']&.match(@hash['userId'])
+          end
         end
         unless found_author
           raise ActionController::BadRequest,

--- a/app/models/stash_engine/url_validator.rb
+++ b/app/models/stash_engine/url_validator.rb
@@ -71,7 +71,7 @@ module StashEngine
         resource_id: resource.id, url: url,
         status_code: status_code,
         file_state: 'created',
-        original_url: (translator.direct_download.nil? ? nil : @url),
+        original_url: translator.original_url,
         cloud_service: translator.service
       }
       return upload_attributes unless valid && status_code == 200

--- a/db/data/20240624115611_fix_existing_github_file_urls.rb
+++ b/db/data/20240624115611_fix_existing_github_file_urls.rb
@@ -1,0 +1,21 @@
+# frozen_string_literal: true
+
+class FixExistingGithubFileUrls < ActiveRecord::Migration[7.0]
+  def up
+    files = StashEngine::GenericFile.where("url like '%https://github.com%'")
+    puts "Updating #{files.count} files"
+
+    files.each do |file|
+      print '.'
+      translator = Stash::UrlTranslator.new(file.url)
+      file.update_columns(original_url: file.url, url: translator.direct_download || file.url)
+    end
+
+    puts ''
+    puts 'Finished'
+  end
+
+  def down
+    raise ActiveRecord::IrreversibleMigration
+  end
+end

--- a/db/data_schema.rb
+++ b/db/data_schema.rb
@@ -1,0 +1,1 @@
+DataMigrate::Data.define(version: 20240624115611)

--- a/lib/stash/url_translator.rb
+++ b/lib/stash/url_translator.rb
@@ -17,7 +17,7 @@ module Stash
     GOOGLE_SHEET = %r{^https://docs\.google\.com/spreadsheets/d/(\S+)/edit(?:\?usp=sharing)?$}
     DROPBOX = %r{^https://www\.dropbox\.com/s/(\S+)/([^/]+)(?:\?dl=[0-9]+)$}
     BOX = %r{^https://([^/]+box\.com)/s/(\S+)$}
-    GITHUB = %r{^https?://github.com/([^/]+/[^/]+)/blob(/[^/]+/[^/]+)$}
+    GITHUB = %r{^https?://github.com/([^/]+/[^/]+)/blob(.+)$}
 
     attr_reader :service, :direct_download, :original_url
 

--- a/lib/tasks/stash_engine_tasks.rake
+++ b/lib/tasks/stash_engine_tasks.rake
@@ -1389,5 +1389,23 @@ namespace :journal_email do
   end
 end
 
+namespace :generic_files do
+  desc 'Set Github download and original URLs that were not already converted to raw files'
+  task fix_github_urls: :environment do
+    Rails.logger.level = Logger::INFO
+    files = StashEngine::GenericFile.where("url like '%https://github.com%'")
+    puts "Updating #{files.count} files"
+
+    files.each do |file|
+      print '.'
+      translator = Stash::UrlTranslator.new(file.url)
+      file.update_columns(original_url: file.url, url: translator.direct_download || file.url)
+    end
+
+    puts ''
+    puts 'Finished'
+  end
+end
+
 # rubocop:enable Metrics/BlockLength
 # :nocov:

--- a/lib/tasks/stash_engine_tasks.rake
+++ b/lib/tasks/stash_engine_tasks.rake
@@ -1389,23 +1389,5 @@ namespace :journal_email do
   end
 end
 
-namespace :generic_files do
-  desc 'Set Github download and original URLs that were not already converted to raw files'
-  task fix_github_urls: :environment do
-    Rails.logger.level = Logger::INFO
-    files = StashEngine::GenericFile.where("url like '%https://github.com%'")
-    puts "Updating #{files.count} files"
-
-    files.each do |file|
-      print '.'
-      translator = Stash::UrlTranslator.new(file.url)
-      file.update_columns(original_url: file.url, url: translator.direct_download || file.url)
-    end
-
-    puts ''
-    puts 'Finished'
-  end
-end
-
 # rubocop:enable Metrics/BlockLength
 # :nocov:

--- a/spec/mocks/url_upload.rb
+++ b/spec/mocks/url_upload.rb
@@ -17,6 +17,22 @@ module Mocks
                    })
     end
 
+    def mock_github_blob_head_request!
+      stub_request(:head, 'https://raw.githubusercontent.com/tracykteal/chicken-naming/master/chicken-naming.ipynb')
+        .with(
+          headers: {
+            'Accept' => '*/*'
+          }
+        )
+        .to_return(status: 200, body: '', headers: {
+          'ETag' => 'e422b2e5bec8dddc1d2b99fd9908b6c8d074f5a270b41b589468a90bf13daabf',
+          'Content-Type' => 'text/plain',
+          'Cache-Control' => 'max-age=300',
+          'Content-Length' => 5373,
+          'Accept-Ranges' => 'bytes'
+        })
+    end
+
     def mock_github_bad_head_request!
       stub_request(:head, 'http://github.com/datadryad/dryad-app/raw/main/app/assets/images/favicon.ico')
         .with(

--- a/spec/mocks/url_upload.rb
+++ b/spec/mocks/url_upload.rb
@@ -25,12 +25,12 @@ module Mocks
           }
         )
         .to_return(status: 200, body: '', headers: {
-          'ETag' => 'e422b2e5bec8dddc1d2b99fd9908b6c8d074f5a270b41b589468a90bf13daabf',
-          'Content-Type' => 'text/plain',
-          'Cache-Control' => 'max-age=300',
-          'Content-Length' => 5373,
-          'Accept-Ranges' => 'bytes'
-        })
+                     'ETag' => 'e422b2e5bec8dddc1d2b99fd9908b6c8d074f5a270b41b589468a90bf13daabf',
+                     'Content-Type' => 'text/plain',
+                     'Cache-Control' => 'max-age=300',
+                     'Content-Length' => 5373,
+                     'Accept-Ranges' => 'bytes'
+                   })
     end
 
     def mock_github_bad_head_request!

--- a/spec/models/stash/url_translator_spec.rb
+++ b/spec/models/stash/url_translator_spec.rb
@@ -53,6 +53,7 @@ module Stash
     it 'sets things correctly for special github software blob urls' do
       translator = Stash::UrlTranslator.new('https://github.com/tracykteal/chicken-naming/blob/master/chicken-naming.ipynb')
       expect(translator.service).to eql('github')
+      expect(translator.original_url).to eql('https://github.com/tracykteal/chicken-naming/blob/master/chicken-naming.ipynb')
       expect(translator.direct_download).to eql('https://raw.githubusercontent.com/tracykteal/chicken-naming/master/chicken-naming.ipynb')
     end
   end

--- a/spec/requests/stash_api/urls_controller_spec.rb
+++ b/spec/requests/stash_api/urls_controller_spec.rb
@@ -146,8 +146,7 @@ module StashApi
         expect(response_body_hash.key?('error')).to eq(true)
       end
 
-
-      it "correctly sets original url and raw url for Github link" do
+      it 'correctly sets original url and raw url for Github link' do
         mock_github_blob_head_request!
         test_url = 'https://github.com/tracykteal/chicken-naming/blob/master/chicken-naming.ipynb'
         response_code = post "/api/v2/datasets/#{CGI.escape(@identifier.to_s)}/urls",

--- a/spec/requests/stash_api/urls_controller_spec.rb
+++ b/spec/requests/stash_api/urls_controller_spec.rb
@@ -145,6 +145,23 @@ module StashApi
         expect(response_code).to eq(403)
         expect(response_body_hash.key?('error')).to eq(true)
       end
+
+
+      it "correctly sets original url and raw url for Github link" do
+        mock_github_blob_head_request!
+        test_url = 'https://github.com/tracykteal/chicken-naming/blob/master/chicken-naming.ipynb'
+        response_code = post "/api/v2/datasets/#{CGI.escape(@identifier.to_s)}/urls",
+                             params: { url: test_url }.to_json,
+                             headers: default_authenticated_headers
+
+        expect(response_code).to eq(201)
+        hash = response_body_hash
+        expect(hash['path']).to eq('chicken-naming.ipynb')
+        expect(hash['url']).to eq('https://raw.githubusercontent.com/tracykteal/chicken-naming/master/chicken-naming.ipynb')
+        expect(hash['size']).to eq(5373)
+        expect(hash['mimeType']).to eq('text/plain')
+        expect(hash['status']).to eq('created')
+      end
     end
   end
 end


### PR DESCRIPTION
closes https://github.com/datadryad/dryad-product-roadmap/issues/3260

- [ ] Any URL upload errors ("Crawling of HTML files isn't supported.") that do not allow URL uploads in the front end should also apply to the API.
- The URL translator should work correctly & match these github file URLs.
  - [ ] The raw version of the URL should be in the url column, while the original should be moved to original_url
  - [ ] The correct file size, matching the file on github should be recorded in the database