### PR TITLE
Fix role bug in users merge

### DIFF
--- a/app/models/stash_engine/user.rb
+++ b/app/models/stash_engine/user.rb
@@ -150,7 +150,7 @@ module StashEngine
       Resource.where(user_id: other_user.id).update_all(user_id: id)
       Resource.where(current_editor_id: other_user.id).update_all(current_editor_id: id)
       Role.where(user_id: other_user.id).each do |r|
-        if Role.find_by(user_id: id, role_object: r.role_object)
+        if Role.find_by(user_id: id, role_object: r.role_object, role: r.role)
           r.delete
         else
           r.update(user_id: id)


### PR DESCRIPTION
Merging users was removing the user from the submitter role if they already had the creator role on the same dataset