### PR TITLE
Fix problem with calculating curation stats

### DIFF
--- a/lib/tasks/stash_engine_tasks.rake
+++ b/lib/tasks/stash_engine_tasks.rake
@@ -1208,7 +1208,7 @@ namespace :curation_stats do
 
   desc 'Recalculate any curation stats from the past three days, not counting today'
   task update_recent: :environment do
-    (Time.now.utc.to_date - 4.days..Time.now.utc.to_date - 1.day).find_each do |date|
+    (Time.now.utc.to_date - 4.days..Time.now.utc.to_date - 1.day).each do |date|
       print '.'
       stats = StashEngine::CurationStats.find_or_create_by(date: date)
       stats.recalculate unless stats.created_at > 2.seconds.ago


### PR DESCRIPTION
Allow the loop to process correctly. `find_each` does not work over ranges.