### PR TITLE
Development environment deployment issues

### DIFF
--- a/Gemfile
+++ b/Gemfile
@@ -168,11 +168,10 @@ group :test do
   gem 'webmock'
 end
 
-group :development, :v3_development, :test, :local_dev, :local do
+group :development, :v3_development, :local_dev, :local, :test do
   gem 'binding_of_caller'
   # Ruby fast debugger - base + CLI (http://github.com/deivid-rodriguez/byebug)
   gem 'byebug'
-  gem 'colorize'
   gem 'listen'
   gem 'parallel_tests'
   gem 'pry'
@@ -184,5 +183,9 @@ group :development, :v3_development, :test, :local_dev, :local do
   gem 'spring'
   # rspec command for spring (https://github.com/jonleighton/spring-commands-rspec)
   gem 'spring-commands-rspec'
+end
+
+group :development, :v3_development, :local_dev do
+  gem 'colorize'
   gem 'web-console'
 end

--- a/Gemfile
+++ b/Gemfile
@@ -122,14 +122,6 @@ gem 'mutex_m'
 # ############################################################
 # Development and testing
 
-gem 'parallel_tests', group: %i[development test]
-
-group :development, :local_dev do
-  gem 'colorize'
-  gem 'web-console'
-  # gem 'httplog', not needed always, but good for troubleshooting HTTP requests to outside http services from the app
-end
-
 group :test do
   # I'm not sure we're really using every one of these libraries like fuubar?, guard?, mocha?, rspec-html?, shoulda?
   # Capybara aims to simplify the process of integration testing Rack applications, such as Rails, Sinatra or Merb (https://github.com/teamcapybara/capybara)
@@ -176,11 +168,13 @@ group :test do
   gem 'webmock'
 end
 
-group :development, :test, :local_dev, :local do
+group :development, :v3_development, :test, :local_dev, :local do
   gem 'binding_of_caller'
   # Ruby fast debugger - base + CLI (http://github.com/deivid-rodriguez/byebug)
   gem 'byebug'
+  gem 'colorize'
   gem 'listen'
+  gem 'parallel_tests'
   gem 'pry'
   gem 'pry-rails'
   gem 'pry-remote', require: 'pry-remote'
@@ -190,4 +184,5 @@ group :development, :test, :local_dev, :local do
   gem 'spring'
   # rspec command for spring (https://github.com/jonleighton/spring-commands-rspec)
   gem 'spring-commands-rspec'
+  gem 'web-console'
 end

--- a/config/environments/v3_development.rb
+++ b/config/environments/v3_development.rb
@@ -1,6 +1,9 @@
 Rails.application.configure do
   # Settings specified here will take precedence over those in config/application.rb.
 
+  # Have to include this because the v3_development env name is elaborate and unexpected
+  config.web_console.development_only = false
+
   # Code is not reloaded between requests.
   config.cache_classes = true
 


### PR DESCRIPTION
We were unable to deploy to the v3_dev environment instance due to the following error:

```
NameError: uninitialized constant LetterOpenerWeb
```

Ensuring all the gems installed for `:development` were also installed for `:v3_development` led to an additional error:

```
Web Console is activated in the v3_development environment. This is
usually a mistake. To ensure it's only activated in development
mode, move it to the development group of your Gemfile:

    gem 'web-console', group: :development

If you still want to run it in the v3_development environment (and know
what you are doing), put this in your Rails application
configuration:

    config.web_console.development_only = false
```

Both are fixed here.


I think we need a tech debt ticket to pare down our long and confusing list of environments and to stop using these unusual environment names that are unanticipated by code (i.e., go back to standard `production` and `development` env names)