### PR TITLE
Fixing all the production bugs

### DIFF
--- a/app/controllers/stash_datacite/publications_controller.rb
+++ b/app/controllers/stash_datacite/publications_controller.rb
@@ -147,15 +147,15 @@ module StashDatacite
         return
       end
       return if params[:publication].blank? # keeps the default fill-in message
-      return if @pub_issn&.value.blank?
-      return if @msid&.value.blank?
+      return if @pub_issn.blank?
+      return if @msid.blank?
 
-      journal = StashEngine::Journal.find_by_issn(@pub_issn.value)
+      journal = StashEngine::Journal.find_by_issn(@pub_issn)
       if journal.blank?
         @error = 'Journal not recognized by Dryad'
         return
       end
-      manu = StashEngine::Manuscript.where(journal: journal, manuscript_number: @msid.value).first
+      manu = StashEngine::Manuscript.where(journal: journal, manuscript_number: @msid).first
       if manu.blank?
         @error = 'We could not find metadata to import for this manuscript.'
         return
@@ -164,7 +164,7 @@ module StashDatacite
       dryad_import = Stash::Import::DryadManuscript.new(resource: @resource, manuscript: manu)
       dryad_import.populate
     rescue HTTParty::Error, SocketError => e
-      logger.error("Dryad manuscript API returned a HTTParty/Socket error for ISSN: #{@pub_issn.value}, MSID: #{@msid.value}\r\n #{e}")
+      logger.error("Dryad manuscript API returned a HTTParty/Socket error for ISSN: #{@pub_issn}, MSID: #{@msid}\r\n #{e}")
       @error = 'We could not find metadata to import for this manuscript.'
     end
 

--- a/app/controllers/stash_engine/journals_controller.rb
+++ b/app/controllers/stash_engine/journals_controller.rb
@@ -6,18 +6,18 @@ module StashEngine
     def index
       params.permit(:q)
       params[:sort] = 'title' if params[:sort].blank?
-      metadata_journal_clause = 'stash_engine_journals.id IN ' \
-                                "(select distinct journal_id from stash_engine_manuscripts where created_at > '#{1.year.ago.iso8601}')"
-      @metadata_journals = Journal.where(metadata_journal_clause).map(&:id)
+      @metadata_journals = Journal.joins(:manuscripts).where("stash_engine_manuscripts.created_at > '#{1.year.ago.iso8601}'").distinct.map(&:id)
       @api_journals = StashEngine::User.joins('inner join oauth_applications on owner_id = stash_engine_users.id')
-        .joins(:roles).where(roles: { role_object_type: ['StashEngine::Journal', 'StashEngine::JournalOrganization'] })
-        .distinct.map(&:journals_as_admin).flatten.uniq.map(&:id)
+        .joins(
+          "inner join stash_engine_roles on stash_engine_users.id = stash_engine_roles.user_id
+          and role_object_type in ('StashEngine::Journal', 'StashEngine::JournalOrganization')"
+        ).distinct.map(&:journals_as_admin).flatten.uniq.map(&:id)
       sponsoring_journals = Journal.where.not(payment_plan_type: [nil, '']).map(&:id)
       display_journals = @metadata_journals | sponsoring_journals | @api_journals
 
       ord = helpers.sortable_table_order(whitelist: %w[title issn allow_blackout payment_plan_type name parent_org_id sponsor_id default_to_ppr])
-      @journals = Journal.left_outer_joins(:sponsor).where(id: display_journals)
-        .order(ord, title: :asc).preload(:issns).preload(:manuscripts).preload(:sponsor)
+      @journals = Journal.left_outer_joins(:sponsor).where(id: display_journals).order(ord, title: :asc)
+        .preload(:sponsor).preload(:issns)
 
       respond_to do |format|
         format.html

--- a/app/controllers/stash_engine/journals_controller.rb
+++ b/app/controllers/stash_engine/journals_controller.rb
@@ -7,11 +7,7 @@ module StashEngine
       params.permit(:q)
       params[:sort] = 'title' if params[:sort].blank?
       @metadata_journals = Journal.joins(:manuscripts).where("stash_engine_manuscripts.created_at > '#{1.year.ago.iso8601}'").distinct.map(&:id)
-      @api_journals = StashEngine::User.joins('inner join oauth_applications on owner_id = stash_engine_users.id')
-        .joins(
-          "inner join stash_engine_roles on stash_engine_users.id = stash_engine_roles.user_id
-          and role_object_type in ('StashEngine::Journal', 'StashEngine::JournalOrganization')"
-        ).distinct.map(&:journals_as_admin).flatten.uniq.map(&:id)
+      setup_api_journals
       sponsoring_journals = Journal.where.not(payment_plan_type: [nil, '']).map(&:id)
       display_journals = @metadata_journals | sponsoring_journals | @api_journals
 
@@ -25,6 +21,23 @@ module StashEngine
           headers['Content-Disposition'] = "attachment; filename=journals_#{Time.new.strftime('%F')}.csv"
         end
       end
+    end
+
+    private
+
+    def setup_api_journals
+      api_journals = StashEngine::User.joins('inner join oauth_applications on owner_id = stash_engine_users.id')
+        .joins(
+          "inner join stash_engine_roles on stash_engine_users.id = stash_engine_roles.user_id and role_object_type='StashEngine::Journal'"
+        ).select('stash_engine_roles.role_object_id').distinct.map(&:role_object_id)
+      api_journals2 = StashEngine::User.joins('inner join oauth_applications on owner_id = stash_engine_users.id')
+        .joins(
+          "inner join stash_engine_roles on stash_engine_users.id = stash_engine_roles.user_id
+          and role_object_type = 'StashEngine::JournalOrganization'"
+        ).joins(
+          'inner join stash_engine_journals on sponsor_id = stash_engine_roles.role_object_id'
+        ).select('stash_engine_journals.id').distinct.map(&:id)
+      @api_journals = api_journals | api_journals2
     end
   end
 end

--- a/app/controllers/stash_engine/publication_updater_controller.rb
+++ b/app/controllers/stash_engine/publication_updater_controller.rb
@@ -103,7 +103,7 @@ module StashEngine
 
     def check_status
       @proposed_change = authorize StashEngine::ProposedChange.find(params[:id])
-      @resource = @proposed_change.identifier&.latest_resource if @proposed_change.present?
+      @resource = @proposed_change&.latest_resource if @proposed_change.present?
       refresh_error if @proposed_change.approved? || @proposed_change.rejected?
     end
 

--- a/app/javascript/react/components/MetadataEntry/PrelimInfo.jsx
+++ b/app/javascript/react/components/MetadataEntry/PrelimInfo.jsx
@@ -14,9 +14,9 @@ function PrelimInfo(
 
   const tempVal = importInfo;
 
-  const [acText, setAcText] = useState(publication_name?.value || '');
-  const [acID, setAcID] = useState(publication_issn?.value || '');
-  const [msId, setMsId] = useState(msid?.value || '');
+  const [acText, setAcText] = useState(publication_name || '');
+  const [acID, setAcID] = useState(publication_issn || '');
+  const [msId, setMsId] = useState(msid || '');
   const [importType, setImportType] = useState(tempVal);
   const [relatedIdentifier, setRelatedIdentifier] = useState(related_identifier);
 
@@ -136,9 +136,9 @@ PrelimInfo.propTypes = {
   importInfo: PropTypes.string.isRequired, // the type of import it is doing
   resourceId: PropTypes.oneOfType([PropTypes.string, PropTypes.number]).isRequired,
   identifierId: PropTypes.oneOfType([PropTypes.string, PropTypes.number]).isRequired,
-  publication_name: PropTypes.object.isRequired,
-  publication_issn: PropTypes.object.isRequired,
-  msid: PropTypes.object.isRequired,
+  publication_name: PropTypes.string.isRequired,
+  publication_issn: PropTypes.string.isRequired,
+  msid: PropTypes.string.isRequired,
   related_identifier: PropTypes.string.isRequired,
   api_journals: PropTypes.array.isRequired,
 };

--- a/app/models/stash_engine/journal.rb
+++ b/app/models/stash_engine/journal.rb
@@ -33,7 +33,7 @@ module StashEngine
     has_many :alternate_titles, class_name: 'StashEngine::JournalTitle', dependent: :destroy
     has_many :roles, class_name: 'StashEngine::Role', as: :role_object, dependent: :destroy
     has_many :users, through: :roles
-    has_many :manuscripts, -> { order(created_at: :asc) }, class_name: 'StashEngine::Manuscript'
+    has_many :manuscripts, -> { order(created_at: :desc) }, class_name: 'StashEngine::Manuscript'
     belongs_to :sponsor, class_name: 'StashEngine::JournalOrganization', optional: true
 
     def payment_plans = %w[SUBSCRIPTION PREPAID DEFERRED TIERED]

--- a/app/views/stash_engine/admin_dashboard/results.js.erb
+++ b/app/views/stash_engine/admin_dashboard/results.js.erb
@@ -6,7 +6,7 @@ urlparams.set('page', '<%= params[:page] %>')
 window.history.pushState({}, null, `${window.location.pathname}?${urlparams.toString()}`)
 document.getElementById('search_results').innerHTML = "<%= escape_javascript(render(partial: 'results')) %>";
 document.getElementById('save_buttons').innerHTML = "<%= escape_javascript(render(partial: 'save_buttons')) %>";
-document.getElementById('search_form').innerHTML = "<%= escape_javascript(render(partial: 'search_form')) %>";
+$('#search_form').html = "<%= escape_javascript(render(partial: 'search_form')) %>";
 document.getElementById('edit_fields-help').addEventListener('click', (e) => {
   e.preventDefault()
   document.getElementById('edit_fields-form').classList.toggle('show-help')

--- a/app/views/stash_engine/journals/index.html.erb
+++ b/app/views/stash_engine/journals/index.html.erb
@@ -53,11 +53,11 @@ Dryad member, you will be responsible for paying the DPC as well as any overage 
     <% if policy(@journals).detail? %>
       <td><%= journal.payment_plan_type %></td>
       <td><%= journal.sponsor&.name %></td>
-      <td><%= journal.top_level_org&.name %></td>
+      <td><%= journal.top_level_org&.name == journal.sponsor&.name ? '' : journal.top_level_org&.name %></td>
     <% end %>
     <td><% if @api_journals.include?(journal.id) || @metadata_journals.include?(journal.id) %><i class="fa fa-check-circle" aria-hidden="true"></i><span class="screen-reader-only">Data integrated</span><% end %></td>
     <% if policy(@journals).detail? %>
-      <td class="c-lined-table__digits"><%= journal.manuscripts&.last&.created_at.presence || @api_journals.include?(journal.id) ? 'API journal' : ''%></td>
+      <td class="c-lined-table__digits"><%= journal.manuscripts.limit(1).first&.created_at.presence || @api_journals.include?(journal.id) ? 'API journal' : ''%></td>
       <td><% if journal.default_to_ppr? %><i class="fa fa-check-circle" aria-hidden="true"></i><span class="screen-reader-only">Default</span><% end %></td>
     <% end %>
   </tr>

--- a/app/views/stash_engine/publication_updater/_proposed_change_line.html.erb
+++ b/app/views/stash_engine/publication_updater/_proposed_change_line.html.erb
@@ -1,6 +1,6 @@
 <%
-  existing_pubname = resource.identifier.journal_name_datum&.value || 'Not available'
-  existing_pubissn = resource.identifier.journal&.issn_array || resource.identifier.journal_datum&.value || 'Not available'
+  existing_pubname = resource.resource_publication&.publication_name || 'Not available'
+  existing_pubissn = resource.journal&.issn_array || resource.resource_publication&.publication_issn || 'Not available'
   existing_pubdoi = fetch_related_primary_article(resource: resource)
 %>
 

--- a/app/views/stash_engine/publication_updater/index.csv.erb
+++ b/app/views/stash_engine/publication_updater/index.csv.erb
@@ -19,8 +19,8 @@
   resource = @resources.select{ |r| r.identifier_id == proposed_change.identifier_id }.first
   next if resource.blank?
 
-  existing_pubname = resource.identifier.journal_name_datum&.value || 'Not available'
-  existing_pubissn = resource.identifier.journal&.issn_array || resource.identifier.journal_datum&.value || 'Not available'
+  existing_pubname = resource.resource_publication&.publication_name || 'Not available'
+  existing_pubissn = resource.journal&.issn_array || resource.resource_publication&.publication_issn || 'Not available'
   existing_pubdoi = fetch_related_primary_article(resource: resource)
 
   row = [ resource.title,


### PR DESCRIPTION
New journals page is too heavy a load—I was able to improve this but a better way of registering API journals is probably needed.

Fixed some leftover `.value` calls from internal_data stuff which was breaking new resource_publication stuff

Made sure to use jquery (ugh) to load the search form so the javascript that controls the dropdown is included.

Already deployed