### PR TITLE
Update rubocop config to ignore Ruby and gems

### DIFF
--- a/.rubocop.yml
+++ b/.rubocop.yml
@@ -127,10 +127,6 @@ Style/NumericPredicate:
 Style/SafeNavigation:
   Enabled: false
 
-# SafeNavigation is always good, even in a long chain
-Style/SafeNavigationChainLength:
-  Enabled: false
-
 # Unclear why it's a good idea to give parameters semantically meaningless names
 Style/SingleLineBlockParams:
   Enabled: false

--- a/.rubocop.yml
+++ b/.rubocop.yml
@@ -12,6 +12,7 @@ AllCops:
     - 'ui-library/**/*'
     - 'node_modules/**/*'
     - 'tmp/**/*'
+    - 'ruby/**/*'
   # Suppress complaints about post-2.0 syntax
   TargetRubyVersion: 3.0
 
@@ -124,6 +125,10 @@ Style/NumericPredicate:
 
 # The semantics of `foo&.bar` are a lot less interchangeable with `foo && foo.bar` than RuboCop thinks
 Style/SafeNavigation:
+  Enabled: false
+
+# SafeNavigation is always good, even in a long chain
+Style/SafeNavigationChainLength:
   Enabled: false
 
 # Unclear why it's a good idea to give parameters semantically meaningless names


### PR DESCRIPTION
In our deployed servers, Ruby is installed within the Dryad directory tree. (This is probably a bad idea, but we can fix it another day -- see ticket https://github.com/datadryad/dryad-product-roadmap/issues/3748)

Rubocop fails spectacularly when running over the source of Ruby and associated gems, because each gem is built with a different style, and expects a different version of Rubocop.

This disables Rubocop from running on the Ruby directories.