### PR TITLE
Add a task to remove abandoned datasets 

### DIFF
--- a/app/models/stash_engine/resource.rb
+++ b/app/models/stash_engine/resource.rb
@@ -164,7 +164,7 @@ module StashEngine
       res_count = Resource.where(identifier_id: identifier_id).count
       return if res_count.positive?
 
-      Identifier.destroy(identifier_id)
+      Identifier.destroy(identifier_id) if Identifier.exists?(identifier_id)
     end
 
     def remove_s3_temp_files

--- a/lib/stash/aws/s3.rb
+++ b/lib/stash/aws/s3.rb
@@ -13,6 +13,7 @@ module Stash
 
       attr_reader :s3_bucket
 
+      # By default, use the temporary storage bucket
       def initialize(s3_bucket_name: APP_CONFIG[:s3][:bucket])
         @s3_bucket = s3_resource.bucket(s3_bucket_name)
       end

--- a/lib/tasks/dev_ops.rake
+++ b/lib/tasks/dev_ops.rake
@@ -94,7 +94,7 @@ namespace :dev_ops do
   task backup: :environment do
     directory = '/home/ec2-user/deploy/shared/cron/backups'
     FileUtils.mkdir_p directory
-    # YAML.safe_load is preferred by rubocop but it causes the read to fail on `unknown alias 'defaul'`
+    # YAML.safe_load is preferred by rubocop but it causes the read to fail on `unknown alias 'default'`
     # rubocop:disable Security/YAMLLoad
     db = YAML.load(ERB.new(File.read(File.join(Rails.root, 'config', 'database.yml'))).result)[Rails.env]
     # rubocop:enable Security/YAMLLoad

--- a/lib/tasks/stash_engine_tasks.rake
+++ b/lib/tasks/stash_engine_tasks.rake
@@ -193,7 +193,6 @@ namespace :identifiers do
     end
   end
 
-
   desc 'clean up in_progress versions and temporary files that are disconnected from datasets'
   task remove_old_versions: :environment do
     # This task cleans up garbage versions of datasets, which may have been abandoned, but they may also have been accidentally created

--- a/lib/tasks/stash_engine_tasks.rake
+++ b/lib/tasks/stash_engine_tasks.rake
@@ -191,7 +191,6 @@ namespace :identifiers do
         end
       end
     end
-
   end
 
 

--- a/lib/tasks/stash_engine_tasks.rake
+++ b/lib/tasks/stash_engine_tasks.rake
@@ -140,8 +140,7 @@ namespace :identifiers do
     else
       puts ' ##### remove_abandoned_datasets -- Deleting old versions of datasets that are still in progress'
     end
-    permanent_bucket = APP_CONFIG[:s3][:merritt_bucket]
-    
+        
     StashEngine::Identifier.where(pub_state: [nil, 'withdrawn', 'unpublished']).find_each do |i|
       next if i.date_first_published.present?
       next unless %w[in_progress withdrawn].include?(i.latest_resource&.current_curation_status)
@@ -149,7 +148,7 @@ namespace :identifiers do
       # Double-check whether it was ever published -- even though we checked the date_first_published,
       # some older datasets did not have this date set properly in the internal metadata before they were
       # withdrawn, so we need to be certain.
-      next if i.resources.map(&:curation_activities).flatten.map(&:status).include?("published")
+      next if i.resources.map(&:curation_activities).flatten.map(&:status).include?('published')
       
       # Find the last activity by a "real" user (not the system user)
       last_user_activity = nil
@@ -164,9 +163,9 @@ namespace :identifiers do
         puts "ABANDONED #{i.identifier} -- #{i.id} -- size #{i.latest_resource.size}"
 
         if dry_run
-          puts " -- skipping deletion due to DRY_RUN setting"
+          puts ' -- skipping deletion due to DRY_RUN setting'
         else
-          puts " -- deleting"
+          puts ' -- deleting'
           # Perform the actual removal
           i.resources.each do |r|
             # Delete temp upload directory, if it exists
@@ -174,7 +173,7 @@ namespace :identifiers do
             Stash::Aws::S3.new.delete_dir(s3_key: s3_dir)
             # Delete permanent storage, if it exists
             perm_bucket = Stash::Aws::S3.new(s3_bucket_name: APP_CONFIG[:s3][:merritt_bucket])
-            if r.download_uri.include?("ark%3A%2F")
+            if r.download_uri.include?('ark%3A%2F')
               m = /ark.*/.match(r.download_uri)
               base_path = CGI.unescape(m.to_s)
               merritt_version = r.stash_version.merritt_version
@@ -182,12 +181,12 @@ namespace :identifiers do
               perm_bucket.delete_dir(s3_key: "#{base_path}|#{merritt_version}|system")
               perm_bucket.delete_file(s3_key: "#{base_path}|manifest")
             else
-              perm_bucket.delete_dir(s3_key: "v3/{s3_dir}")
+              perm_bucket.delete_dir(s3_key: "v3/#{s3_dir}")
             end
 
             # Metadata
             # Note that when the last resource is destroyed, the Identifier is automatically destroyed
-            r.destroy 
+            r.destroy
           end
         end
       end

--- a/lib/tasks/stash_engine_tasks.rake
+++ b/lib/tasks/stash_engine_tasks.rake
@@ -140,7 +140,7 @@ namespace :identifiers do
     else
       puts ' ##### remove_abandoned_datasets -- Deleting old versions of datasets that are still in progress'
     end
-        
+
     StashEngine::Identifier.where(pub_state: [nil, 'withdrawn', 'unpublished']).find_each do |i|
       next if i.date_first_published.present?
       next unless %w[in_progress withdrawn].include?(i.latest_resource&.current_curation_status)
@@ -149,7 +149,7 @@ namespace :identifiers do
       # some older datasets did not have this date set properly in the internal metadata before they were
       # withdrawn, so we need to be certain.
       next if i.resources.map(&:curation_activities).flatten.map(&:status).include?('published')
-      
+
       # Find the last activity by a "real" user (not the system user)
       last_user_activity = nil
       i.latest_resource&.curation_activities&.reverse_each do |ca|
@@ -193,7 +193,7 @@ namespace :identifiers do
     end
 
   end
-  
+
 
   desc 'clean up in_progress versions and temporary files that are disconnected from datasets'
   task remove_old_versions: :environment do
@@ -219,7 +219,7 @@ namespace :identifiers do
       puts "   DESTROY resource #{res.id}"
       res.destroy unless dry_run
     end
-    
+
     # Remove directories in AWS temporary storage that have no corresponding resource, or whose resource is already submitted
     s3_prefix = StashEngine::Resource.last.s3_dir_name(type: 'base')
     s3_prefix = if s3_prefix.include?('-')


### PR DESCRIPTION
Closes https://github.com/datadryad/dryad-product-roadmap/issues/3377

Rake task that will remove datasets which have never been published, and do not appear to be heading towards publication. These datasets have been in "in_progress" or "withdrawn" status for over a year with no activity.

