### PR TITLE
Fix expandable elements sometimes not opening on first click

### DIFF
--- a/app/views/stash_datacite/authors/_show.html.erb
+++ b/app/views/stash_datacite/authors/_show.html.erb
@@ -60,13 +60,14 @@
 	  <script type="text/javascript">
 	  	document.getElementById('affiliation-list-button').addEventListener('click', (e) => {
 	  		const list = document.getElementById('affiliation-list')
+	  		const button = document.getElementById('affiliation-list-button')
 	  		if (list.hasAttribute('hidden')) {
-		  		e.target.setAttribute('aria-expanded', 'true')
+		  		button.setAttribute('aria-expanded', 'true')
 	  		} else {
-	  			e.target.setAttribute('aria-expanded', 'false')
+	  			button.setAttribute('aria-expanded', 'false')
 		  	}
-		  	e.target.lastElementChild.classList.toggle('fa-caret-down')
-		  	e.target.lastElementChild.classList.toggle('fa-caret-up')
+		  	button.lastElementChild.classList.toggle('fa-caret-down')
+		  	button.lastElementChild.classList.toggle('fa-caret-up')
 		  	list.toggleAttribute('hidden')
 	  	})
 	  	const openHash = () => {

--- a/app/views/stash_datacite/shared/_citations.html.erb
+++ b/app/views/stash_datacite/shared/_citations.html.erb
@@ -11,13 +11,14 @@
 <script type="text/javascript">
   const expandCitation = (e) => {
     const citation = document.getElementById('dataset-citation')
+    const button = document.getElementById('expand-citation')
     if (citation.hasAttribute('hidden')) {
-      e.target.setAttribute('aria-expanded', 'true')
+      button.setAttribute('aria-expanded', 'true')
     } else {
-      e.target.setAttribute('aria-expanded', 'false')
+      button.setAttribute('aria-expanded', 'false')
     }
-    e.target.lastElementChild.classList.toggle('fa-caret-down')
-    e.target.lastElementChild.classList.toggle('fa-caret-up')
+    button.lastElementChild.classList.toggle('fa-caret-down')
+    button.lastElementChild.classList.toggle('fa-caret-up')
     citation.toggleAttribute('hidden')
   }
   document.getElementById('expand-citation').addEventListener('click', expandCitation)


### PR DESCRIPTION
Very occasionally the citation and affiliations do not expand on the first click. This fixes this issue.