### PR TITLE
Change research domain input from datalist to select

### DIFF
--- a/app/javascript/react/components/MetadataEntry/ResearchDomain.jsx
+++ b/app/javascript/react/components/MetadataEntry/ResearchDomain.jsx
@@ -43,22 +43,21 @@ function ResearchDomain({
             Research domain
           </label>
           <Field
-            type="text"
+            as="select"
             name="fos_subjects"
             id={`fos_subjects__${frmSuffix}`}
             list={`fos_subject__${frmSuffix}`}
-            className="fos-subjects js-change-submit c-input__text"
+            className="fos-subjects js-change-submit c-input__select"
             onBlur={() => { // formRef.current.handleSubmit();
               formik.handleSubmit();
             }}
-          />
-          <datalist id={`fos_subject__${frmSuffix}`} className="c-input__text">
+          >
             {subjectList.map((subj, index) => {
               // key made from subj + count of preceding duplicates
               const key = subj + subjectList.slice(0, index).filter((s) => s === subj).length;
               return <option value={subj} key={key}>{subj}</option>;
             })}
-          </datalist>
+          </Field>
         </Form>
       )}
     </Formik>

--- a/spec/features/stash_datacite/new_collection_spec.rb
+++ b/spec/features/stash_datacite/new_collection_spec.rb
@@ -39,6 +39,7 @@ RSpec.feature 'NewCollection', type: :feature do
   context :form_submission, js: true do
 
     before(:each) do
+      StashDatacite::Subject.create(subject: 'Agricultural biotechnology', subject_scheme: 'fos')
       create_datasets
       start_new_collection
     end
@@ -53,7 +54,7 @@ RSpec.feature 'NewCollection', type: :feature do
     it 'fills in submission form', js: true do
 
       # subjects
-      fill_in 'fos_subjects', with: 'Agricultural biotechnology'
+      select 'Agricultural biotechnology', from: 'Research domain'
 
       # ##############################
       # Title

--- a/spec/features/stash_datacite/new_dataset_spec.rb
+++ b/spec/features/stash_datacite/new_dataset_spec.rb
@@ -191,13 +191,6 @@ RSpec.feature 'NewDataset', type: :feature do
       expect(page).to have_text('you will receive an invoice')
     end
 
-    it 'fills in a Field of Science subject', js: true do
-      fill_required_metadata
-      select 'Agricultural biotechnology', from: 'Research domain'
-      navigate_to_review
-      expect(page).to have_text('Agricultural biotechnology', wait: 5)
-    end
-
   end
 
 end

--- a/spec/features/stash_datacite/new_dataset_spec.rb
+++ b/spec/features/stash_datacite/new_dataset_spec.rb
@@ -41,13 +41,14 @@ RSpec.feature 'NewDataset', type: :feature do
   context :form_submission, js: true do
 
     before(:each) do
+      StashDatacite::Subject.create(subject: 'Agricultural biotechnology', subject_scheme: 'fos')
       start_new_dataset
     end
 
     it 'fills in submission form', js: true do
 
       # subjects
-      fill_in 'fos_subjects', with: 'Agricultural biotechnology'
+      select 'Agricultural biotechnology', from: 'Research domain'
 
       # ##############################
       # Title
@@ -192,28 +193,9 @@ RSpec.feature 'NewDataset', type: :feature do
 
     it 'fills in a Field of Science subject', js: true do
       fill_required_metadata
-      fill_in 'fos_subjects', with: 'Agricultural biotechnology'
+      select 'Agricultural biotechnology', from: 'Research domain'
       navigate_to_review
       expect(page).to have_text('Agricultural biotechnology', wait: 5)
-    end
-
-    it 'fills in a Field of Science subject that is not official', js: true do
-      name = Array.new(3) { Faker::Lorem.word }.join(' ')
-      fill_required_metadata
-      fill_in 'fos_subjects', with: name
-      navigate_to_review
-      expect(page).to have_text(name, wait: 5)
-    end
-
-    it 'fills in a Field of Science subject and changes it and it keeps the latter', js: true do
-      name = Array.new(3) { Faker::Lorem.word }.join(' ')
-      fill_required_metadata
-      fill_in 'fos_subjects', with: name
-      fill_in_funder(name: 'Wiring Harness Solutions', value: '12XU')
-      fill_in 'fos_subjects', with: 'Agricultural biotechnology'
-      navigate_to_review
-      expect(page).to have_text('Agricultural biotechnology', wait: 5)
-      expect(page).not_to have_text(name, wait: 5)
     end
 
   end

--- a/spec/javascript/react/components/MetadataEntry/ResearchDomain.test.js
+++ b/spec/javascript/react/components/MetadataEntry/ResearchDomain.test.js
@@ -54,8 +54,7 @@ describe('ResearchDomain', () => {
     const resDomain = screen.getByLabelText('Research domain', {exact: false});
     expect(resDomain).toHaveValue(subject);
 
-    userEvent.clear(screen.getByLabelText('Research domain'));
-    userEvent.type(screen.getByLabelText('Research domain'), subjectList[20]);
+    await userEvent.selectOptions(screen.getByLabelText('Research domain'), subjectList[20]);
 
     await waitFor(() => expect(screen.getByLabelText('Research domain')).toHaveValue(subjectList[20]));
 


### PR DESCRIPTION
Closes https://github.com/datadryad/dryad-product-roadmap/issues/3759

Removed rspec tests checking the ability to enter arbitrary text for Research domain—it must be selected from a set list with this change.