### PR TITLE
Send published notices on sandbox

### DIFF
--- a/config/app_config.yml
+++ b/config/app_config.yml
@@ -322,6 +322,7 @@ stage: &STAGE
   feedback_email_from: no-reply-dryad-stg@datadryad.org
   google_analytics_id: UA-145629338-3
   matomo_analytics_id: datadryad-stg
+  send_journal_published_notices: true
   repository:
     domain: https://merritt-stage.cdlib.org
     endpoint: "http://mrtsword-stg.cdlib.org:39001/mrtsword/collection/cdl_dryadstg"


### PR DESCRIPTION
Update the sandbox environment (v3_stage) to enable sending of email messages to publishers. This allows better testing for ACS journals.

Note: I have updated the contents of the v3_stage database, so all journals now have an empty list of contacts, EXCEPT for ACS journals. This ensures that we're only sending sandbox notifications to the journals that have actually requested them.