### PR TITLE
Fix exceptions

### DIFF
--- a/app/controllers/stash_api/datasets_controller.rb
+++ b/app/controllers/stash_api/datasets_controller.rb
@@ -577,7 +577,12 @@ module StashApi
     end
 
     def duplicate_resource
-      nr = @resource.amoeba_dup
+      begin
+        nr = @resource.amoeba_dup
+      rescue ActiveRecord::RecordNotUnique
+        nr = @resource.identifier.latest_resource unless @resource.identifier.latest_resource_id == @resource.id
+        nr ||= @resource.amoeba_dup
+      end
       nr.curation_activities&.update_all(user_id: @user.id)
       nr.current_editor_id = @user.id
       nr.save!

--- a/app/controllers/stash_engine/dashboard_controller.rb
+++ b/app/controllers/stash_engine/dashboard_controller.rb
@@ -1,7 +1,7 @@
 module StashEngine
   class DashboardController < ApplicationController
-    before_action :require_login, only: :show
-    before_action :ensure_tenant, only: :show
+    before_action :require_login, only: %i[show user_datasets]
+    before_action :ensure_tenant, only: %i[show user_datasets]
     protect_from_forgery except: :user_datasets
 
     MAX_VALIDATION_TRIES = 5
@@ -25,8 +25,6 @@ module StashEngine
     def react_basics; end
 
     def user_datasets
-      return nil unless current_user.present?
-
       @page = params[:page] || '1'
       @page_size = params[:page_size] || '10'
       respond_to do |format|


### PR DESCRIPTION
A better fix for the user datasets exception (that doesn't, itself, cause an exception) and another attempt to catch the RecordNotUnique exception when starting a new dataset version (it's confusing that there are 2 'duplicate_resource' methods and hard to tell which is being used)