### PR TITLE
Add permissions check for changing submitter

### DIFF
--- a/app/models/stash_engine/resource.rb
+++ b/app/models/stash_engine/resource.rb
@@ -664,8 +664,17 @@ module StashEngine
       # collaborators
       return true if users.include?(user)
 
-      # curator or admin for the memebr institution
+      # curator or admin for the member institution
       admin_for_this_item?(user: user)
+    end
+
+    def user_edit_permission?(user:)
+      return false unless user
+      # the creator and submitter may change editor roles
+      return true if creator == user || submitter == user
+
+      # admins and curators may change editor roles
+      user.min_app_admin?
     end
 
     # Checks if someone may download files for this resource

--- a/app/models/stash_engine/user.rb
+++ b/app/models/stash_engine/user.rb
@@ -37,6 +37,10 @@ module StashEngine
     belongs_to :tenant, class_name: 'StashEngine::Tenant', optional: true
     has_many :admin_searches, class_name: 'StashEngine::AdminSearch', dependent: :destroy
     has_one :flag, class_name: 'StashEngine::Flag', as: :flaggable, dependent: :destroy
+    has_one :api_application,
+            class_name: 'Doorkeeper::Application',
+            foreign_key: :owner_id,
+            dependent: :destroy # or :destroy if you need callbacks
     has_many :access_grants,
              class_name: 'Doorkeeper::AccessGrant',
              foreign_key: :resource_owner_id,


### PR DESCRIPTION
Closes https://github.com/datadryad/dryad-product-roadmap/issues/3844

We had previously discussed (as part of adding multiple editors) that only the creator and submitter should be able to add other editors, and only they or curators should be able to change the submitter.