### PR TITLE
Fix javascript loading order

### DIFF
--- a/app/views/layouts/stash_engine/application.html.erb
+++ b/app/views/layouts/stash_engine/application.html.erb
@@ -4,6 +4,23 @@
   <%= render 'layouts/stash_engine/standard_head' %>
   <%= render 'layouts/stash_engine/stash_head' %>
   <%= content_for :head %>
+  <script type="text/javascript">
+    function load_data() {
+      $("[data-load]:not([data-loaded])").filter(":visible").each(function () {
+        var path = $(this).attr('data-load');
+        // $(this).load(path);
+        $.ajax({
+          url: path,
+          //data,
+          // success: success,
+          dataType: 'script'
+        }).always(function() {
+          // modernizeIt();
+        });
+        $(this).attr('data-loaded')
+      });
+    }
+  </script>
 </head>
 <body class='<%= "#{controller_name}_#{action_name}" %>'>
   <%= render 'layouts/stash_engine/top_area' %>
@@ -20,22 +37,6 @@
   <script type="text/javascript" defer="defer">
     // see http://stackoverflow.com/questions/6214201/best-practices-for-loading-page-content-via-ajax-request-in-rails3
     // for information about how data-load works, only I made it more standard UJS.
-
-    function load_data() {
-      $("[data-load]:not([data-loaded])").filter(":visible").each(function () {
-        var path = $(this).attr('data-load');
-        // $(this).load(path);
-        $.ajax({
-          url: path,
-          //data,
-          // success: success,
-          dataType: 'script'
-        }).always(function() {
-          // modernizeIt();
-        });
-        $(this).attr('data-loaded')
-      });
-    }
     $(window).on("load", function() {
       load_data()
     });

--- a/app/views/stash_datacite/resources/_show.html.erb
+++ b/app/views/stash_datacite/resources/_show.html.erb
@@ -25,10 +25,8 @@
 <%# takes local of identifier, no_link == true means don't link metrics %>
 <% no_link = false unless defined?(no_link) %>
 <% if resource.identifier&.counter_stat&.citation_count > 0 && !no_link %>
-  <div id="citations-section"
-       data-load="<%= stash_url_helpers.show_citations_path(identifier_id: resource.identifier_id, format: :js) %>">
-    <i class="fa fa-spin fa-spinner" aria-hidden="true" style="color: #888"></i>
-  </div>
+  <h2 tabindex="0" class="expand-button" role="button" aria-expanded="false" aria-controls="citations-sec">Works referencing this dataset</h2>
+  <div id="citations-section" data-load="<%= stash_url_helpers.show_citations_path(identifier_id: resource.identifier_id, format: :js) %>"></div>
 <% end %>
 
 <script type="application/ld+json">

--- a/app/views/stash_engine/landing/_citations.html.erb
+++ b/app/views/stash_engine/landing/_citations.html.erb
@@ -1,5 +1,4 @@
 <%# takes a local identifier AR object #%>
-<h2 tabindex="0" class="expand-button" role="button" aria-expanded="false" aria-controls="citations-sec">Works referencing this dataset</h2>
 <div id="citations-sec" hidden>
   <ul class="o-list">
     <% identifier.cached_citations.each do |cite| %>


### PR DESCRIPTION
Curators have noticed the citation section does not expand—this is because the expand button header for the section is loaded by javascript after the javascript which makes it a button has already run. Another javascript loading issue appears in the console intermittently. This fixes both problems.