### PR TITLE
Update and reinstate dataset validations

### DIFF
--- a/app/controllers/stash_datacite/resources_controller.rb
+++ b/app/controllers/stash_datacite/resources_controller.rb
@@ -154,6 +154,9 @@ module StashDatacite
 
       @resource.identifier.update_search_words!
 
+      error_items = Resource::DatasetValidations.new(resource: @resource, user: current_user).errors
+      redirect_to stash_url_helpers.metadata_entry_pages_find_or_create_path(resource_id: @resource.id) and return if error_items
+
       redirect_to stash_url_helpers.dashboard_path, alert: 'Dataset is already being submitted' if processing?(@resource)
     end
   end

--- a/app/controllers/submission_mixin.rb
+++ b/app/controllers/submission_mixin.rb
@@ -23,25 +23,13 @@ module SubmissionMixin
   end
 
   def check_dataset_completions
-    errors = errors_for_completions
-    if @resource.size > APP_CONFIG.maximums.merritt_size
-      errors.push('The files for this dataset are larger than the allowed version or total object size')
-    end
+    error = StashDatacite::Resource::DatasetValidations.new(resource: @resource, user: current_user).errors
     if @resource.identifier&.processing?
-      errors.push('Your previous version is still being processed, please wait until it completes before submitting again')
+      error = 'Your previous version is still being processed, please wait until it completes before submitting again'
     end
-    return unless errors.length.positive?
+    return unless error
 
-    return_error(messages: errors, status: 403) { yield }
-  end
-
-  def errors_for_completions
-    validations = StashDatacite::Resource::DatasetValidations.new(resource: @resource)
-    if @resource.loosen_validation && @user.min_curator?
-      validations.loose_errors.map { |err| err.message.gsub('{', '').gsub('}', '') }
-    else
-      validations.errors.map { |err| err.message.gsub('{', '').gsub('}', '') }
-    end
+    return_error(messages: error, status: 403) { yield }
   end
 
   def pre_submission_updates

--- a/app/controllers/submission_mixin.rb
+++ b/app/controllers/submission_mixin.rb
@@ -23,7 +23,7 @@ module SubmissionMixin
   end
 
   def check_dataset_completions
-    error = StashDatacite::Resource::DatasetValidations.new(resource: @resource, user: current_user).errors
+    error = StashDatacite::Resource::DatasetValidations.new(resource: @resource, user: @user).errors
     if @resource.identifier&.processing?
       error = 'Your previous version is still being processed, please wait until it completes before submitting again'
     end

--- a/app/javascript/react/components/MetadataEntry/Subjects/index.jsx
+++ b/app/javascript/react/components/MetadataEntry/Subjects/index.jsx
@@ -9,15 +9,16 @@ export const keywordPass = (subjects) => {
   return false;
 };
 
-export const keywordFail = (subjects) => {
+export const keywordFail = (resource) => {
+  const {subjects, identifier: {publication_date}} = resource;
   const keywords = subjects.filter((s) => !['fos', 'bad_fos'].includes(s.subject_scheme));
   const subject = subjects.find((s) => ['fos', 'bad_fos'].includes(s.subject_scheme));
-  if (!subject) {
+  if (!subject && (!publication_date || publication_date > new Date('2021-12-20'))) {
     return (
       <p className="error-text" id="domain_error">A research domain is required</p>
     );
   }
-  if (keywords.length < 3) {
+  if (keywords.length < 3 && (!publication_date || publication_date > new Date('2023-06-07'))) {
     return (
       <p className="error-text" id="subj_error">At least 3 subject keywords are required</p>
     );

--- a/app/javascript/react/components/ReadMeWizard/index.jsx
+++ b/app/javascript/react/components/ReadMeWizard/index.jsx
@@ -4,7 +4,10 @@ import axios from 'axios';
 export {default} from './ReadMeWizard';
 
 export const readmeCheck = (resource) => {
-  const readme = resource.descriptions.find((d) => d.description_type === 'technicalinfo')?.description;
+  const {descriptions, identifier: {publication_date}, generic_files: files} = resource;
+  const readme = descriptions.find((d) => d.description_type === 'technicalinfo')?.description;
+  const markdownFile = files.filter((f) => f.file_state !== 'deleted' && f.type === 'StashEngine::DataFile' && f.upload_file_name === 'README.md');
+  const readmeFile = files.filter((f) => f.file_state !== 'deleted' && f.type === 'StashEngine::DataFile' && f.upload_file_name.startsWith('README'));
   if (readme) {
     try {
       const obj = JSON.parse(readme);
@@ -17,7 +20,14 @@ export const readmeCheck = (resource) => {
       return false;
     }
   }
-  return <p className="error-text" id="readme_error">A README is required</p>;
+  if (!publication_date || publication_date > new Date('2023-08-29')) {
+    return <p className="error-text" id="readme_error">A README is required</p>;
+  } if (publication_date > new Date('2022-09-28')) {
+    if (!markdownFile) return <p className="error-text" id="readme_error">A README is required</p>;
+  } else if (publication_date > new Date('2021-12-20')) {
+    if (!readmeFile) return <p className="error-text" id="readme_error">A README is required</p>;
+  }
+  return false;
 };
 
 export function ReadMePreview({resource, previous, curator}) {

--- a/app/javascript/react/components/ReadMeWizard/index.jsx
+++ b/app/javascript/react/components/ReadMeWizard/index.jsx
@@ -24,10 +24,10 @@ export function ReadMePreview({resource, previous, curator}) {
   const readmeRef = useRef(null);
   const readme = resource.descriptions.find((d) => d.description_type === 'technicalinfo')?.description;
   const prev = previous?.descriptions.find((d) => d.description_type === 'technicalinfo')?.description;
-  const diff = curator && previous && readme !== prev;
+  const diff = previous && readme !== prev;
 
   const getREADME = () => {
-    axios.get(`/resources/${resource.id}/display_readme${diff ? '?admin' : ''}`).then((data) => {
+    axios.get(`/resources/${resource.id}/display_readme${curator && diff ? '?admin' : ''}`).then((data) => {
       const active_readme = document.createRange().createContextualFragment(data.data);
       readmeRef.current.append(active_readme);
     });

--- a/app/javascript/react/containers/Submission.jsx
+++ b/app/javascript/react/containers/Submission.jsx
@@ -65,7 +65,7 @@ function Submission({
       name: 'Subjects',
       index: 3,
       pass: keywordPass(resource.subjects),
-      fail: (review || step.index > 2) && keywordFail(resource.subjects),
+      fail: (review || step.index > 2) && keywordFail(resource),
       component: <Subjects resource={resource} setResource={setResource} />,
       help: <SubjHelp />,
       preview: <SubjPreview resource={resource} previous={previous} />,
@@ -92,7 +92,7 @@ function Submission({
       name: 'Files',
       index: 6,
       pass: resource.generic_files.length > 0,
-      fail: (review || step.index > 5) && filesCheck(resource.generic_files, user.superuser, config_maximums),
+      fail: (review || step.index > 5) && filesCheck(resource, user.superuser, config_maximums),
       component: <UploadFiles
         resource={resource}
         setResource={setResource}

--- a/app/models/stash_api/dataset_parser.rb
+++ b/app/models/stash_api/dataset_parser.rb
@@ -192,7 +192,8 @@ module StashApi
         author_email: parse_email(json_author[:email]),
         author_orcid: json_author[:orcid] || @previous_orcids["#{json_author[:firstName]} #{json_author[:lastName]}"],
         resource_id: @resource.id,
-        author_order: json_author[:order] || nil
+        author_order: json_author[:order] || nil,
+        corresp: parse_email(json_author[:email]).present?
       )
       # If the affiliation was provided, prefer the ROR id over a textual name.
       if json_author[:affiliationROR].present?

--- a/app/views/stash_engine/user_mailer/peer_review.html.erb
+++ b/app/views/stash_engine/user_mailer/peer_review.html.erb
@@ -16,7 +16,7 @@
       <br />
       After your dataset has been approved for publication by a member of our curation team, this link will become
       active and your dataset will be made public. This DOI link is permanent and should be included in the
-      Data Availability Statement of your published articles.
+      Data Availability Statement of your published articles.<br/>
     </li>
     <li>
       Reviewer URL: <a href="<%= shr %>"><%= shr %></a>.<br /><br />

--- a/spec/models/stash_datacite/dataset_validations_spec.rb
+++ b/spec/models/stash_datacite/dataset_validations_spec.rb
@@ -11,10 +11,8 @@ module StashDatacite
         @author2 = create(:author, resource: @resource)
         @author3 = create(:author, resource: @resource)
         @resource.subjects << [create(:subject), create(:subject), create(:subject)]
-        create(:data_file, resource: @resource)
-        @readme = create(:data_file, resource: @resource, upload_file_name: 'README.md')
-        create(:data_file, resource: @resource)
-        create(:data_file, resource: @resource)
+        create(:description, resource: @resource, description_type: 'technicalinfo')
+        4.times { create(:data_file, resource: @resource) }
         @resource.reload
       end
 
@@ -22,109 +20,25 @@ module StashDatacite
         it 'returns no errors if things are correctly filled' do
           validations = DatasetValidations.new(resource: @resource)
           allow(validations).to receive(:s3_error_uploads).and_return([]) # don't check with live S3 for this test
-          expect(validations.errors).to be_empty
+          expect(validations.errors).to be_falsey
         end
       end
 
-      describe :title do
-        it 'returns error if title not filled' do
-          @resource.update(title: '')
-          validations = DatasetValidations.new(resource: @resource)
-          error = validations.title
-          expect(error.message).to include('dataset title')
-          expect(error.ids.first).to eq("title__#{@resource.id}")
-        end
-        it 'returns error for nondescript title' do
-          @resource.update(title: 'Figure S1 Data supplement')
-          validations = DatasetValidations.new(resource: @resource)
-          error = validations.title
-          expect(error.message).to include('descriptive title')
-          expect(error.ids.first).to eq("title__#{@resource.id}")
-        end
-        it 'returns error for ALL CAPS title' do
-          @resource.update(title: @resource.title.upcase)
-          validations = DatasetValidations.new(resource: @resource)
-          error = validations.title
-          expect(error.message).to include('Correct the casing of your')
-          expect(error.ids.first).to eq("title__#{@resource.id}")
-        end
-      end
-
-      describe :authors do
-        it 'returns error for missing firstname' do
-          @author2.update(author_first_name: '')
-          validations = DatasetValidations.new(resource: @resource)
-          errors = validations.authors
-          error = errors.first
-          expect(errors.count).to eq(1)
-          expect(error.message).to include('2nd')
-          expect(error.message).to include('first name')
-          expect(error.ids.first).to include('author_first_name__')
-        end
-
-        it 'returns error for missing affiliation' do
-          @author2.affiliation.update(long_name: '*')
-          validations = DatasetValidations.new(resource: @resource)
-          errors = validations.authors
-          error = errors.first
-          expect(errors.count).to eq(1)
-          expect(error.message).to include('2nd')
-          expect(error.message).to include('institutional affiliation')
-          expect(error.ids.first).to include('instit_affil__')
-        end
-
-        it 'returns error for missing corresponding author email' do
-          @author1.update(author_email: '')
-          validations = DatasetValidations.new(resource: @resource)
-          errors = validations.authors
-          error = errors.first
-          expect(errors.count).to eq(1)
-          expect(error.message).to include("submitting author's email")
-          expect(error.ids.first).to include('author_email__')
-        end
-      end
-
-      describe :research_domain do
-        it 'returns error an error object if research domain (FOS subject) not filled' do
-          @resource.update(subjects: [])
-          validations = DatasetValidations.new(resource: @resource)
-          error = validations.research_domain
-          expect(error.message).to include('research domain')
-          expect(error.ids.first).to eq("fos_subjects__#{@resource.id}")
-        end
-      end
-
-      describe :abstract do
-        it 'returns error for missing abstract' do
-          abstract = @resource.descriptions.where(description_type: 'abstract').first
-          abstract.update(description: '')
-          validations = DatasetValidations.new(resource: @resource)
-          error = validations.abstract
-          expect(error.message).to include('abstract')
-          expect(error.ids.first).to eq('abstract_label')
-        end
-      end
-
-      describe :article_id do
+      describe :import do
         it 'gives error for unfilled publication' do
           @resource.identifier.update(import_info: 'published')
 
           validations = DatasetValidations.new(resource: @resource)
-          error = validations.article_id.first
-
-          expect(error.message).to include('journal of the related publication')
-          expect(error.ids).to eq(%w[publication])
+          error = validations.import
+          expect(error).to eq('Journal name missing')
         end
 
-        it 'gives error for unfilled publication doi if publication' do
-          @resource.identifier.update(import_info: 'published')
-          create(:resource_publication, resource_id: @resource.id, publication_name: 'Barrel of Monkeys: the Primate Journal')
+        it 'gives error for unfilled preprint server' do
+          @resource.identifier.update(import_info: 'preprint')
 
           validations = DatasetValidations.new(resource: @resource)
-          error = validations.article_id.first
-
-          expect(error.message).to include('formatted DOI')
-          expect(error.ids).to eq(%w[primary_article_doi])
+          error = validations.import
+          expect(error).to eq('Preprint server missing')
         end
 
         it 'gives error for unfilled manuscript number if manuscript' do
@@ -132,10 +46,17 @@ module StashDatacite
           create(:resource_publication, resource_id: @resource.id, publication_name: 'Barrel of Monkeys: the Primate Journal')
 
           validations = DatasetValidations.new(resource: @resource)
-          error = validations.article_id.first
+          error = validations.import
+          expect(error).to eq('Manuscript number missing')
+        end
 
-          expect(error.message).to include('manuscript number')
-          expect(error.ids).to eq(%w[msId])
+        it 'gives error for unfilled publication doi if publication' do
+          @resource.identifier.update(import_info: 'published')
+          create(:resource_publication, resource_id: @resource.id, publication_name: 'Barrel of Monkeys: the Primate Journal')
+
+          validations = DatasetValidations.new(resource: @resource)
+          error = validations.import
+          expect(error).to eq('DOI missing')
         end
 
         it 'gives a formatting error when someone puts in a URL instead of a DOI' do
@@ -145,10 +66,8 @@ module StashDatacite
             'primary_article')
 
           validations = DatasetValidations.new(resource: @resource)
-          error = validations.article_id.first
-
-          expect(error.message).to include('formatted DOI')
-          expect(error.ids).to eq(%w[primary_article_doi])
+          error = validations.import
+          expect(error).to eq('DOI missing')
         end
 
         it "doesn't give error if manuscript filled" do
@@ -157,9 +76,8 @@ module StashDatacite
                  manuscript_number: '12xu')
 
           validations = DatasetValidations.new(resource: @resource)
-          errors = validations.article_id
-
-          expect(errors).to eq([])
+          error = validations.import
+          expect(error).to be_falsey
         end
 
         it "doesn't give error if DOI filled" do
@@ -169,9 +87,99 @@ module StashDatacite
                  related_identifier: 'https://doi.org/12346/4387', related_identifier_type: 'doi')
 
           validations = DatasetValidations.new(resource: @resource)
-          errors = validations.article_id
+          error = validations.import
+          expect(error).to be_falsey
+        end
+      end
 
-          expect(errors).to eq([])
+      describe :title do
+        it 'returns error if title not filled' do
+          @resource.update(title: '')
+          validations = DatasetValidations.new(resource: @resource)
+          error = validations.title
+          expect(error).to eq('Blank title')
+        end
+        it 'returns error for nondescript title' do
+          @resource.update(title: 'Figure S1 Data supplement')
+          validations = DatasetValidations.new(resource: @resource)
+          error = validations.title
+          expect(error).to eq('Nondescriptive title')
+        end
+        it 'returns error for ALL CAPS title' do
+          @resource.update(title: @resource.title.upcase)
+          validations = DatasetValidations.new(resource: @resource)
+          error = validations.title
+          expect(error).to eq('All caps title')
+        end
+        it 'returns error for Title Case title' do
+          @resource.update(title: @resource.title.titleize)
+          validations = DatasetValidations.new(resource: @resource)
+          error = validations.title
+          expect(error).to eq('Title case title')
+        end
+      end
+
+      describe :authors do
+        it 'returns error for missing submitter' do
+          @author1.update(author_orcid: '')
+          validations = DatasetValidations.new(resource: @resource)
+          error = validations.authors
+          expect(error).to eq('Submitter missing')
+        end
+        it 'returns error for missing submitter email' do
+          @author1.update(author_email: '')
+          validations = DatasetValidations.new(resource: @resource)
+          error = validations.authors
+          expect(error).to eq('Submitter email missing')
+        end
+        it 'returns error for missing firstname' do
+          @author2.update(author_first_name: '')
+          validations = DatasetValidations.new(resource: @resource)
+          error = validations.authors
+          expect(error).to eq('Names missing')
+        end
+        it 'returns error for missing affiliation' do
+          @author2.affiliation.destroy
+          validations = DatasetValidations.new(resource: @resource)
+          error = validations.authors
+          expect(error).to eq('Affiliations missing')
+        end
+        it 'returns error for duplicate name' do
+          @author2.update(author_first_name: @author1.author_first_name, author_last_name: @author1.author_last_name)
+          validations = DatasetValidations.new(resource: @resource)
+          error = validations.authors
+          expect(error).to eq('Duplicate author names')
+        end
+        it 'returns error for duplicate email' do
+          @author2.update(author_email: @author1.author_email)
+          validations = DatasetValidations.new(resource: @resource)
+          error = validations.authors
+          expect(error).to eq('Duplicate author emails')
+        end
+        it 'returns error for no corresp' do
+          @resource.authors.update_all(corresp: false)
+          validations = DatasetValidations.new(resource: @resource)
+          error = validations.authors
+          expect(error).to eq('Published email missing')
+        end
+      end
+
+      describe :abstract do
+        it 'returns error for missing abstract' do
+          abstract = @resource.descriptions.where(description_type: 'abstract').first
+          abstract.update(description: '')
+          validations = DatasetValidations.new(resource: @resource)
+          error = validations.abstract
+          expect(error).to eq('Abstract missing')
+        end
+      end
+
+      describe :subjects do
+        it 'returns error an error object if research domain (FOS subject) not filled' do
+          @resource.update(subjects: [])
+          validations = DatasetValidations.new(resource: @resource)
+          error = validations.subjects
+          expect(error).to eq('Research domain missing')
         end
       end
 
@@ -189,16 +197,30 @@ module StashDatacite
 
         it 'returns collected datasets error when collection has no related identifiers' do
           validations = DatasetValidations.new(resource: @collection)
-          error = validations.collected_datasets.first
-          expect(error.message).to include('datasets in the collection')
+          error = validations.collected_datasets
+          expect(error).to eq('No datasets in the collection')
         end
 
         it 'returns no errors when collected datasets are present' do
           create(:related_identifier, relation_type: 'haspart', work_type: 'dataset', resource_id: @collection.id,
                                       related_identifier: 'https://doi.org/12346/4387', related_identifier_type: 'doi')
           validations = DatasetValidations.new(resource: @collection)
-          errors = validations.collected_datasets
-          expect(errors).to eq([])
+          error = validations.collected_datasets
+          expect(error).to be_falsey
+        end
+      end
+
+      describe :required_data_files do
+        before(:each) do
+          @resource.generic_files.each { |f| f.update(url: 'http://example.com') }
+        end
+
+        it 'requires at least one data file' do
+          @resource.data_files.destroy_all
+          create(:data_file, resource: @resource, upload_file_name: 'README.md')
+          validations = DatasetValidations.new(resource: @resource)
+          error = validations.data_required
+          expect(error).to eq('No data files')
         end
       end
 
@@ -211,11 +233,7 @@ module StashDatacite
 
           validations = DatasetValidations.new(resource: @resource)
           error = validations.s3_error_uploads
-          expect(error.message).to include('Check that the following file(s) have uploaded')
-          expect(error.message).to include(files[0].upload_file_name)
-          expect(error.message).to include(files[1].upload_file_name)
-          expect(error.message).to include(files[2].upload_file_name)
-          expect(error.ids.first).to eq('filelist_id')
+          expect(error).to eq('Upload file errors')
         end
 
         it 'does not check missing files once Merritt processing is complete' do
@@ -226,7 +244,7 @@ module StashDatacite
 
           validations = DatasetValidations.new(resource: @resource)
           errors = validations.s3_error_uploads
-          expect(errors).to eq([])
+          expect(errors).to be_falsey
         end
 
         it 'only checks files that are new uploads and are not urls' do
@@ -240,7 +258,7 @@ module StashDatacite
 
           validations = DatasetValidations.new(resource: @resource)
           errors = validations.s3_error_uploads
-          expect(errors).to eq([])
+          expect(errors).to be_falsey
         end
       end
 
@@ -261,8 +279,7 @@ module StashDatacite
 
           validations = DatasetValidations.new(resource: @resource)
           errors = validations.url_error_validating
-
-          expect(errors).to eq([])
+          expect(errors).to be_falsey
         end
 
         it 'returns no errors when all newly created files are valid' do
@@ -273,8 +290,7 @@ module StashDatacite
 
           validations = DatasetValidations.new(resource: @resource)
           errors = validations.url_error_validating
-
-          expect(errors).to eq([])
+          expect(errors).to be_falsey
         end
 
         it 'returns error when at least one newly created file has an error' do
@@ -284,9 +300,7 @@ module StashDatacite
 
           validations = DatasetValidations.new(resource: @resource)
           error = validations.url_error_validating
-
-          expect(error.message).to include('are available and publicly viewable')
-          expect(error.message).to include(@resource.data_files.first.upload_file_name)
+          expect(error).to eq('URL file errors')
         end
 
         it 'returns error when at least one Zenodo file has an error' do
@@ -302,53 +316,19 @@ module StashDatacite
 
           validations = DatasetValidations.new(resource: @resource)
           error = validations.url_error_validating
-
-          expect(error.message).to include('are available and publicly viewable')
-          expect(error.message).to include(@resource.software_files.first.upload_file_name)
-        end
-
-      end
-
-      describe :required_readme do
-        it 'requires a README file' do
-          @readme.update(upload_file_name: 'some-bogus-filename.txt')
-          validations = DatasetValidations.new(resource: @resource)
-          error = validations.readme_required
-          expect(error.message).to include('README')
-
-          @readme.update(upload_file_name: 'README.md')
-          error = validations.readme_required
-          expect(error).to be_empty
+          expect(error).to eq('URL file errors')
         end
       end
 
-      describe :required_data_files do
-        before(:each) do
-          @resource.generic_files.each { |f| f.update(url: 'http://example.com') }
-        end
-
-        it 'requires at least one data file' do
-          @resource.data_files.destroy_all
-          create(:data_file, resource: @resource, upload_file_name: 'README.md')
-          validations = DatasetValidations.new(resource: @resource)
-          error = validations.data_required
-          expect(error.message).to include('one data file')
-        end
-      end
-
-      describe :over_file_count do
+      describe :over_max do
         it 'gives error if over file count' do
           allow(APP_CONFIG.maximums).to receive(:files).and_return(2) # limit is lower than our files
 
           validations = DatasetValidations.new(resource: @resource)
-          error = validations.over_file_count
-
-          expect(error.message).to include('limit the number of files to 2')
-          expect(error.ids.first).to eq('filelist_id')
+          error = validations.over_max
+          expect(error).to eq('Too many files')
         end
-      end
 
-      describe :over_files_size do
         it 'gives an error if over file size for merritt data files' do
           size = @resource.generic_files.sum(:upload_file_size)
           @resource.generic_files.update_all(type: 'StashEngine::DataFile')
@@ -356,10 +336,8 @@ module StashDatacite
           allow(APP_CONFIG.maximums).to receive(:merritt_size).and_return(size - 1)
 
           validations = DatasetValidations.new(resource: @resource)
-          errors = validations.over_files_size
-
-          expect(errors.first.message).to include('Data uploads are limited')
-          expect(errors.first.ids.first).to eq('filelist_id')
+          error = validations.over_max
+          expect(error).to eq('Over file size limit')
         end
 
         it 'gives an error if over file size for zenodo software files' do
@@ -370,10 +348,8 @@ module StashDatacite
           allow(APP_CONFIG.maximums).to receive(:zenodo_size).and_return(size - 1)
 
           validations = DatasetValidations.new(resource: @resource)
-          errors = validations.over_files_size
-
-          expect(errors.first.message).to include('Software uploads are limited')
-          expect(errors.first.ids.first).to eq('filelist_id')
+          error = validations.over_max
+          expect(error).to eq('Over file size limit')
         end
 
         it 'gives an error if over file size for zenodo supplemental files' do
@@ -384,10 +360,17 @@ module StashDatacite
           allow(APP_CONFIG.maximums).to receive(:zenodo_size).and_return(size - 1)
 
           validations = DatasetValidations.new(resource: @resource)
-          errors = validations.over_files_size
+          error = validations.over_max
+          expect(error).to eq('Over file size limit')
+        end
+      end
 
-          expect(errors.first.message).to include('Supplemental uploads are limited')
-          expect(errors.first.ids.first).to eq('filelist_id')
+      describe :required_readme do
+        it 'requires a README' do
+          @resource.descriptions.type_technical_info.first.destroy
+          validations = DatasetValidations.new(resource: @resource)
+          error = validations.readme_required
+          expect(error).to eq('README missing')
         end
       end
     end

--- a/spec/requests/stash_api/datasets_controller_spec.rb
+++ b/spec/requests/stash_api/datasets_controller_spec.rb
@@ -824,7 +824,7 @@ module StashApi
         @res  = my_id.in_progress_resource
         @res.update(title: 'Sufficiently complex title for test dataset')
         @res.update(data_files: [create(:data_file, file_state: 'copied'),
-                                 create(:data_file, file_state: 'copied', upload_file_name: 'README.md')])
+                                 create(:data_file, file_state: 'copied')])
         @patch_body = [{ op: 'replace', path: '/versionStatus', value: 'submitted' }].to_json
       end
 
@@ -869,6 +869,7 @@ module StashApi
           access_token             = get_access_token(doorkeeper_application: @doorkeeper_application2)
 
           # HACK: in update to make this regular user the owner/editor of this item
+          create(:description, resource: @res, description_type: 'technicalinfo')
           @res.update(current_editor_id: user2.id)
           @res.submitter = user2.id
 
@@ -950,8 +951,9 @@ module StashApi
           @access_token           = get_access_token(doorkeeper_application: @doorkeeper_application)
           @identifier             = create(:identifier)
           @res                    = create(:resource, identifier: @identifier, user: @super_user)
+          create(:description, resource: @res, description_type: 'technicalinfo')
           @res.update(data_files: [create(:data_file, file_state: 'copied'),
-                                   create(:data_file, file_state: 'copied', upload_file_name: 'README.md')])
+                                   create(:data_file, file_state: 'copied')])
           @res.authors.first.update(author_orcid: @super_user.orcid)
           @res.subjects << [create(:subject), create(:subject), create(:subject)]
           @ca = create(:curation_activity, resource: @res, status: 'peer_review')


### PR DESCRIPTION
Closes https://github.com/datadryad/dryad-product-roadmap/issues/4023
Closes https://github.com/datadryad/dryad-product-roadmap/issues/3106
Closes https://github.com/datadryad/dryad-product-roadmap/issues/4024

Reinstate double checking submissions in the backend before allowing submission or PPR release, but update all the checks to match the form field checks, and add date checks to both the rails and javascript checks to allow resubmission of previously published datasets based on older requirements.