### PR TITLE
Scroll to API section in URL

### DIFF
--- a/app/views/stash_engine/pages/_api.html.md
+++ b/app/views/stash_engine/pages/_api.html.md
@@ -109,6 +109,7 @@ Detailed, interactive documentation of all available Dryad request methods:
       });
     })
   })
+  awaitSelector('.opblock.is-open').then((el) => el.scrollIntoView())
 </script>
 
 <p style="text-align:right; font-size: smaller">Created with <a href="https://swagger.io/tools/swagger-ui/" target="blank">Swagger UI<span class="screen-reader-only"> (opens in new window)</span></a></p>

--- a/public/javascript/interactions.js
+++ b/public/javascript/interactions.js
@@ -99,7 +99,7 @@ expandButtons.forEach(button => {
 
 if (window.location.hash) {
   const hashed = document.getElementById(window.location.hash.substring(1))
-  if (hashed.getAttribute('aria-expanded') === 'false') {
+  if (hashed && hashed.getAttribute('aria-expanded') === 'false') {
     hashed.setAttribute('aria-expanded', 'true');
     const section = document.getElementById(hashed.getAttribute('aria-controls'))
     section.removeAttribute('hidden');


### PR DESCRIPTION
Swagger seems to have a problem with this functionality in embedded docs, so I've added a scroll command of our own that fixes this. Also fixed a console error on the API page.