### PR TITLE
Fix bugs preventing preview/download of latest files

### DIFF
--- a/app/models/stash_engine/identifier.rb
+++ b/app/models/stash_engine/identifier.rb
@@ -172,7 +172,7 @@ module StashEngine
     def latest_downloadable_resource(user: nil)
       return latest_resource_with_public_download if user.nil?
 
-      lr = resources.submitted_only.by_version_desc.first
+      lr = resources_with_file_changes.submitted.last
       return lr if lr&.permission_to_edit?(user: user)
 
       latest_resource_with_public_download

--- a/app/views/stash_engine/landing/_files.html.erb
+++ b/app/views/stash_engine/landing/_files.html.erb
@@ -22,7 +22,7 @@
           <span><%= formatted_date(res.publication_date.present? && res.publication_date < Time.now.utc ? res.publication_date : res.updated_at) %> version files</span>
           <span><%= filesize(res.total_file_size) %><% if dl_resource == res && res.total_file_size > APP_CONFIG.maximums.zip_size %><i id="download-select" class="fas fa-download" title="Select files for download"></i><% end %></span>
         </summary>
-        <% if dl_resource == res %><form id="download-select-form" <% if res.total_file_size > APP_CONFIG.maximums.zip_size %>aria-labelledby="download-select-label"<% end %>><% end %>
+        <% if dl_resource == res %><form id="download-select-form" <% if res.total_file_size > APP_CONFIG.maximums.zip_size %>aria-labelledby="download-select-label"<% end %>></form><% end %>
         <ul class="c-file-group__list">
           <% res.current_file_uploads.each do |fu| %>
           <% params = {file_id: fu.id} %>
@@ -39,7 +39,7 @@
                 <%= filesize(fu.upload_file_size) %>
                 <% if dl_resource == res %>
                 <% if fu.upload_file_size < APP_CONFIG.maximums.zip_size %>
-                  <input class="select-file-download" data-size="<%= fu.upload_file_size %>" type="checkbox" name="<%= fu.upload_file_name%>" <%if res.total_file_size < APP_CONFIG.maximums.zip_size %>checked hidden <% end %>aria-label="Select <%= fu.upload_file_name%> for download">
+                  <input class="select-file-download" data-size="<%= fu.upload_file_size %>" type="checkbox" name="<%= fu.upload_file_name%>" <%if res.total_file_size < APP_CONFIG.maximums.zip_size %>checked hidden <% end %>aria-label="Select <%= fu.upload_file_name%> for download" form="download-select-form">
                 <% else %>
                   <span class="select-file-download" title="Too big for zip download" aria-label="Too big for zip download"></span>
                 <% end %>
@@ -48,7 +48,6 @@
             </li>
           <% end %>
         </ul>
-        <% if dl_resource == res %></form><% end %>
       </details>
     <% end %>
     <div id="file_preview_box"></div>


### PR DESCRIPTION
Fix bug (accidental form nesting) preventing file previews from working for the latest version of a dataset

Also closes https://github.com/datadryad/dryad-product-roadmap/issues/3861 —the 'latest_downloadable_resource' check was choosing from all submitted resources, not just those with file changes (the downloadable ones!), which meant the download button tried to download totally unlisted versions with only meta changes