### PR TITLE
Speed up load and display of the My datasets page

### DIFF
--- a/app/controllers/stash_engine/dashboard_controller.rb
+++ b/app/controllers/stash_engine/dashboard_controller.rb
@@ -24,7 +24,7 @@ module StashEngine
       respond_to do |format|
         format.js do
           @datasets = policy_scope(Identifier, policy_scope_class: IdentifierPolicy::DashboardScope).page(@page).per(@page_size)
-          @display_resources = @datasets.map { |dataset| StashDatacite::ResourcesController::DatasetPresenter.new(dataset&.latest_resource) }
+          @datasets = @datasets.preload(latest_resource: %i[last_curation_activity stash_version current_resource_state])
         end
       end
     end

--- a/app/models/stash_engine/identifier.rb
+++ b/app/models/stash_engine/identifier.rb
@@ -114,6 +114,20 @@ module StashEngine
       id
     end
 
+    def identifier_str
+      "#{identifier_type && identifier_type.downcase}:#{identifier}"
+    end
+
+    def identifier_uri
+      raise TypeError, "Unsupported identifier type #{identifier_type}" unless identifier_type == 'DOI'
+
+      "https://doi.org/#{identifier}"
+    end
+
+    def identifier_value
+      identifier
+    end
+
     def view_count
       ResourceUsage.joins(resource: :identifier)
         .where('stash_engine_identifiers.identifier = ? AND stash_engine_identifiers.identifier_type = ?',
@@ -412,12 +426,10 @@ module StashEngine
 
     # overrides reading the pub state so it can set it for caching if it's not set yet
     def pub_state
-      my_state = read_attribute(:pub_state)
-      return my_state unless my_state.nil?
+      return super unless super.blank?
 
-      my_state = calculated_pub_state
-      update_column(:pub_state, my_state) # avoid any callbacks and validations which will only stir up trouble
-      my_state
+      update(pub_state: calculated_pub_state)
+      calculated_pub_state
     end
 
     def embargoed_until_article_appears?

--- a/app/models/stash_engine/resource.rb
+++ b/app/models/stash_engine/resource.rb
@@ -512,26 +512,21 @@ module StashEngine
     # Identifiers
 
     def identifier_str
-      ident = identifier
-      return unless ident
+      return unless identifier
 
-      ident_type = ident.identifier_type
-      ident && "#{ident_type && ident_type.downcase}:#{ident.identifier}"
+      identifier.identifier_str
     end
 
     def identifier_uri
-      ident = identifier
-      return unless ident
+      return unless identifier
 
-      ident_type = ident.identifier_type
-      raise TypeError, "Unsupported identifier type #{ident_type}" unless ident_type == 'DOI'
-
-      "https://doi.org/#{ident.identifier}"
+      identifier.identifier_uri
     end
 
     def identifier_value
-      ident = identifier
-      ident && ident.identifier
+      return unless identifier
+
+      identifier.identifier_value
     end
 
     def ensure_identifier(doi)

--- a/app/policies/stash_engine/identifier_policy.rb
+++ b/app/policies/stash_engine/identifier_policy.rb
@@ -37,7 +37,7 @@ module StashEngine
         @scope
           .joins(latest_resource: :last_curation_activity)
           .where(latest_resource: { user_id: @user&.id })
-          .select("stash_engine_identifiers.*,
+          .select("stash_engine_identifiers.id, identifier, identifier_type, pub_state, latest_resource_id,
             CASE
               WHEN status in ('in_progress', 'action_required') THEN 0
               WHEN status='peer_review' THEN 1
@@ -45,8 +45,7 @@ module StashEngine
               WHEN status='withdrawn' THEN 4
               ELSE 3
             END as sort_order")
-          .order('sort_order ASC')
-          .merge(CurationActivity.order(updated_at: :desc))
+          .order('sort_order asc, latest_resource.updated_at desc')
       end
 
       private

--- a/app/views/stash_engine/dashboard/_user_datasets.html.erb
+++ b/app/views/stash_engine/dashboard/_user_datasets.html.erb
@@ -1,10 +1,10 @@
 <% @datasets.each_with_index do |dataset, i| %>
   <% resource = dataset&.latest_resource %>
-  <% display_r = @display_resources[i]%>
+  <% title = resource.title.blank? ? '[No title supplied]' : resource.title %>
   <% delete_confirm = 'Are you sure you want to remove this dataset'
     if resource&.stash_version.version > 1
       delete_confirm << ' version?'
-      if dataset.date_last_published
+      if dataset.pub_state == 'published'
         delete_confirm << ' The published version will still be available.'
       end
     else
@@ -35,12 +35,12 @@
     <div>
       <p class="c-user-dataset-title">
         <% if resource.submitted? # merritt state %>
-          <%= link_to display_r.title, stash_url_helpers.show_path(display_r.external_identifier) %>
+          <%= link_to title, stash_url_helpers.show_path(dataset.identifier_str) %>
         <% else %>
-          <%= display_r.title %>
+          <%= title %>
         <% end %>
       </p>
-      <p class="c-user-dataset-details"><span>DOI: <%= dataset.identifier %></span><span>Version <%= resource&.stash_version.version%></span><span><%= time_ago_in_words(resource.updated_at, include_seconds: true) %> since last update</span><% if dataset.date_last_published %><span>Published: <%= formatted_date(dataset.date_last_published) %></span><% if dataset.sort_order != 3 %><span class="prev-published"><i class="fa fa-check" aria-hidden="true"></i> Previous version published</span><% end %><% end %></p>
+      <p class="c-user-dataset-details"><span>DOI: <%= dataset.identifier %></span><span>Version <%= resource&.stash_version.version%></span><span><%= time_ago_in_words(resource.updated_at, include_seconds: true) %> since last update</span><% if dataset.pub_state == 'published' %><span>Published: <%= formatted_date(dataset.date_last_published) %></span><% if dataset.sort_order != 3 %><span class="prev-published"><i class="fa fa-check" aria-hidden="true"></i> Previous version published</span><% end %><% end %></p>
     </div>
       <div>
       <div class="c-user-datasets-status">
@@ -58,15 +58,15 @@
         "><%= resource&.last_curation_activity&.readable_status %></span>
         <div class="c-user-datasets-actions">
           <% if resource&.last_curation_activity.status == 'in_progress' %>
-            <% if resource&.dataset_in_progress_editor&.id == current_user&.id %>
+            <% if resource.current_editor_id == current_user&.id %>
               <%= button_to stash_url_helpers.metadata_entry_pages_find_or_create_path(resource_id: resource.id), name: 'resume', form_class: 'o-button__inline-form', class: 'o-button__plain-text7', method: :post do %>
                 Resume <i class="fa fa-pencil" aria-hidden="true"></i>
               <% end %>
               <%= button_to stash_url_helpers.resource_path(resource), method: :delete, data: { confirm: delete_confirm }, name: 'delete', form_class: 'o-button__inline-form', class: 'o-button__plain-text7', title: resource&.stash_version.version > 1 ? 'Revert to previous version' : 'Delete dataset' do %>
                 <%= resource&.stash_version.version > 1 ? 'Revert' : 'Delete' %> <i class="fa fa-trash-can" aria-hidden="true"></i>
               <% end %>
-            <% elsif resource&.dataset_in_progress_editor.present? %>
-              Dataset being edited by <%= resource.dataset_in_progress_editor.name %>
+            <% elsif resource.current_editor_id.present? %>
+              Dataset being edited by <%= resource.editor.name %>
             <% end %>
           <% end %>
           <% if dataset.sort_order == 1 %>
@@ -91,10 +91,10 @@
 <script type="text/javascript">
   (function () {
     window.onpageshow = function(event) {
-        if (event.persisted) {
-            window.location.reload();
-          }
-      };
+      if (event.persisted) {
+          window.location.reload();
+        }
+    };
   })();
   function setLoading(e) {
     var icon = e.target.lastElementChild


### PR DESCRIPTION
The My datasets page uses a lot of slow methods and models unnecessarily and loads a lot of secondary associations for each result in individual SQL commands. This speeds everything up by switching to already loaded models for some checks, removing several instances of circular model loading (loading an association which then reloads the original model), only loading what is needed in the original sql query, and preloading associations to reduce sql queries overall.