### PR TITLE
Increase time for removing files from abandoned datasets

### DIFF
--- a/lib/tasks/stash_engine_tasks.rake
+++ b/lib/tasks/stash_engine_tasks.rake
@@ -164,7 +164,7 @@ namespace :identifiers do
         end
       end
 
-      if last_user_activity.present? && last_user_activity < 1.year.ago
+      if last_user_activity.present? && last_user_activity < 2.years.ago
         log "ABANDONED #{i.identifier} -- #{i.id} -- size #{i.latest_resource.size}"
 
         if dry_run

--- a/lib/tasks/stash_engine_tasks.rake
+++ b/lib/tasks/stash_engine_tasks.rake
@@ -164,8 +164,8 @@ namespace :identifiers do
         end
       end
 
-      # Only remove the files if two years have passed since the last user activity 
-      if last_user_activity.present? && last_user_activity < 2.years.ago 
+      # Only remove the files if two years have passed since the last user activity
+      if last_user_activity.present? && last_user_activity < 2.years.ago
         log "ABANDONED #{i.identifier} -- #{i.id} -- size #{i.latest_resource.size}"
 
         if dry_run

--- a/lib/tasks/stash_engine_tasks.rake
+++ b/lib/tasks/stash_engine_tasks.rake
@@ -164,7 +164,8 @@ namespace :identifiers do
         end
       end
 
-      if last_user_activity.present? && last_user_activity < 2.years.ago
+      # Only remove the files if two years have passed since the last user activity 
+      if last_user_activity.present? && last_user_activity < 2.years.ago 
         log "ABANDONED #{i.identifier} -- #{i.id} -- size #{i.latest_resource.size}"
 
         if dry_run


### PR DESCRIPTION
There were unexpected interactions between the automatic withdrawal process (`withdrawn_email_notice`) and the abandoned dataset process (`remove_abandoned_datasets`), which were causing data files to be deleted earlier than we had originally planned. This updates the abandonded dataset process to guarantee that the files will only be deleted after two years of inactivity (at least 1 year past the final notice of deletion).