### PR TITLE
Relax the Content-Type restrictions for API status updates

### DIFF
--- a/app/controllers/stash_api/datasets_controller.rb
+++ b/app/controllers/stash_api/datasets_controller.rb
@@ -413,7 +413,7 @@ module StashApi
 
     def do_patch
       content_type = request.headers['content-type']
-      return unless request.method == 'PATCH' && content_type.present? && content_type.start_with?('application/json-patch+json')
+      return unless request.method == 'PATCH' && content_type.present? && content_type.start_with?('application/json')
 
       check_patch_prerequisites { yield }
       check_dataset_completions { yield }


### PR DESCRIPTION
Fixes https://github.com/datadryad/dryad-product-roadmap/issues/3920

When using an API call to update the curation status, allow Content-Type to be either "application/json" or "application/json-patch+json".