### PR TITLE
Admin tenant removal fixes

### DIFF
--- a/app/controllers/stash_engine/sessions_controller.rb
+++ b/app/controllers/stash_engine/sessions_controller.rb
@@ -14,6 +14,7 @@ module StashEngine
 
     # this is the place omniauth calls back for shibboleth logins
     def callback
+      current_user.roles.tenant_roles.delete_all
       current_user.update(tenant_id: params[:tenant_id])
       do_redirect
     end
@@ -123,6 +124,7 @@ module StashEngine
         tenant = StashEngine::Tenant.find(params[:tenant_id])
         case tenant&.authentication&.strategy
         when 'author_match'
+          current_user.roles.tenant_roles.delete_all
           current_user.update(tenant_id: tenant.id)
           do_redirect
         when 'ip_address'
@@ -275,6 +277,7 @@ module StashEngine
         net = IPAddr.new(range)
         next unless net.include?(IPAddr.new(request.remote_ip))
 
+        current_user.roles.tenant_roles.delete_all
         current_user.update(tenant_id: tenant.id)
         do_redirect
         return nil # adding nil here to jump out of loop and return early since rubocop sucks & requires a return value
@@ -299,6 +302,7 @@ module StashEngine
     def set_default_tenant
       return unless current_user.present?
 
+      current_user.roles.tenant_roles.delete_all
       current_user.update(tenant_id: APP_CONFIG.default_tenant)
     end
   end

--- a/app/controllers/stash_engine/sessions_controller.rb
+++ b/app/controllers/stash_engine/sessions_controller.rb
@@ -111,6 +111,7 @@ module StashEngine
 
     # no partner, so set as generic dryad tenant without membership benefits
     def no_partner
+      session[:target_page] = params[:target_page] if params[:target_page]
       set_default_tenant
       do_redirect
     end

--- a/app/views/stash_engine/shared/_change_tenant.html.erb
+++ b/app/views/stash_engine/shared/_change_tenant.html.erb
@@ -26,6 +26,7 @@
     <br/><br/>
     <p>Is your institution not a member of Dryad?</p>
     <%= form_with(url: no_partner_path, method: :post) do |f| %>
+      <% if @target_page %><input type="hidden" name="target_page" value="<%= @target_page %>"><% end %>
       <%= f.button type: 'submit', class: 'o-button__plain-text7' do %>
          <i class="fa fa-minus-circle" aria-hidden="true"></i> Remove member affiliation (<%= current_tenant.short_name %>)
       <% end %>

--- a/app/views/stash_engine/user_admin/edit.js.erb
+++ b/app/views/stash_engine/user_admin/edit.js.erb
@@ -7,6 +7,6 @@ when 'tenant_id'
 end %>";
 <% if @field == 'tenant_id' %>
 $('#edit_roles_form').html("<%= escape_javascript(render partial: 'admin_role_form', locals: { user: @user }) %>");
+document.getElementById('user_role_<%= @user.id %>').innerHTML = "<%= @user.roles.present? ? @user.roles.map{|r| "#{r.role_object_type&.delete_prefix("StashEngine::")&.sub('JournalOrganization', 'Publisher')} #{r.role}".strip.capitalize }.join(", ") : "User" %>";
 <% end %>
-
 document.getElementById('genericModalDialog').close();


### PR DESCRIPTION
Fix some bugs when removing tenants from users 
- routing correctly when doing a self-removal of a tenant
- remove existing tenant roles when changing a tenant
- reflect the automatic removal of tenant roles that happens when a tenant is changed from the user admin screens in the UI