### PR TITLE
updated robots.txt

### DIFF
--- a/public/robots.txt
+++ b/public/robots.txt
@@ -1,5 +1,7 @@
 User-agent: *
 Disallow: /search
 Disallow: /stash/downloads
+Disallow: /stash/downloadZip
+Disallow: /stash/share
 Crawl-delay: 5
 Sitemap: https://datadryad.org/sitemap.xml


### PR DESCRIPTION
closes: https://github.com/datadryad/dryad-product-roadmap/issues/2566

Removes `/stash/downloadZip` and `/stash/share` from being crawled by bots