### PR TITLE
Fix checkbox download issues

### DIFF
--- a/app/views/stash_engine/downloads/_download.html.erb
+++ b/app/views/stash_engine/downloads/_download.html.erb
@@ -40,7 +40,7 @@
       })
     }
     selectDownloads()
-    selectForm.addEventListener('change', selectDownloads)
+    Array.from(selectForm.elements).forEach(inpt => inpt.addEventListener('change', selectDownloads))
   <% end %>
   const dlbutton = document.getElementById('download_zip_button');
   if ("serviceWorker" in navigator) {

--- a/app/views/stash_engine/downloads/_download_zip.js.erb
+++ b/app/views/stash_engine/downloads/_download_zip.js.erb
@@ -11,7 +11,7 @@ navigator.serviceWorker.ready.then(worker => {
 const insertFiles = async (files) => {
   const selectForm = document.getElementById('download-select-form').elements
   for (const f of files) {
-    if (selectForm[f.filename].checked) {
+    if (selectForm[f.filename]?.checked) {
       for (const k of Object.keys(f)) {
         const i = document.createElement('input');
         i.setAttribute('type', 'hidden');

--- a/app/views/stash_engine/landing/_files.html.erb
+++ b/app/views/stash_engine/landing/_files.html.erb
@@ -61,12 +61,6 @@
   </div>
 </div>
 <script type="text/javascript">
-  const details = document.getElementsByClassName('c-file-group')
-  for (const expander of details) {
-    expander.addEventListener('toggle', (e) => {
-      load_data()
-    })
-  }
   const load_preview = (n) => {
     const box = document.getElementById('file_preview_box');
     box.innerHTML = `<div class="file_preview"><p role="heading" level="3" id="preview_file_name"><span>Preview: ${n}</span></p><p style="text-align:center"><i class="fa fa-spin fa-spinner" aria-hidden="true" style="color: #888"></i></p></div>`;

--- a/public/javascript/dataload.js
+++ b/public/javascript/dataload.js
@@ -37,3 +37,10 @@ if (!!document.getElementById('blog-latest-posts')) {
     })
   })
 }     
+
+const details = document.getElementsByClassName('c-file-group')
+for (const expander of details) {
+  expander.addEventListener('toggle', (e) => {
+    load_data()
+  })
+}


### PR DESCRIPTION
Closes https://github.com/datadryad/dryad-product-roadmap/issues/3875

Some issues were caused by the fix https://github.com/datadryad/dryad-app/pull/1966 which removed the form nesting. it turns out other javascript was relying on the form nesting 🤦 . There was also a javascript problem when a single file was larger than the automatic zip maximum.

Now everything should work!

Also fixed a js loading sequence console error
