### PR TITLE
Update resource destroy

### DIFF
--- a/app/services/stash_engine/delete_datasets_service.rb
+++ b/app/services/stash_engine/delete_datasets_service.rb
@@ -13,7 +13,6 @@ module StashEngine
         user_id = current_user&.id || 0
         note = "#{(user_id == 0 && 'System cleanup') || 'User'} deleted unsubmitted version #{resource.version_number}"
         StashEngine::CurationActivity.create(resource_id: last.id, status: last.current_curation_status, user_id: user_id, note: note)
-        resource.create(resource_id: last.id, status: last.current_curation_status, user_id: user_id, note: note)
       end
       success = resource.destroy
       last.identifier.update(latest_resource_id: last.id) if success && last.identifier

--- a/app/services/stash_engine/delete_datasets_service.rb
+++ b/app/services/stash_engine/delete_datasets_service.rb
@@ -13,8 +13,12 @@ module StashEngine
         user_id = current_user&.id || 0
         note = "#{(user_id == 0 && 'System cleanup') || 'User'} deleted unsubmitted version #{resource.version_number}"
         StashEngine::CurationActivity.create(resource_id: last.id, status: last.current_curation_status, user_id: user_id, note: note)
+        resource.create(resource_id: last.id, status: last.current_curation_status, user_id: user_id, note: note)
       end
-      resource.destroy
+      success = resource.destroy
+      last.identifier.update(latest_resource_id: last.id) if success && last.identifier
+
+      success
     end
   end
 end


### PR DESCRIPTION
Given a published dataset where user created a ne in progress version.
Currently when the user deleted the in progress version, the identifier was not updated with the ID of the previous resource.
The results are:
- the published dataset does not appear in the admin dashboard and in admin search
- activity log page is not loading due to errors

Right now, there is no identifier in production that has a bad `latest_resource_id`, so no data migration is needed