### PR TITLE
Exclude throttling on file preview_check

### DIFF
--- a/config/initializers/rack_attack.rb
+++ b/config/initializers/rack_attack.rb
@@ -63,7 +63,9 @@ end
 # But don't return anything for /assets, which are just part of each page and should not be tracked.
 # Also, don't throttle AWS presign requests for upload chunks that will be sent to S3 for files
 Rack::Attack.throttle('all_requests_by_IP', limit: APP_CONFIG[:rate_limit][:all_requests], period: 1.minute) do |req|
-  req.ip unless req.path.start_with?('/assets') || req.path.match(%r{^/stash/[a-z]+_file/presign_upload/\d+})
+  req.ip unless req.path.start_with?('/assets') ||
+                req.path.match(%r{^/stash/[a-z]+_file/presign_upload/\d+}) ||
+                req.path.start_with?('/data_file/preview_check')
 end
 
 # File download throttling

--- a/config/initializers/rack_attack.rb
+++ b/config/initializers/rack_attack.rb
@@ -65,7 +65,7 @@ end
 Rack::Attack.throttle('all_requests_by_IP', limit: APP_CONFIG[:rate_limit][:all_requests], period: 1.minute) do |req|
   req.ip unless req.path.start_with?('/assets') ||
                 req.path.match(%r{^/stash/[a-z]+_file/presign_upload/\d+}) ||
-                req.path.start_with?('/data_file/preview_check')
+                req.path.start_with?('/stash/data_file/preview_check')
 end
 
 # File download throttling


### PR DESCRIPTION
We were seeing legitimate users blocked due to the speed of requests for the preview_check function. This excludes it from the throttling process.