### PR TITLE
Fix citation format for works citing

### DIFF
--- a/app/models/stash_engine/counter_citation.rb
+++ b/app/models/stash_engine/counter_citation.rb
@@ -5,6 +5,7 @@
 #  id            :integer          not null, primary key
 #  citation      :text(65535)
 #  doi           :text(65535)
+#  metadata      :json
 #  created_at    :datetime         not null
 #  updated_at    :datetime         not null
 #  identifier_id :integer
@@ -39,10 +40,11 @@ module StashEngine
       return cites.first unless cites.blank?
 
       datacite_metadata = Stash::DataciteMetadata.new(doi: doi)
+      raw_metadata = datacite_metadata.raw_metadata
       html_citation = datacite_metadata.html_citation
       return nil if html_citation.blank? # do not save to database and return nil early
 
-      create(citation: html_citation, doi: doi, identifier_id: stash_identifier.id)
+      create(citation: html_citation, metadata: raw_metadata.to_json, doi: doi, identifier_id: stash_identifier.id)
     end
   end
 end

--- a/db/migrate/20240914161148_store_raw_metadata.rb
+++ b/db/migrate/20240914161148_store_raw_metadata.rb
@@ -1,0 +1,5 @@
+class StoreRawMetadata < ActiveRecord::Migration[7.0]
+  def change
+    add_column :stash_engine_counter_citations, :metadata, :json, after: :citation
+  end
+end

--- a/lib/stash/datacite_metadata.rb
+++ b/lib/stash/datacite_metadata.rb
@@ -38,7 +38,7 @@ module Stash
       return '' if names.blank?
 
       names = names.map { |i| name_finder(i) }
-      return "#{names.first} et al." if names.length > 4
+      return "#{names.first(3).join('; ')} et al." if names.length > 4
 
       names.join('; ')
     end
@@ -63,7 +63,9 @@ module Stash
     end
 
     def resource_type
-      return raw_metadata['type'].capitalize if raw_metadata['type']
+      return ' [Preprint]' if ('posted-content', 'preprint').include?(raw_metadata['type'])
+      return ' [Dataset]' if raw_metadata['type'] == 'dataset'
+      return ' [Software]' if raw_metadata['type'] == 'software'
 
       ''
     end
@@ -84,8 +86,13 @@ module Stash
       return nil if raw_metadata.nil?
 
       # html_safe when concatenated with other stuff makes non-html-safe escaped
-      ''.html_safe + "#{author_names} (#{year_published}), #{title}, #{journal}, #{resource_type}, " +
-          "<a href=\"#{doi_link}\" target=\"_blank\">#{doi_link}</a>".html_safe
+      citation_array = []
+      citation_array << "#{author_names} #{year_published ? "(#{year_published})" : ''}"
+      citation_array << "#{title.html_safe}#{resource_type}"
+      citation_array << journal
+      citation_array << publisher unless raw_metadata['type'].include?('journal')
+      citation_array << "<a href=\"#{doi_link}\" target=\"_blank\">#{doi_link}</a>".html_safe
+      citation_array.reject(&:blank?).join('. ')
     end
 
     def logger

--- a/lib/stash/datacite_metadata.rb
+++ b/lib/stash/datacite_metadata.rb
@@ -63,7 +63,7 @@ module Stash
     end
 
     def resource_type
-      return ' [Preprint]' if ('posted-content', 'preprint').include?(raw_metadata['type'])
+      return ' [Preprint]' if %w[posted-content preprint].include?(raw_metadata['type'])
       return ' [Dataset]' if raw_metadata['type'] == 'dataset'
       return ' [Software]' if raw_metadata['type'] == 'software'
 
@@ -87,7 +87,7 @@ module Stash
 
       # html_safe when concatenated with other stuff makes non-html-safe escaped
       citation_array = []
-      citation_array << "#{author_names} #{year_published ? "(#{year_published})" : ''}"
+      citation_array << "#{author_names}#{year_published ? " (#{year_published})" : ''}"
       citation_array << "#{title.html_safe}#{resource_type}"
       citation_array << journal
       citation_array << publisher unless raw_metadata['type'].include?('journal')

--- a/spec/factories/stash_engine/counter_citations.rb
+++ b/spec/factories/stash_engine/counter_citations.rb
@@ -5,6 +5,7 @@
 #  id            :integer          not null, primary key
 #  citation      :text(65535)
 #  doi           :text(65535)
+#  metadata      :json
 #  created_at    :datetime         not null
 #  updated_at    :datetime         not null
 #  identifier_id :integer

--- a/spec/models/stash_engine/counter_citation_spec.rb
+++ b/spec/models/stash_engine/counter_citation_spec.rb
@@ -5,6 +5,7 @@
 #  id            :integer          not null, primary key
 #  citation      :text(65535)
 #  doi           :text(65535)
+#  metadata      :json
 #  created_at    :datetime         not null
 #  updated_at    :datetime         not null
 #  identifier_id :integer


### PR DESCRIPTION
For https://github.com/datadryad/dryad-product-roadmap/issues/3640

I notice we save the citation string we create, and not the retrieved raw metadata itself, making it hard to regenerate/correct the citation formatting for existing records. I've added a db column and we will save the raw JSON retrieved going into the future to make any future changes to the citation string easy to regenerate.

We will need to build a way to retrieve and refresh everything where the JSON has not previously been saved, once we've agreed on a method for this with DataCite.