### PR TITLE
Fix Attributes per element limit exceeded exception

### DIFF
--- a/app/models/stash_datacite/resource/schema_dataset.rb
+++ b/app/models/stash_datacite/resource/schema_dataset.rb
@@ -81,7 +81,11 @@ module StashDatacite
         return [] unless @resource.descriptions
 
         @resource.descriptions.map do |d|
-          str = ActionView::Base.full_sanitizer.sanitize(d.description || '')
+          str = if d.description_type == 'technicalinfo'
+                  d.description
+                else
+                  ActionView::Base.full_sanitizer.sanitize(d.description || '')
+                end
           ((str&.length || 0) > 1000 ? "#{str[0..1000]}..." : str)
         end.compact
       end


### PR DESCRIPTION
The following exception occurs because a README contains several data images.

```
An ActionView::Template::Error occurred in landing#show:

  Attributes per element limit exceeded
  app/models/stash_datacite/resource/schema_dataset.rb:84:in `block in descriptions'


-------------------------------
Request:
-------------------------------

  * URL        : https://datadryad.org/stash/dataset/doi:10.5061/dryad.k0p2ngfff
  * HTTP Method: GET
  * IP address : 66.249.79.166
  * Parameters : {"controller"=>"stash_engine/landing", "action"=>"show", "id"=>"doi:10.5061/dryad.k0p2ngfff"}
  * Timestamp  : 2025-02-18 22:43:15 UTC
  * Server : ip-172-31-17-78.us-west-2.compute.internal
    * Rails root : /home/ec2-user/deploy/releases/20250218135142
  * Process: 1269411
```

READMEs are already limited in the HTML they can include and can be excluded from the sanitizer causing this issue