### PR TITLE
updated actions/upload-artifact@v3 to v4

### DIFF
--- a/.github/workflows/rspec_features.yml
+++ b/.github/workflows/rspec_features.yml
@@ -63,7 +63,7 @@ jobs:
 
     - name: Archive capybara screenshots
       if: ${{ failure() }}
-      uses: actions/upload-artifact@v3
+      uses: actions/upload-artifact@v4
       with:
         name: capybara-screenshots
         path: tmp/capybara/*

--- a/spec/features/stash_datacite/dataset_versioning_spec.rb
+++ b/spec/features/stash_datacite/dataset_versioning_spec.rb
@@ -45,7 +45,7 @@ RSpec.feature 'DatasetVersioning', type: :feature do
         click_link 'My datasets'
 
         expect(page).to have_text(@resource.title)
-        expect(page).to have_text('In progress')
+        expect(page).not_to have_text('In progress')
       end
     end
 

--- a/spec/features/stash_datacite/dataset_versioning_spec.rb
+++ b/spec/features/stash_datacite/dataset_versioning_spec.rb
@@ -45,7 +45,7 @@ RSpec.feature 'DatasetVersioning', type: :feature do
         click_link 'My datasets'
 
         expect(page).to have_text(@resource.title)
-        expect(page).not_to have_text('In progress')
+        expect(page).to have_text('In progress')
       end
     end
 


### PR DESCRIPTION
Closes: https://github.com/datadryad/dryad-product-roadmap/issues/3433

Node 16 related warning messages appear on github actions - feature testing fails
The reason seems to be `actions/upload-artifact@v3` which is scheduled for deprecation on November 30, 2024