### PR TITLE
Related works style fix

### DIFF
--- a/app/assets/stylesheets/scss/_landing.scss
+++ b/app/assets/stylesheets/scss/_landing.scss
@@ -358,10 +358,14 @@
 
     li {
       margin:.25ch 0;
-      padding: 0;
-
-      i {
-        margin-right: .5ch;
+      padding-left: 2ch;
+      a {
+        overflow-wrap: anywhere;
+        word-break: break-all;
+        i {
+          margin-left: -2ch;
+          margin-right: .5ch;
+        }
       }
     }
   }


### PR DESCRIPTION
Curators have pointed out the related works on the landing page can break weird on chrome, specifically, putting the icon on its own line. This fixes that and spruces the display up a bit across browsers.