### PR TITLE
Fix data migrations

### DIFF
--- a/app/models/stash_engine/identifier.rb
+++ b/app/models/stash_engine/identifier.rb
@@ -203,8 +203,8 @@ module StashEngine
       resources.reverse.each do |r|
         next unless r.current_editor_id
 
-        user = StashEngine::User.find(r.current_editor_id)
-        return user if user.min_curator?
+        user = StashEngine::User.find_by(id: r.current_editor_id)
+        return user if user&.min_curator?
       end
       nil
     end

--- a/db/data/20240719144223_populate_last_status_date.rb
+++ b/db/data/20240719144223_populate_last_status_date.rb
@@ -2,18 +2,17 @@
 
 class PopulateLastStatusDate < ActiveRecord::Migration[7.0]
   def up
-    StashEngine::Resource.find_in_batches(batch_size: 1000) do |batch|
-      batch.each do |res|
-        status = res.current_curation_status
-        date = res.last_curation_activity.created_at
+    StashEngine::Resource.joins(:process_date).where(process_date: {delete_calculation_date: nil}).find_each do |res|
+      status = res.current_curation_status
+      date = res.last_curation_activity&.created_at
+      next unless date.present?
 
-        res.curation_activities.map { |q| [q.status, q.created_at] }.sort { |a, b| b[1] <=> a[1] }.each do |item|
-          break if status != item[0]
-          date = item[1]
-        end
-        res.process_date.update_columns(last_status_date: date, delete_calculation_date: date)
-        res.identifier.process_date.update_columns(delete_calculation_date: date)
+      res.curation_activities.map { |q| [q.status, q.created_at] }.sort { |a, b| b[1] <=> a[1] }.each do |item|
+        break if status != item[0]
+        date = item[1]
       end
+      res&.process_date.update_columns(last_status_date: date, delete_calculation_date: date)
+      res&.identifier&.process_date.update_columns(delete_calculation_date: date)
     end
   end
 

--- a/db/data/20240914163619_resource_roles.rb
+++ b/db/data/20240914163619_resource_roles.rb
@@ -2,9 +2,10 @@
 
 class ResourceRoles < ActiveRecord::Migration[7.0]
   def up
-    StashEngine::Identifier.joins(:latest_resource).find_each do |idt|
-      creator = idt.resources.first.curation_activities.first.user_id
-      submitter = idt.latest_resource.user_id
+    StashEngine::Resource.latest_per_dataset.left_outer_joins(:roles).where.not(roles: {role: 'submitter'}).distinct.find_each do |res|
+      idt = res.identifier
+      submitter = res.user_id
+      creator = idt.resources.first.curation_activities.first.user_id  
       curator = idt.most_recent_curator&.id || nil
       idt.resources.update_all(user_id: curator)
       idt.resources.each do |r|


### PR DESCRIPTION
The date data migration keeps running into problems on prod because of incomplete data (so far missing identifiers, missing last_curation_activity), and then when it restarts it starts completely over (I tried deleting resources with no identifier and restarting, hopefully that wasn't a bad decision). This fixes these issues, only processing resources that haven't already been done and checking for an association's existence before trying to update it.

The roles data migration has a problem with recorded user ids no longer matching users found