### PR TITLE
Fix blacklight modal bug

### DIFF
--- a/app/views/layouts/blacklight/base.html.erb
+++ b/app/views/layouts/blacklight/base.html.erb
@@ -36,7 +36,7 @@
       </div>
     </main>
     <%= render partial: "stash_engine/shared/footer" %>
-    <%= render partial: "stash_engine/shared/dialog_modal" %>
+    <%= render partial: 'shared/modal' %>
   </body>
   </html>
 <% end %>


### PR DESCRIPTION
Undo change from #1968—I thought the partial called here did not exist, and removed the call, but it seems to actually be some blacklight thing that loads a modal from that gem

Closes https://github.com/datadryad/dryad-product-roadmap/issues/3879