### PR TITLE
Fix database backup process

### DIFF
--- a/lib/tasks/dev_ops.rake
+++ b/lib/tasks/dev_ops.rake
@@ -96,7 +96,7 @@ namespace :dev_ops do
     FileUtils.mkdir_p directory
     # YAML.safe_load is preferred by rubocop but it causes the read to fail on `unknown alias 'defaul'`
     # rubocop:disable Security/YAMLLoad
-    db = YAML.load(ERB.new(File.read(File.join(Rails.root, 'config', 'database.yml'))).result)[Rails.env]
+    db = YAML.load(ERB.new(File.read(File.join(Rails.root, 'config', 'database.yml'))).result, aliases: true)[Rails.env]
     # rubocop:enable Security/YAMLLoad
     file = File.join(directory, "#{Rails.env}_#{Time.now.strftime('%H_%M')}.sql")
     p command = 'mysqldump --opt --skip-add-locks --single-transaction --no-create-db --set-gtid-purged=off ' \


### PR DESCRIPTION
The database backups were failing, because the recent Ruby/Rails upgrade included a "security" feature that wouldn't let us load our own config files. Grrr.

This explicitly tells the YAML.load and its dependent Psych library that it is ok to follow the aliases that we use in the config files.

See [discussion of this issue in the sidekiq project](https://github.com/sidekiq/sidekiq/issues/5140).