### PR TITLE
Improve robustness of auto-withdraw functionality

### DIFF
--- a/app/mailers/stash_engine/user_mailer.rb
+++ b/app/mailers/stash_engine/user_mailer.rb
@@ -25,7 +25,7 @@ module StashEngine
 
       # Don't send if this was an abandoned dataset
       removed_files_note = 'remove_abandoned_datasets CRON - removing data files from abandoned dataset'
-      return if resource.curation_activities&.map(&:note)&.include?(removed_files_note) 
+      return if resource.curation_activities&.map(&:note)&.include?(removed_files_note)
 
       assign_variables(resource)
       return unless @user.present? && user_email(@user).present?

--- a/app/mailers/stash_engine/user_mailer.rb
+++ b/app/mailers/stash_engine/user_mailer.rb
@@ -23,6 +23,10 @@ module StashEngine
     def user_journal_withdrawn(resource, status)
       return unless status == 'withdrawn'
 
+      # Don't send if this was an abandoned dataset
+      removed_files_note = 'remove_abandoned_datasets CRON - removing data files from abandoned dataset'
+      return if resource.curation_activities&.map(&:note)&.include?(removed_files_note) 
+
       assign_variables(resource)
       return unless @user.present? && user_email(@user).present?
 

--- a/app/services/stash_engine/abandoned_dataset_service.rb
+++ b/app/services/stash_engine/abandoned_dataset_service.rb
@@ -92,6 +92,9 @@ module StashEngine
         .where('stash_engine_process_dates.delete_calculation_date <= ?', 1.year.ago.end_of_day)
         .each do |resource|
 
+        # Do not withdraw if this dataset has ever been published
+        next if %w[published embargoed].include?(resource.identifier&.calculated_pub_state)
+
         reminder_flag = 'withdrawn_email_notice'
         last_reminder = resource.curation_activities.where('note LIKE ?', "%#{reminder_flag}%")&.last
         next if last_reminder.present?


### PR DESCRIPTION
Protection against withdrawing a dataset that is published, and needs to remain published. (See example in 10.5061/dryad.184gk80)

Protection against sending journal emails to authors of abandoned datasets (See example in doi:10.5061/dryad.3xsj3txnv
)