### PR TITLE
Fix journals appearing twice in journal management

### DIFF
--- a/app/controllers/stash_engine/journal_admin_controller.rb
+++ b/app/controllers/stash_engine/journal_admin_controller.rb
@@ -13,8 +13,8 @@ module StashEngine
       if params[:q]
         q = params[:q]
         # search the query in any searchable field
-        @journals = @journals.left_outer_joins(:issns).distinct.where('LOWER(title) LIKE LOWER(?) OR stash_engine_journal_issns.id LIKE ?',
-                                                             "%#{q.strip}%", "%#{q.strip}%")
+        @journals = @journals.left_outer_joins(:issns).distinct
+          .where('LOWER(title) LIKE LOWER(?) OR stash_engine_journal_issns.id LIKE ?', "%#{q.strip}%", "%#{q.strip}%")
       end
 
       ord = helpers.sortable_table_order(whitelist: %w[title issns payment_plan_type default_to_ppr])

--- a/app/controllers/stash_engine/journal_admin_controller.rb
+++ b/app/controllers/stash_engine/journal_admin_controller.rb
@@ -13,7 +13,7 @@ module StashEngine
       if params[:q]
         q = params[:q]
         # search the query in any searchable field
-        @journals = @journals.left_outer_joins(:issns).where('LOWER(title) LIKE LOWER(?) OR stash_engine_journal_issns.id LIKE ?',
+        @journals = @journals.left_outer_joins(:issns).distinct.where('LOWER(title) LIKE LOWER(?) OR stash_engine_journal_issns.id LIKE ?',
                                                              "%#{q.strip}%", "%#{q.strip}%")
       end
 


### PR DESCRIPTION
Journals with 2 issns sometimes appear twice when searching the journal management page