### PR TITLE
Correct payment workflow for partner entities

### DIFF
--- a/app/controllers/stash_datacite/resources_controller.rb
+++ b/app/controllers/stash_datacite/resources_controller.rb
@@ -47,7 +47,7 @@ module StashDatacite
 
     def submission
       @resource.current_state = 'processing'
-      @resource.identifier.record_payment
+      @resource.identifier.record_payment unless @resource.identifier.publication_date.present?
       @resource.check_add_readme_file
       @resource.check_add_cedar_json
 

--- a/app/models/stash_engine/identifier.rb
+++ b/app/models/stash_engine/identifier.rb
@@ -284,9 +284,8 @@ module StashEngine
     end
 
     def record_payment
-      # once we have assigned payment to an entity, keep that entity,
-      # unless it was a journal that the submission is no longer affiliated with
-      # (in general, we don't want to tell a user their payment is covered and then later take it away)
+      # once we have assigned payment to an entity, keep that entity
+      # unless it was a journal that was removed or a new journal covers the dpc
       clear_payment_for_changed_journal
       return if payment_type.present? && payment_type != 'unknown'
 
@@ -637,7 +636,7 @@ module StashEngine
 
     def clear_payment_for_changed_journal
       return unless payment_type.present?
-      return unless payment_type.include?('journal')
+      return unless payment_type.include?('journal') || journal&.will_pay?
       return if payment_id == journal&.single_issn
 
       self.payment_type = nil

--- a/lib/stash/import/crossref.rb
+++ b/lib/stash/import/crossref.rb
@@ -77,8 +77,8 @@ module Stash
       def populate_pub_update!
         return nil unless @sm.present? && @resource.present?
 
-        populate_publication_issn
         populate_publication_name
+        populate_publication_issn
         @resource.reload
       end
 
@@ -362,35 +362,32 @@ module Stash
         @resource.publication_date = date_parts_to_date(publication_date)
       end
 
-      def populate_publication_issn
-        return unless @sm['ISSN'].present? && @sm['ISSN'].first.present?
-
-        # We only want to save the ISSN if we receive one that we already know about. Otherwise,
-        # it is likely an alternative ISSN for a journal where we have a different primary ISSN
-        # (most journals have separate ISSNs for print, online, linking)
-        # In that case, we will save the journal name, and look up the correct ISSN from the name.
-        return unless StashEngine::Journal.find_by_issn(@sm['ISSN'].first).present?
-
-        datum = StashEngine::ResourcePublication.find_or_initialize_by(resource_id: @resource.id)
-
-        return if @resource.journal&.id == StashEngine::Journal.find_by_issn(@sm['ISSN'].first).id
-
-        datum.publication_issn = @sm['ISSN'].first
-        datum.save
-      end
-
       def populate_publication_name
         return unless publisher.present?
-        # We do not want to overwrite correct journal names with nonstandardized names for the same journal
-        # only update the journal name if the dataset is not already set with this journal
+        # We do not want to overwrite correct journal names with nonstandardized names
+        # only update the journal name if the dataset is not already set with this journal ISSN
         return if @sm['ISSN'].present? && @sm['ISSN'].first.present? && @resource.journal.present? &&
           @resource.journal.id == StashEngine::Journal.find_by_issn(@sm['ISSN'].first)&.id
 
         datum = StashEngine::ResourcePublication.find_or_initialize_by(resource_id: @resource.id)
         datum.publication_name = publisher
-        # If the publication name matches an existing journal, populate/update the ISSN
         journal = StashEngine::Journal.find_by_title(publisher)
-        datum.publication_issn = journal.single_issn if journal.present?
+        # If the publication name matches an existing journal, populate/update the ISSN
+        # Otherwise, remove existing ISSNs that do not match the imported journal name
+        datum.publication_issn = journal.present? ? journal.single_issn : nil
+        datum.save
+      end
+
+      def populate_publication_issn
+        return unless @sm['ISSN'].present? && @sm['ISSN'].first.present?
+
+        # Do not change the ISSN if one for this journal is already set
+        return if @resource.journal&.id == StashEngine::Journal.find_by_issn(@sm['ISSN'].first).id
+
+        # First look up the ISSN from the journal name (populate_publication_name).
+        # If we do not know the ISSN, save it for quarterly checking and addition to our db
+        datum = StashEngine::ResourcePublication.find_or_initialize_by(resource_id: @resource.id)
+        datum.publication_issn = @sm['ISSN'].first
         datum.save
       end
 


### PR DESCRIPTION
Ensures journals overwrite any other entities paying DPCs on submission

Also removes publication_issn journal ISSNs when a Crossref match does not match what is recorded in either ISSN or in name (verifying the title, mentioned in https://github.com/datadryad/dryad-product-roadmap/issues/2601). This is pretty safe to do now that second ISSNs for existing journals have been backfilled.

Closes https://github.com/datadryad/dryad-product-roadmap/issues/2346