### PR TITLE
Default to admin dashboard for admins

### DIFF
--- a/app/controllers/stash_datacite/resources_controller.rb
+++ b/app/controllers/stash_datacite/resources_controller.rb
@@ -38,8 +38,7 @@ module StashDatacite
           @resource.save!
           @resource.reload
           if @resource.identifier.payment_type.blank? || @resource.identifier.payment_type == 'unknown'
-            session[:origin] = 'resource'
-            session[:redirect_resource_id] = @resource.id
+            @target_page = stash_url_helpers.review_resource_path(@resource.id)
             @aff_tenant = StashEngine::Tenant.find_by_ror_id(@resource.identifier&.submitter_affiliation&.ror_id).partner_list.first
           end
         end

--- a/app/controllers/stash_datacite/resources_controller.rb
+++ b/app/controllers/stash_datacite/resources_controller.rb
@@ -73,7 +73,7 @@ module StashDatacite
         session[:returnURL] = nil
         redirect_to(return_url, notice: "Submitted updates for #{@resource.identifier}, title: #{@resource.title}", allow_other_host: true)
       else
-        redirect_to(stash_url_helpers.dashboard_path(doi: @resource.identifier.identifier), notice: resource_submitted_message(@resource))
+        redirect_to(stash_url_helpers.choose_dashboard_path(doi: @resource.identifier.identifier), notice: resource_submitted_message(@resource))
       end
     end
 

--- a/app/controllers/stash_engine/application_controller.rb
+++ b/app/controllers/stash_engine/application_controller.rb
@@ -29,14 +29,14 @@ module StashEngine
 
     def user_not_authorized
       flash[:alert] = 'You are not authorized to view this information.'
-      redirect_back(fallback_location: '/stash/dashboard')
+      redirect_back(fallback_location: choose_dashboard_path)
     end
 
     def display_authorization_failure
       Rails.logger.warn("Resource #{resource ? resource.id : 'nil'}: user ID is #{resource.user_id || 'nil'} but " \
                         "current user is #{current_user.id || 'nil'}")
       flash[:alert] = 'You do not have permission to modify this dataset.'
-      redirect_back(fallback_location: '/stash/dashboard')
+      redirect_back(fallback_location: choose_dashboard_path)
     end
 
     def redirect_url_for(original_url, host, port)

--- a/app/controllers/stash_engine/dashboard_controller.rb
+++ b/app/controllers/stash_engine/dashboard_controller.rb
@@ -6,6 +6,12 @@ module StashEngine
 
     MAX_VALIDATION_TRIES = 5
 
+    def choose
+      return redirect_to admin_dashboard_path if current_user.min_admin?
+
+      redirect_to dashboard_path
+    end
+
     def show
       @doi = CGI.escape(params[:doi] || '')
     end

--- a/app/controllers/stash_engine/metadata_entry_pages_controller.rb
+++ b/app/controllers/stash_engine/metadata_entry_pages_controller.rb
@@ -46,10 +46,10 @@ module StashEngine
 
       if ownership_transfer_needed?
         if current_user
-          ca = CurationActivity.create(status: @resource.current_curation_status || 'in_progress',
-                                       user_id: 0,
-                                       resource_id: @resource.id,
-                                       note: "Transferring ownership to #{current_user.name} (#{current_user.id}) using an edit code")
+          ca = CurationActivity.create(
+            status: @resource.current_curation_status || 'in_progress', user_id: 0, resource_id: @resource.id,
+            note: "Transferring ownership to #{current_user.name} (#{current_user.id}) using an edit code"
+          )
           @resource.curation_activities << ca
           @resource.user_id = current_user.id
           @resource.current_editor_id = current_user.id
@@ -74,12 +74,11 @@ module StashEngine
           redirect_to stash_url_helpers.choose_sso_path and return
         end
       end
-
       if @resource&.current_resource_state&.resource_state == 'in_progress'
-        redirect_to(stash_url_helpers.metadata_entry_pages_find_or_create_path(resource_id: resource.id))
-      else
-        new_version
+        redirect_to(stash_url_helpers.metadata_entry_pages_find_or_create_path(resource_id: resource.id)) and return
       end
+
+      new_version
     end
     # rubocop:enable Metrics/AbcSize, Metrics/MethodLength
 

--- a/app/controllers/stash_engine/metadata_entry_pages_controller.rb
+++ b/app/controllers/stash_engine/metadata_entry_pages_controller.rb
@@ -167,7 +167,7 @@ module StashEngine
         redirect_to(stash_url_helpers.metadata_entry_pages_find_or_create_path(resource_id: @identifier.in_progress_resource.id))
         false
       elsif @identifier.processing? || @identifier.error?
-        redirect_to stash_url_helpers.dashboard_path,
+        redirect_to stash_url_helpers.choose_dashboard_path,
                     alert: 'You may not create a new version of the dataset until processing completes or any errors are resolved'
         false
       end

--- a/app/controllers/stash_engine/resources_controller.rb
+++ b/app/controllers/stash_engine/resources_controller.rb
@@ -104,7 +104,7 @@ module StashEngine
             session[:returnURL] = nil
             redirect_to(return_url, allow_other_host: true, notice: notice)
           elsif current_user
-            redirect_to return_to_path_or(dashboard_path), notice: notice
+            redirect_to return_to_path_or(choose_dashboard_path), notice: notice
           else
             redirect_to root_path, notice: notice
           end
@@ -238,7 +238,7 @@ module StashEngine
     end
 
     def require_in_progress
-      redirect_to dashboard_path, alert: 'You may only edit the current version of the dataset' unless resource.current_state == 'in_progress'
+      redirect_to choose_dashboard_path, alert: 'You may only edit the current version of the dataset' unless resource.current_state == 'in_progress'
       false
     end
 

--- a/app/controllers/stash_engine/sessions_controller.rb
+++ b/app/controllers/stash_engine/sessions_controller.rb
@@ -95,7 +95,7 @@ module StashEngine
       existing.update(first_name: params[:first_name], last_name: params[:last_name], email: params[:email],
                       tenant_id: params[:tenant_id])
       session[:user_id] = existing.id
-      redirect_to stash_url_helpers.dashboard_path, status: :found
+      redirect_to stash_url_helpers.choose_dashboard_path, status: :found
     end
 
     def choose_sso
@@ -179,7 +179,7 @@ module StashEngine
       user = @users.first
       session[:user_id] = user.id
       # tenant = Tenant.find(user.tenant_id) # this was used to redirect to correct tenant, now not needed
-      redirect_to stash_url_helpers.dashboard_path
+      redirect_to stash_url_helpers.choose_dashboard_path
     end
 
     # get orcid emails as returned by API
@@ -297,7 +297,7 @@ module StashEngine
       when 'resource'
         redirect_to stash_url_helpers.review_resource_path(session[:redirect_resource_id])
       else
-        redirect_to stash_url_helpers.dashboard_path
+        redirect_to stash_url_helpers.choose_dashboard_path
       end
     end
 

--- a/app/controllers/stash_engine/shared_security_controller.rb
+++ b/app/controllers/stash_engine/shared_security_controller.rb
@@ -24,15 +24,14 @@ module StashEngine
           # to the login page. Now that they are logged in, we will redirect to the target_page,
           # but first clear it from the session so we don't continually redirect to it.
           session[:target_page] = nil
-          redirect_to target_page
+          redirect_to target_page and return
         end
         return
       end
 
       return if valid_edit_code?
 
-      flash[:alert] = 'You must be logged in.'
-      session[:target_page] = request.fullpath
+      flash[:alert] = 'You must log in and select an institution (or none).'
       redirect_to stash_url_helpers.choose_login_path
     end
 

--- a/app/controllers/stash_engine/shared_security_controller.rb
+++ b/app/controllers/stash_engine/shared_security_controller.rb
@@ -47,21 +47,21 @@ module StashEngine
       return if @resource&.current_resource_state&.resource_state == 'in_progress'
 
       flash[:alert] = 'You may not edit a submitted version of your dataset by using the back button. Please open your dataset from the editing link'
-      redirect_to stash_url_helpers.dashboard_path
+      redirect_to stash_url_helpers.choose_dashboard_path
     end
 
     def require_superuser
       return if current_user && current_user.superuser?
 
       flash[:alert] = 'You must be a superuser to view this information.'
-      redirect_to stash_url_helpers.dashboard_path
+      redirect_to stash_url_helpers.choose_dashboard_path
     end
 
     def require_curator
       return if current_user && current_user.min_curator?
 
       flash[:alert] = 'You must be a curator to view this information.'
-      redirect_to stash_url_helpers.dashboard_path
+      redirect_to stash_url_helpers.choose_dashboard_path
     end
 
     def ajax_require_curator
@@ -72,7 +72,7 @@ module StashEngine
       return if current_user && current_user.min_app_admin?
 
       flash[:alert] = 'You must be a curator to view this information.'
-      redirect_to stash_url_helpers.dashboard_path
+      redirect_to stash_url_helpers.choose_dashboard_path
     end
 
     def ajax_require_min_app_admin
@@ -83,7 +83,7 @@ module StashEngine
       return if current_user && current_user.min_admin?
 
       flash[:alert] = 'You must be an administrator to view this information.'
-      redirect_to stash_url_helpers.dashboard_path
+      redirect_to stash_url_helpers.choose_dashboard_path
     end
 
     # this requires a method called resource in the controller that returns the current resource (usually @resource)

--- a/app/controllers/stash_engine/user_account_controller.rb
+++ b/app/controllers/stash_engine/user_account_controller.rb
@@ -3,7 +3,7 @@ module StashEngine
     before_action :require_user_login
 
     def index
-      session[:origin] = 'account'
+      @target_page = stash_url_helpers.my_account_path
     end
 
     def edit

--- a/app/views/stash_engine/admin_datasets/activity_log.html.erb
+++ b/app/views/stash_engine/admin_datasets/activity_log.html.erb
@@ -142,7 +142,6 @@
                       method: :post, :html => { onsubmit: "document.body.classList.add('prevent-clicks')" }) do -%>
           <button class="o-button__submit">Forcibly edit dataset</button>
           <%= hidden_field_tag :resource_id, res&.id, id: "resource_id_#{res&.id}" %>
-          <%= hidden_field_tag :return_url, '/stash/dashboard' %>
         <% end %>
         <p>Forcibly editing a dataset will assign it to you, and begin an editing session.
           Please only do this if you know the author is unable/unwilling to submit it.</p>

--- a/app/views/stash_engine/shared/_change_tenant.html.erb
+++ b/app/views/stash_engine/shared/_change_tenant.html.erb
@@ -15,6 +15,7 @@
   <div class="t-login__choose">
     <div class="c-institution__container" style="width: 100%">
       <%= form_with(url: sso_path, method: :post, html: {style: 'justify-content: space-between;'}) do %>
+        <% if @target_page %><input type="hidden" name="target_page" value="<%= @target_page %>"><% end %>
         <%= react_component('components/TenantForm', {tenants: tenant_select}) %>
         <span style="flex-grow: 1"></span>
         <button class="o-button__plain-text7" id="keep_tenant" aria-expanded="true" aria-controls="edit_tenant-form"><i class="fas fa-times" aria-hidden="true"></i> Cancel</button>

--- a/app/views/stash_engine/user_admin/_user_datasets.erb
+++ b/app/views/stash_engine/user_admin/_user_datasets.erb
@@ -39,7 +39,6 @@
           <% if policy(p.resource).curator_edit? %>
             <%= form_with(url: stash_url_helpers.metadata_entry_pages_new_version_path, method: :post) do %>
               <%= hidden_field_tag :resource_id, p.resource.id, id: "resource_id_#{p.resource.id}" %>
-              <%= hidden_field_tag :return_url, '/stash/dashboard' %>
               <button class="c-admin-edit-icon js-trap-curator-url" title="Edit dataset" aria-label="Edit dataset"><i class="fa fa-pencil" aria-hidden="true"></i></button>
             <% end %>
           <% end %>

--- a/config/routes.rb
+++ b/config/routes.rb
@@ -195,6 +195,7 @@ Rails.application.routes.draw do
         to: 'generic_files#check_frictionless',
         as: 'generic_file_check_frictionless'
 
+    get 'choose_dashboard', to: 'dashboard#choose', as: 'choose_dashboard'
     get 'dashboard', to: 'dashboard#show', as: 'dashboard'
     get 'dashboard/user_datasets', to: 'dashboard#user_datasets'
     get 'ajax_wait', to: 'dashboard#ajax_wait', as: 'ajax_wait'

--- a/spec/features/stash_engine/admin_dashboard_spec.rb
+++ b/spec/features/stash_engine/admin_dashboard_spec.rb
@@ -192,8 +192,7 @@ RSpec.feature 'AdminDashboard', type: :feature do
       it 'has all filters for system users', js: true do
         visit root_path
         click_button 'Datasets'
-        # click_link 'Admin dashboard'
-        visit stash_url_helpers.admin_dashboard_path
+        click_link 'Admin dashboard'
         expect(page).to have_text('Admin dashboard')
         expect(page).to have_select('filter-member')
         expect(page).to have_button('multiselect-status__input')
@@ -211,9 +210,7 @@ RSpec.feature 'AdminDashboard', type: :feature do
       it 'limits options in the dashboard', js: true do
         visit root_path
         click_button 'Datasets'
-        # click_link 'Admin dashboard'
-        visit stash_url_helpers.admin_dashboard_path
-
+        click_link 'Admin dashboard'
         expect(page).to have_content(@resource.title)
         expect(page).not_to have_selector('button.c-admin-edit-icon .fa-pencil') # no pencil editing icons for you
       end
@@ -226,6 +223,7 @@ RSpec.feature 'AdminDashboard', type: :feature do
       end
 
       it 'has admin link', js: true do
+        visit root_path
         click_button 'Datasets'
         expect(page).to have_link('Admin dashboard')
         expect(page).to have_link('Publication updater')
@@ -234,8 +232,7 @@ RSpec.feature 'AdminDashboard', type: :feature do
       it 'selects identifiers and curator fields by default', js: true do
         visit root_path
         click_button 'Datasets'
-        # click_link 'Admin dashboard
-        visit stash_url_helpers.admin_dashboard_path
+        click_link 'Admin dashboard'
         expect(find('#identifiers')).to be_checked
         expect(find('thead')).to have_text('Publication IDs')
         expect(find('#curator')).to be_checked
@@ -246,8 +243,7 @@ RSpec.feature 'AdminDashboard', type: :feature do
         before(:each) do
           visit root_path
           click_button 'Datasets'
-          # click_link 'Admin dashboard
-          visit stash_url_helpers.admin_dashboard_path
+          click_link 'Admin dashboard'
         end
 
         it 'allows assigning a curator to a dataset' do
@@ -370,8 +366,7 @@ RSpec.feature 'AdminDashboard', type: :feature do
 
         visit root_path
         click_button 'Datasets'
-        # click_link 'Admin dashboard'
-        visit stash_url_helpers.admin_dashboard_path
+        click_link 'Admin dashboard'
         expect(page).to have_text('Admin dashboard')
         expect(page).to have_text(res1.title)
         expect(page).not_to have_text(res2.title)
@@ -380,8 +375,7 @@ RSpec.feature 'AdminDashboard', type: :feature do
       it 'selects affiliations field by default', js: true do
         visit root_path
         click_button 'Datasets'
-        # click_link 'Admin dashboard'
-        visit stash_url_helpers.admin_dashboard_path
+        click_link 'Admin dashboard'
         expect(find('#affiliations')).to be_checked
       end
     end
@@ -406,8 +400,7 @@ RSpec.feature 'AdminDashboard', type: :feature do
 
         visit root_path
         click_button 'Datasets'
-        # click_link 'Admin dashboard'
-        visit stash_url_helpers.admin_dashboard_path
+        click_link 'Admin dashboard'
         expect(page).to have_text('Admin dashboard')
         expect(page).to have_text(res1.title)
         expect(page).not_to have_text(res2.title)
@@ -416,17 +409,14 @@ RSpec.feature 'AdminDashboard', type: :feature do
       it 'selects affiliations field by default', js: true do
         visit root_path
         click_button 'Datasets'
-        # click_link 'Admin dashboard
-        visit stash_url_helpers.admin_dashboard_path
+        click_link 'Admin dashboard'
         expect(find('#affiliations')).to be_checked
       end
 
       it 'Limits options in the dashboard', js: true do
         visit root_path
         click_button 'Datasets'
-        # click_link 'Admin dashboard'
-        visit stash_url_helpers.admin_dashboard_path
-
+        click_link 'Admin dashboard'
         expect(page).to have_content(@resource.title)
         expect(page).not_to have_selector('button.c-admin-edit-icon .fa-pencil') # no pencil editing icons for you
       end
@@ -434,8 +424,7 @@ RSpec.feature 'AdminDashboard', type: :feature do
       it 'does not allow editing a dataset from the dashboard', js: true do
         visit root_path
         click_button 'Datasets'
-        # click_link 'Admin dashboard'
-        visit stash_url_helpers.admin_dashboard_path
+        click_link 'Admin dashboard'
         expect(page).to have_text('Admin dashboard')
         expect(page).not_to have_css('button[title="Edit dataset"]')
       end
@@ -467,8 +456,7 @@ RSpec.feature 'AdminDashboard', type: :feature do
       it 'shows only datasets for consortium tenants', js: true do
         visit root_path
         click_button 'Datasets'
-        # click_link 'Admin dashboard
-        visit stash_url_helpers.admin_dashboard_path
+        click_link 'Admin dashboard'
         expect(page).to have_text('Admin dashboard')
         assert_selector('tbody tr', count: 4)
         expect(page).to have_text(@res2.title)
@@ -478,8 +466,7 @@ RSpec.feature 'AdminDashboard', type: :feature do
       it 'shows consortium admins dropdown for their tenants', js: true do
         visit root_path
         click_button 'Datasets'
-        # click_link 'Admin dashboard
-        visit stash_url_helpers.admin_dashboard_path
+        click_link 'Admin dashboard'
         expect(page).to have_text('Admin dashboard')
         expect(page).to have_select('filter-member')
         expect(page).to have_selector('#filter-member option', count: 4)
@@ -488,8 +475,7 @@ RSpec.feature 'AdminDashboard', type: :feature do
       it 'filters by tenant', js: true do
         visit root_path
         click_button 'Datasets'
-        # click_link 'Admin dashboard
-        visit stash_url_helpers.admin_dashboard_path
+        click_link 'Admin dashboard'
         expect(page).to have_text('Admin dashboard')
         select('member1', from: 'filter-member')
         click_button('Apply')
@@ -523,8 +509,7 @@ RSpec.feature 'AdminDashboard', type: :feature do
 
         visit root_path
         click_button 'Datasets'
-        # click_link 'Admin dashboard
-        visit stash_url_helpers.admin_dashboard_path
+        click_link 'Admin dashboard'
         expect(page).to have_text('Admin dashboard')
         expect(page).to have_text(@res1.title)
         expect(page).not_to have_text(res2.title)
@@ -533,8 +518,7 @@ RSpec.feature 'AdminDashboard', type: :feature do
       it 'selects identifiers field by default', js: true do
         visit root_path
         click_button 'Datasets'
-        # click_link 'Admin dashboard
-        visit stash_url_helpers.admin_dashboard_path
+        click_link 'Admin dashboard'
         expect(find('#identifiers')).to be_checked
         expect(find('thead')).to have_text('Publication IDs')
       end
@@ -569,8 +553,7 @@ RSpec.feature 'AdminDashboard', type: :feature do
 
         visit root_path
         click_button 'Datasets'
-        # click_link 'Admin dashboard
-        visit stash_url_helpers.admin_dashboard_path
+        click_link 'Admin dashboard'
         expect(page).to have_text('Admin dashboard')
         assert_selector('tbody tr', count: 6)
         expect(page).to have_text(@res1.title)
@@ -580,8 +563,7 @@ RSpec.feature 'AdminDashboard', type: :feature do
       it 'selects journal field by default', js: true do
         visit root_path
         click_button 'Datasets'
-        # click_link 'Admin dashboard
-        visit stash_url_helpers.admin_dashboard_path
+        click_link 'Admin dashboard'
         expect(find('#journal')).to be_checked
         expect(find('thead')).to have_text('Journal')
       end
@@ -589,8 +571,7 @@ RSpec.feature 'AdminDashboard', type: :feature do
       it 'shows sponsor admins dropdown for their journals', js: true do
         visit root_path
         click_button 'Datasets'
-        # click_link 'Admin dashboard
-        visit stash_url_helpers.admin_dashboard_path
+        click_link 'Admin dashboard'
         expect(page).to have_text('Admin dashboard')
         expect(page).to have_select('filter-journal')
         expect(page).to have_selector('#filter-journal option', count: 4)
@@ -599,8 +580,7 @@ RSpec.feature 'AdminDashboard', type: :feature do
       it 'filters by journal', js: true do
         visit root_path
         click_button 'Datasets'
-        # click_link 'Admin dashboard
-        visit stash_url_helpers.admin_dashboard_path
+        click_link 'Admin dashboard'
         expect(page).to have_text('Admin dashboard')
         select(@journal.title, from: 'filter-journal')
         click_button('Apply')
@@ -634,8 +614,7 @@ RSpec.feature 'AdminDashboard', type: :feature do
 
         visit root_path
         click_button 'Datasets'
-        # click_link 'Admin dashboard
-        visit stash_url_helpers.admin_dashboard_path
+        click_link 'Admin dashboard'
         expect(page).to have_text('Admin dashboard')
         expect(page).to have_text(@res1.title)
         expect(page).not_to have_text(res2.title)
@@ -644,8 +623,7 @@ RSpec.feature 'AdminDashboard', type: :feature do
       it 'selects and displays funders and awards field by default', js: true do
         visit root_path
         click_button 'Datasets'
-        # click_link 'Admin dashboard
-        visit stash_url_helpers.admin_dashboard_path
+        click_link 'Admin dashboard'
         expect(find('#funders')).to be_checked
         expect(find('#awards')).to be_checked
         expect(find('thead')).to have_text('Grant funders')

--- a/spec/features/stash_engine/admin_paths_spec.rb
+++ b/spec/features/stash_engine/admin_paths_spec.rb
@@ -126,14 +126,14 @@ RSpec.feature 'AdminPaths', type: :feature do
       sign_in(create(:user, role: 'admin', role_object: tenant, tenant_id: 'ucop'))
       visit stash_url_helpers.publication_updater_path
       # User redirected
-      expect(page).to have_text('My datasets')
+      expect(page).to have_text('Admin dashboard')
     end
 
     it 'is not accessible by dryad admins' do
       sign_in(create(:user,  role: 'admin'))
       visit stash_url_helpers.publication_updater_path
       # User redirected
-      expect(page).to have_text('My datasets')
+      expect(page).to have_text('Admin dashboard')
     end
 
     it 'is accessible by curators' do
@@ -191,7 +191,7 @@ RSpec.feature 'AdminPaths', type: :feature do
       sign_in(create(:user, role: 'admin', role_object: tenant, tenant_id: 'ucop'))
       visit stash_url_helpers.user_admin_path
       # User redirected
-      expect(page).to have_text('My datasets')
+      expect(page).to have_text('Admin dashboard')
     end
 
     it 'is not accessible by tenant curators' do
@@ -199,7 +199,7 @@ RSpec.feature 'AdminPaths', type: :feature do
       sign_in(create(:user, role: 'curator', role_object: tenant, tenant_id: 'ucop'))
       visit stash_url_helpers.user_admin_path
       # User redirected
-      expect(page).to have_text('My datasets')
+      expect(page).to have_text('Admin dashboard')
     end
 
     it 'is accessible by dryad admins' do
@@ -222,7 +222,7 @@ RSpec.feature 'AdminPaths', type: :feature do
       sign_in(create(:user, role: 'admin', role_object: tenant, tenant_id: 'ucop'))
       visit stash_url_helpers.tenant_admin_path
       # User redirected
-      expect(page).to have_text('My datasets')
+      expect(page).to have_text('Admin dashboard')
     end
 
     it 'is not accessible by tenant curators' do
@@ -230,7 +230,7 @@ RSpec.feature 'AdminPaths', type: :feature do
       sign_in(create(:user, role: 'curator', role_object: tenant, tenant_id: 'ucop'))
       visit stash_url_helpers.tenant_admin_path
       # User redirected
-      expect(page).to have_text('My datasets')
+      expect(page).to have_text('Admin dashboard')
     end
 
     it 'is accessible by dryad admins' do
@@ -253,7 +253,7 @@ RSpec.feature 'AdminPaths', type: :feature do
       sign_in(create(:user, role: 'admin', role_object: tenant, tenant_id: 'ucop'))
       visit stash_url_helpers.journal_admin_path
       # User redirected
-      expect(page).to have_text('My datasets')
+      expect(page).to have_text('Admin dashboard')
     end
 
     it 'is not accessible by tenant curators' do
@@ -261,7 +261,7 @@ RSpec.feature 'AdminPaths', type: :feature do
       sign_in(create(:user, role: 'curator', role_object: tenant, tenant_id: 'ucop'))
       visit stash_url_helpers.journal_admin_path
       # User redirected
-      expect(page).to have_text('My datasets')
+      expect(page).to have_text('Admin dashboard')
     end
 
     it 'is accessible by dryad admins' do
@@ -284,7 +284,7 @@ RSpec.feature 'AdminPaths', type: :feature do
       sign_in(create(:user, role: 'admin', role_object: tenant, tenant_id: 'ucop'))
       visit stash_url_helpers.publisher_admin_path
       # User redirected
-      expect(page).to have_text('My datasets')
+      expect(page).to have_text('Admin dashboard')
     end
 
     it 'is not accessible by tenant curators' do
@@ -292,7 +292,7 @@ RSpec.feature 'AdminPaths', type: :feature do
       sign_in(create(:user, role: 'curator', role_object: tenant, tenant_id: 'ucop'))
       visit stash_url_helpers.publisher_admin_path
       # User redirected
-      expect(page).to have_text('My datasets')
+      expect(page).to have_text('Admin dashboard')
     end
 
     it 'is accessible by dryad admins' do
@@ -315,14 +315,14 @@ RSpec.feature 'AdminPaths', type: :feature do
       sign_in(create(:user, role: 'admin', role_object: tenant, tenant_id: 'ucop'))
       visit stash_url_helpers.status_dashboard_path
       # User redirected
-      expect(page).to have_text('My datasets')
+      expect(page).to have_text('Admin dashboard')
     end
 
     it 'is not accessible by curators' do
       sign_in(create(:user, role: 'curator'))
       visit stash_url_helpers.status_dashboard_path
       # User redirected
-      expect(page).to have_text('My datasets')
+      expect(page).to have_text('Admin dashboard')
     end
 
     it 'is accessible by super users', js: true do
@@ -346,14 +346,14 @@ RSpec.feature 'AdminPaths', type: :feature do
       sign_in(create(:user, role: 'admin', role_object: tenant, tenant_id: 'ucop'))
       visit stash_url_helpers.submission_queue_path
       # User redirected
-      expect(page).to have_text('My datasets')
+      expect(page).to have_text('Admin dashboard')
     end
 
     it 'is not accessible by curators' do
       sign_in(create(:user, role: 'curator'))
       visit stash_url_helpers.submission_queue_path
       # User redirected
-      expect(page).to have_text('My datasets')
+      expect(page).to have_text('Admin dashboard')
     end
 
     it 'is accessible by super users', js: true do
@@ -376,14 +376,14 @@ RSpec.feature 'AdminPaths', type: :feature do
       sign_in(create(:user, role: 'admin', role_object: tenant, tenant_id: 'ucop'))
       visit stash_url_helpers.zenodo_queue_path
       # User redirected
-      expect(page).to have_text('My datasets')
+      expect(page).to have_text('Admin dashboard')
     end
 
     it 'is not accessible by curators' do
       sign_in(create(:user, role: 'curator'))
       visit stash_url_helpers.zenodo_queue_path
       # User redirected
-      expect(page).to have_text('My datasets')
+      expect(page).to have_text('Admin dashboard')
     end
 
     it 'is accessible by super users' do

--- a/spec/requests/stash_engine/sessions_controller_spec.rb
+++ b/spec/requests/stash_engine/sessions_controller_spec.rb
@@ -8,7 +8,7 @@ module StashEngine
 
         response_code = post '/stash/sessions/sso', params: { 'tenant_id' => 'dryad_ip' }
         expect(response_code).to eql(302) # redirect
-        expect(response.headers['Location']).to include('/stash/dashboard')
+        expect(response.headers['Location']).to include('/stash/choose_dashboard')
       end
 
       it 'blocks user from non-allowed IP address' do


### PR DESCRIPTION
Closes https://github.com/datadryad/dryad-product-roadmap/issues/3590

In addition to removing the returnURL when it was set to the user dashboard in some instances for curators (inexplicable!) this sets the default dashboard page to the admin dashboard for all admins, fixes a missing target_page redirect, and swaps some other ways of going back to a URL to use the target_page session variable, for tidiness.