### PR TITLE
Remove pub date from new copied resources

### DIFF
--- a/app/models/stash_engine/resource.rb
+++ b/app/models/stash_engine/resource.rb
@@ -127,6 +127,7 @@ module StashEngine
                   # let init_version do its job
                   new_resource.current_resource_state_id = nil
                   # do not mark these resources for public view until they've been re-curated and embargoed/published again
+                  new_resource.publication_date = nil
                   new_resource.meta_view = false
                   new_resource.file_view = false
 

--- a/spec/models/stash_engine/resources_spec.rb
+++ b/spec/models/stash_engine/resources_spec.rb
@@ -286,11 +286,11 @@ module StashEngine
         expect(resource.publication_date).to be_nil
       end
 
-      it 'is copied by amoeba duplication' do
+      it 'is not copied by amoeba duplication' do
         pub_date = Time.new(2015, 5, 18, 13, 25, 30)
         r1 = create(:resource, user_id: user.id, publication_date: pub_date)
         r2 = r1.amoeba_dup
-        expect(r2.publication_date).to eq(pub_date)
+        expect(r2.publication_date).to be_nil
       end
     end
 


### PR DESCRIPTION
I was trying to see if any other resources were affected by the issue where published resources are set to file_view=false (https://github.com/datadryad/dryad-product-roadmap/issues/3186, https://github.com/datadryad/dryad-product-roadmap/issues/3206)

I'll have to figure out a more complex query for checking this, because doing this query there were tons more than I was expecting (around 8800):

`StashEngine::Resource.where('publication_date < now()').where(file_view: false)`

It turns out when a resource is copied to make a new version from one that has been published, it still has the previous publication_date set, even though the new version has never been published. This removes that!