### PR TITLE
fixed rspec exiting from rake tasks specs

### DIFF
--- a/spec/spec_helper.rb
+++ b/spec/spec_helper.rb
@@ -45,6 +45,14 @@ RSpec.configure do |config|
     host! 'my.example.org'
   end
 
+  config.around(:each, type: :task) do |ex|
+    begin
+      ex.run
+    rescue SystemExit => e
+      puts "Got SystemExit: #{e.inspect}. Ignoring"
+    end
+  end
+
   # rspec-expectations config goes here. You can use an alternate
   # assertion/expectation library such as wrong or the stdlib/minitest
   # assertions if you prefer.

--- a/spec/spec_helper.rb
+++ b/spec/spec_helper.rb
@@ -46,11 +46,9 @@ RSpec.configure do |config|
   end
 
   config.around(:each, type: :task) do |ex|
-    begin
-      ex.run
-    rescue SystemExit => e
-      puts "Got SystemExit: #{e.inspect}. Ignoring"
-    end
+    ex.run
+  rescue SystemExit => e
+    puts "Got SystemExit: #{e.inspect}. Ignoring"
   end
 
   # rspec-expectations config goes here. You can use an alternate


### PR DESCRIPTION
Rspec did not run all specs, but random numbers of specs due to `exit` commands in rake tasks. 