### PR TITLE
Retain metadata of abandoned datasets when files are deleted

### DIFF
--- a/lib/tasks/stash_engine_tasks.rake
+++ b/lib/tasks/stash_engine_tasks.rake
@@ -147,7 +147,7 @@ namespace :identifiers do
     
     StashEngine::Identifier.where(pub_state: [nil, 'withdrawn', 'unpublished']).find_each do |i|
       next if i.date_first_published.present?
-      next unless %w[in_progress withdrawn].include?(i.latest_resource&.current_curation_status)      
+      next unless %w[in_progress withdrawn].include?(i.latest_resource&.current_curation_status)
       next if i.latest_resource.curation_activities&.map(&:note)&.include?(removed_files_note)
 
       # Double-check whether it was ever published -- even though we checked the date_first_published,

--- a/lib/tasks/stash_engine_tasks.rake
+++ b/lib/tasks/stash_engine_tasks.rake
@@ -144,7 +144,7 @@ namespace :identifiers do
     end
 
     removed_files_note = 'remove_abandoned_datasets CRON - removing data files from abandoned dataset'
-    
+
     StashEngine::Identifier.where(pub_state: [nil, 'withdrawn', 'unpublished']).find_each do |i|
       next if i.date_first_published.present?
       next unless %w[in_progress withdrawn].include?(i.latest_resource&.current_curation_status)
@@ -178,7 +178,7 @@ namespace :identifiers do
             status: 'withdrawn',
             note: removed_files_note
           )
-          
+
           # Perform the actual removal
           i.resources.each do |r|
             # Delete files from temp upload directory, if it exists

--- a/lib/tasks/stash_engine_tasks.rake
+++ b/lib/tasks/stash_engine_tasks.rake
@@ -143,7 +143,7 @@ namespace :identifiers do
       log ' ##### remove_abandoned_datasets -- Deleting old versions of datasets that are still in progress'
     end
 
-    removed_files_note='remove_abandoned_datasets CRON - removing data files from abandoned dataset'
+    removed_files_note = 'remove_abandoned_datasets CRON - removing data files from abandoned dataset'
     
     StashEngine::Identifier.where(pub_state: [nil, 'withdrawn', 'unpublished']).find_each do |i|
       next if i.date_first_published.present?

--- a/lib/tasks/stash_engine_tasks.rake
+++ b/lib/tasks/stash_engine_tasks.rake
@@ -143,7 +143,7 @@ namespace :identifiers do
       log ' ##### remove_abandoned_datasets -- Deleting old versions of datasets that are still in progress'
     end
 
-    removed_files_note="remove_abandoned_datasets CRON - removing data files from abandoned dataset"
+    removed_files_note='remove_abandoned_datasets CRON - removing data files from abandoned dataset'
     
     StashEngine::Identifier.where(pub_state: [nil, 'withdrawn', 'unpublished']).find_each do |i|
       next if i.date_first_published.present?

--- a/lib/tasks/stash_engine_tasks.rake
+++ b/lib/tasks/stash_engine_tasks.rake
@@ -197,7 +197,7 @@ namespace :identifiers do
               perm_bucket.delete_dir(s3_key: "v3/#{s3_dir}")
             end
 
-            # Important! Retain the metadata for this dataset, so curators can determine what happened to it       
+            # Important! Retain the metadata for this dataset, so curators can determine what happened to it
           end
         end
       end


### PR DESCRIPTION
Closes https://github.com/datadryad/dryad-product-roadmap/issues/3705

In addition to removing the "destroy" statement, we don't want to re-process the dataset every time this runs. So the curation activities are checked to see whether the files have already been deleted.