### PR TITLE
Update mail delivery settings

### DIFF
--- a/app/controllers/stash_api/related_works_controller.rb
+++ b/app/controllers/stash_api/related_works_controller.rb
@@ -58,7 +58,7 @@ module StashApi
       last_note = last_cur&.note || ''
       return if last_note.match(/Related .+ added with http.+ from the API/) && last_cur.created_at > 1.day.ago
 
-      StashEngine::UserMailer.related_work_updated(@resource).deliver_later
+      StashEngine::UserMailer.related_work_updated(@resource).deliver_now
     end
   end
 end

--- a/app/controllers/stash_engine/sessions_controller.rb
+++ b/app/controllers/stash_engine/sessions_controller.rb
@@ -70,7 +70,7 @@ module StashEngine
         params.each do |k, v|
           message = "#{message}#{k}: #{v}\n" if %w[authenticity_token commit controller action g-recaptcha-response].exclude?(k)
         end
-        StashEngine::UserMailer.feedback_signup(message).deliver_later
+        StashEngine::UserMailer.feedback_signup(message).deliver_now
         redirect_to stash_url_helpers.feedback_path, notice: 'Sign up successful. Thank you!'
       else
         redirect_to stash_url_helpers.feedback_path, flash: { alert: 'Please fill in reCAPTCHA' }

--- a/app/models/stash_engine/curation_activity.rb
+++ b/app/models/stash_engine/curation_activity.rb
@@ -279,13 +279,9 @@ module StashEngine
 
       case status
       when 'published', 'embargoed'
-        # These messages deliver_later because we don't want to slow down the curators, who
-        # would have to wait for the thread to finish in a deliver_now situation
-        StashEngine::UserMailer.status_change(resource, status).deliver_later
-        StashEngine::UserMailer.journal_published_notice(resource, status).deliver_later
+        StashEngine::UserMailer.status_change(resource, status).deliver_now
+        StashEngine::UserMailer.journal_published_notice(resource, status).deliver_now
       when 'peer_review'
-        # These messages deliver_now because the status change to peer_review typically happens in the
-        # status_updater, and we don't want its thread to be killed before the message delivers
         StashEngine::UserMailer.status_change(resource, status).deliver_now
         StashEngine::UserMailer.journal_review_notice(resource, status).deliver_now
       when 'submitted'
@@ -334,7 +330,7 @@ module StashEngine
             secret: SecureRandom.urlsafe_base64,
             invited_at: Time.new.utc
           )
-        ).deliver_later
+        ).deliver_now
       end
     end
 

--- a/app/models/stash_engine/proposed_change.rb
+++ b/app/models/stash_engine/proposed_change.rb
@@ -105,7 +105,7 @@ module StashEngine
         status: 'submitted',
         note: "#{provenance.capitalize} #{CROSSREF_PUBLISHED_MESSAGE}"
       )
-      StashEngine::UserMailer.peer_review_pub_linked(resource).deliver_later
+      StashEngine::UserMailer.peer_review_pub_linked(resource).deliver_now
     end
 
     def add_metadata_updated_curation_note(provenance, resource, type)

--- a/app/services/stash_engine/status_dashboard/dependency_checker_service.rb
+++ b/app/services/stash_engine/status_dashboard/dependency_checker_service.rb
@@ -29,7 +29,7 @@ module StashEngine
       end
 
       def report_outage(message)
-        UserMailer.dependency_offline(@dependency, message).deliver_later
+        UserMailer.dependency_offline(@dependency, message).deliver_now
       end
 
       def extract_log_err(log)


### PR DESCRIPTION
Addendum for https://github.com/datadryad/dryad-product-roadmap/issues/3604

On the sandbox server, the `deliver_later` was not actually sending the message, even when the `send_journal_published_notices` was set. In tracking this down, I have seen a number of complaints of interaction of `deliver_later` with variouse configurations, so I think it is best to avoid for now.
