### PR TITLE
Allow publications/journals of different work types per dataset 

### DIFF
--- a/app/controllers/stash_engine/admin_dashboard_controller.rb
+++ b/app/controllers/stash_engine/admin_dashboard_controller.rb
@@ -269,7 +269,7 @@ module StashEngine
       journal_ids = @filters.dig(:journal, :value)&.to_i
       journal_ids = (@journal_limit.map(&:id).include?(journal_ids) ? journal_ids : @journal_limit.map(&:id)) if @journal_limit.present?
 
-      @datasets = @datasets.joins(:journal).where('stash_engine_journals.id': journal_ids) if journal_ids.present?
+      @datasets = @datasets.joins(:journals).where('stash_engine_journals.id': journal_ids) if journal_ids.present?
     end
 
     def sponsor_filter
@@ -278,7 +278,7 @@ module StashEngine
       sponsor_ids = @filters[:sponsor]&.to_i
       sponsor_ids = (@sponsor_limit.map(&:id).include?(sponsor_ids) ? sponsor_ids : @sponsor_limit.map(&:id)) if @sponsor_limit.present?
 
-      @datasets = @datasets.joins(:journal).where('stash_engine_journals.sponsor_id': sponsor_ids) if sponsor_ids.present?
+      @datasets = @datasets.joins(:journals).where('stash_engine_journals.sponsor_id': sponsor_ids) if sponsor_ids.present?
     end
 
     def funder_filter

--- a/app/controllers/stash_engine/admin_datasets_controller.rb
+++ b/app/controllers/stash_engine/admin_datasets_controller.rb
@@ -16,7 +16,11 @@ module StashEngine
         )
       when 'publication'
         authorize %i[stash_engine admin_datasets], :data_popup?
-        @publication = StashEngine::ResourcePublication.find_or_create_by(resource_id: @identifier.latest_resource.id)
+        @publication = StashEngine::ResourcePublication.find_or_create_by(resource_id: @identifier.latest_resource.id, pub_type: :primary_article)
+      when 'preprint'
+        authorize %i[stash_engine admin_datasets], :data_popup?
+        @publication = StashEngine::ResourcePublication.find_or_create_by(resource_id: @identifier.latest_resource.id, pub_type: :preprint)
+        @field = 'publication'
       when 'data'
         authorize %i[stash_engine admin_datasets], :data_popup?
         setup_internal_data_list

--- a/app/models/stash_engine/identifier.rb
+++ b/app/models/stash_engine/identifier.rb
@@ -354,6 +354,14 @@ module StashEngine
       latest_resource&.manuscript
     end
 
+    def preprint_issn
+      latest_resource&.resource_preprint&.publication_issn
+    end
+
+    def preprint_server
+      latest_resource&.resource_preprint&.publication_name
+    end
+
     def automatic_ppr?
       return false unless latest_manuscript.present?
       return false if has_accepted_manuscript?

--- a/app/models/stash_engine/resource.rb
+++ b/app/models/stash_engine/resource.rb
@@ -54,6 +54,7 @@ module StashEngine
     has_one :process_date, as: :processable, dependent: :destroy
     has_many :resource_publications, dependent: :destroy
     has_one :resource_publication, -> { primary_article }, dependent: :destroy
+    has_one :resource_preprint, -> { preprint }, class_name: 'StashEngine::ResourcePublication', dependent: :destroy
     has_many :authors, class_name: 'StashEngine::Author', dependent: :destroy
     has_many :generic_files, class_name: 'StashEngine::GenericFile', dependent: :destroy
     has_many :data_files, class_name: 'StashEngine::DataFile', dependent: :destroy

--- a/app/models/stash_engine/resource.rb
+++ b/app/models/stash_engine/resource.rb
@@ -52,7 +52,8 @@ module StashEngine
     # ------------------------------------------------------------
     # Relations
     has_one :process_date, as: :processable, dependent: :destroy
-    has_one :resource_publication, dependent: :destroy
+    has_many :resource_publications, dependent: :destroy
+    has_one :resource_publication, -> { primary_article }, dependent: :destroy
     has_many :authors, class_name: 'StashEngine::Author', dependent: :destroy
     has_many :generic_files, class_name: 'StashEngine::GenericFile', dependent: :destroy
     has_many :data_files, class_name: 'StashEngine::DataFile', dependent: :destroy
@@ -100,6 +101,8 @@ module StashEngine
     has_many :alternate_identifiers, class_name: 'StashDatacite::AlternateIdentifier', dependent: :destroy
     has_many :formats, class_name: 'StashDatacite::Format', dependent: :destroy
     has_many :processor_results, class_name: 'StashEngine::ProcessorResult', dependent: :destroy
+    has_many :journal_issns, through: :resource_publications
+    has_many :journals, through: :journal_issns
     has_one :manuscript, through: :resource_publication
     has_one :journal_issn, through: :resource_publication
     has_one :journal, through: :journal_issn
@@ -640,7 +643,7 @@ module StashEngine
       user.min_app_admin? || user_id == user.id ||
         user.tenants.map(&:id).include?(tenant_id) ||
         funders_match?(user: user) ||
-        user.journals_as_admin.include?(journal)
+        user.journals_as_admin.intersect?(journals)
     end
 
     def funders_match?(user:)

--- a/app/models/stash_engine/resource_publication.rb
+++ b/app/models/stash_engine/resource_publication.rb
@@ -21,6 +21,8 @@
 module StashEngine
   class ResourcePublication < ApplicationRecord
     self.table_name = 'stash_engine_resource_publications'
+    enum pub_type: { primary_article: 0, preprint: 1 }
+    validates :pub_type, uniqueness: { scope: :resource_id }
     # connecting a resource with the publication for a manuscript and/or a primary_article related_identifier
     belongs_to :resource
     belongs_to :journal_issn, class_name: 'StashEngine::JournalIssn', foreign_key: :publication_issn, optional: true

--- a/app/views/stash_engine/admin_datasets/_publication_popup.html.erb
+++ b/app/views/stash_engine/admin_datasets/_publication_popup.html.erb
@@ -4,17 +4,25 @@
       method: :put,
       local: false do |f| %>
   <div class="c-input">
-    <label class="c-input__label" for="curation_activity_note">Publication ISSN:</label>
+    <label class="c-input__label" for="curation_activity_note">
+      <% if publication.pub_type == 'primary_article' %>Publication ISSN:<% end %>
+      <% if publication.pub_type == 'preprint' %>Preprint server ISSN:<% end %>
+    </label>
     <%= f.text_field(:publication_issn, class: 'c-input__text', style: 'width: 100%') %>
   </div>
   <div class="c-input">
-    <label class="c-input__label" for="curation_activity_note">Publication name:</label>
+    <label class="c-input__label" for="curation_activity_note">
+      <% if publication.pub_type == 'primary_article' %>Publication name:<% end %>
+      <% if publication.pub_type == 'preprint' %>Preprint server name:<% end %>
+    </label>
     <%= f.text_field(:publication_name, class: 'c-input__text', style: 'width: 100%') %>
   </div>
-  <div class="c-input">
-    <label class="c-input__label" for="curation_activity_note">Manuscript number:</label>
-    <%= f.text_field(:manuscript_number, class: 'c-input__text', style: 'width: 100%') %>
-  </div>
+  <% if publication.pub_type == 'primary_article' %>
+    <div class="c-input">
+      <label class="c-input__label" for="curation_activity_note">Manuscript number:</label>
+      <%= f.text_field(:manuscript_number, class: 'c-input__text', style: 'width: 100%') %>
+    </div>
+  <% end %>
   <div class="c-modal__buttons-right">
     <%= submit_tag 'Submit', class: 'o-button__plain-text2', id: 'popup_submit' %>
     <%= button_tag 'Cancel', type: 'button', id: 'cancel_dialog', class: 'o-button__plain-text7' %>

--- a/app/views/stash_engine/admin_datasets/activity_log.html.erb
+++ b/app/views/stash_engine/admin_datasets/activity_log.html.erb
@@ -100,21 +100,42 @@
 
 <div id="publication">
   <h2>Publication information</h2>
-  <div style="display: flex; flex-wrap: wrap; gap: 2ch">
-    <div class="o-admin-form-pair">
-      <b>Publication ISSN:</b><span id="publication_issn" class="callout"><%= @identifier.publication_issn %></span>
+  <div style="display: flex; flex-basis: 48%; gap: 4ch">
+    <div style="display: flex; flex-direction: column; gap: 2ch">
+      <div class="o-admin-form-pair" style="justify-content: space-between; align-items: baseline;">
+        <h3 style="margin: 0">Preprint</h3>
+        <% if policy([:stash_engine, :admin_datasets]).data_popup? %>
+          <%= form_with(url: ds_admin_popup_path(id: @identifier&.id, field: 'preprint'), method: :get, local: false) do %>
+            <button class="o-button__plain-text7" aria-label="Edit preprint server information" title="Edit" aria-haspopup="dialog" id="preprint_button_<%= @identifier&.id %>"><i class="fa fa-pencil" aria-hidden="true" style="margin-right: .5ch;"></i></button>
+          <% end %>
+        <% end %>
+      </div>
+      <div class="o-admin-form-pair">
+        <b>Preprint server ISSN:</b><span id="preprint_publication_issn" class="callout"><%= @identifier.preprint_issn %></span>
+      </div>
+      <div class="o-admin-form-pair">
+        <b>Preprint server name:</b><span id="preprint_publication_name" class="callout"><%= @identifier.preprint_server %></span>
+      </div>
     </div>
-    <div class="o-admin-form-pair">
-      <b>Publication name:</b><span id="publication_name" class="callout"><%= @identifier.publication_name %></span>
+    <div style="display: flex; flex-direction: column; gap: 2ch">
+      <div class="o-admin-form-pair" style="justify-content: space-between;">
+        <h3 style="margin: 0">Primary article</h3>
+        <% if policy([:stash_engine, :admin_datasets]).data_popup? %>
+          <%= form_with(url: ds_admin_popup_path(id: @identifier&.id, field: 'publication'), method: :get, local: false) do %>
+            <button class="o-button__plain-text7" aria-label="Edit publication information" title="Edit" aria-haspopup="dialog" id="publication_button_<%= @identifier&.id %>"><i class="fa fa-pencil" aria-hidden="true" style="margin-right: .5ch;"></i></button>
+          <% end %>
+        <% end %>
+      </div>
+      <div class="o-admin-form-pair">
+        <b>Publication ISSN:</b><span id="primary_article_publication_issn" class="callout"><%= @identifier.publication_issn %></span>
+      </div>
+      <div class="o-admin-form-pair">
+        <b>Publication name:</b><span id="primary_article_publication_name" class="callout"><%= @identifier.publication_name %></span>
+      </div>
+      <div class="o-admin-form-pair">
+        <b>Manuscript number:</b><span id="manuscript_number" class="callout"><%= @identifier.manuscript_number %></span>
+      </div>
     </div>
-    <div class="o-admin-form-pair">
-      <b>Manuscript number:</b><span id="manuscript_number" class="callout"><%= @identifier.manuscript_number %></span>
-    </div>
-    <% if policy([:stash_engine, :admin_datasets]).data_popup? %>
-      <%= form_with(url: ds_admin_popup_path(id: @identifier&.id, field: 'publication'), method: :get, local: false) do %>
-        <button class="o-button__plain-text7" aria-label="Edit publication information" title="Edit" aria-haspopup="dialog" id="publication_button_<%= @identifier&.id %>"><i class="fa fa-pencil" aria-hidden="true" style="margin-right: .5ch;"></i></button>
-      <% end %>
-    <% end %>
   </div>
   <% if @identifier.internal_data %>
     <p><button class="o-button__plain-text7" onclick="document.getElementById('internal_data').toggleAttribute('hidden')"><i class="fa fa-eye" aria-hidden="true" style="margin-right: .5ch;"></i>View historical Internal data</button></p>

--- a/app/views/stash_engine/resource_publications/update.js.erb
+++ b/app/views/stash_engine/resource_publications/update.js.erb
@@ -1,4 +1,6 @@
-document.getElementById("publication_issn").innerHTML = "<%= @publication.publication_issn %>"
-document.getElementById("publication_name").innerHTML = "<%= @publication.publication_name %>"
+document.getElementById("<%= @publication.pub_type %>_publication_issn").innerHTML = "<%= @publication.publication_issn %>"
+document.getElementById("<%= @publication.pub_type %>_publication_name").innerHTML = "<%= @publication.publication_name %>"
+<% if @publication.pub_type == 'primary_article' %>
 document.getElementById("manuscript_number").innerHTML = "<%= @publication.manuscript_number %>"
+<% end %>
 document.getElementById('genericModalDialog').close();

--- a/db/migrate/20250103162957_multiple_resource_publication.rb
+++ b/db/migrate/20250103162957_multiple_resource_publication.rb
@@ -1,0 +1,7 @@
+class MultipleResourcePublication < ActiveRecord::Migration[7.0]
+  def change
+    add_column :stash_engine_resource_publications, :pub_type, :integer, default: 0
+    remove_index :stash_engine_resource_publications, :resource_id
+    add_index :stash_engine_resource_publications, [:resource_id, :pub_type], unique: true, name: 'index_resource_pub_type'
+  end
+end


### PR DESCRIPTION
Closes https://github.com/datadryad/dryad-product-roadmap/issues/3828

1. Allows resource publications/journals of different types per dataset (1 for primary_article and 1 for preprint, currently)
2. Allows admins of any associated journal access to the dataset & ability to see it on the admin dashboard
3. Adds ability to add/edit a preprint server on the activity log page

Remaining to be done:

- Decide how to record publications as preprint servers, other than through the activity log, and implement. What will be the various methods this can be done by (via API, user interface for normal users)?
- Decide how/whether to display the preprint server (on admin dashboard, landing page?)
- DB cleanup/recuration task for the addition of preprint server publication entries for datasets with related preprints where we have a journal ISSN/journal entry for the server (also modify the pubupdater to do this when new preprint connections are added)