### PR TITLE
Adjust validations

### DIFF
--- a/app/javascript/react/components/MetadataEntry/Publication/index.jsx
+++ b/app/javascript/react/components/MetadataEntry/Publication/index.jsx
@@ -45,7 +45,7 @@ export const publicationPass = (resource) => !!resource.identifier.import_info |
 
 export const publicationFail = (resource) => {
   const {import_info} = resource.identifier;
-  if (!!resource.title || !!import_info) {
+  if (resource.title) {
     if (resource.title) {
       if (nondescript(resource.title)) {
         return (
@@ -82,6 +82,9 @@ export const publicationFail = (resource) => {
         );
       }
     } else {
+      return <p className="error-text" id="title_error">Title is required</p>;
+    }
+    if (import_info) {
       const {publication_name, manuscript_number} = resource.resource_publication;
       const {publication_name: preprint_server} = resource.resource_preprint || {};
       if (['manuscript', 'published'].includes(import_info) && !publication_name) {
@@ -109,7 +112,6 @@ export const publicationFail = (resource) => {
           <p className="error-text" id="doi_error">A valid DOI for the preprint is required</p>
         );
       }
-      return <p className="error-text" id="title_error">Title is required</p>;
     }
   }
   return false;

--- a/app/javascript/react/components/MetadataEntry/Publication/index.jsx
+++ b/app/javascript/react/components/MetadataEntry/Publication/index.jsx
@@ -43,9 +43,9 @@ const copyTitle = (e) => {
 
 export const publicationPass = (resource) => !!resource.identifier.import_info || !!resource.title;
 
-export const publicationFail = (resource) => {
+export const publicationFail = (resource, review) => {
   const {import_info} = resource.identifier;
-  if (resource.title) {
+  if (!!import_info || review) {
     if (resource.title) {
       if (nondescript(resource.title)) {
         return (
@@ -84,34 +84,32 @@ export const publicationFail = (resource) => {
     } else {
       return <p className="error-text" id="title_error">Title is required</p>;
     }
-    if (import_info) {
-      const {publication_name, manuscript_number} = resource.resource_publication;
-      const {publication_name: preprint_server} = resource.resource_preprint || {};
-      if (['manuscript', 'published'].includes(import_info) && !publication_name) {
-        return (
-          <p className="error-text" id="journal_error">The journal of the related publication is required</p>
-        );
-      }
-      if (import_info === 'manuscript' && !manuscript_number) {
-        return (
-          <p className="error-text" id="msid_error">The manuscript number is required</p>
-        );
-      }
-      if (import_info === 'published' && !validPrimary(resource)) {
-        return (
-          <p className="error-text" id="doi_error">A valid DOI for the article is required</p>
-        );
-      }
-      if (import_info === 'preprint' && !preprint_server) {
-        return (
-          <p className="error-text" id="journal_error">The server of the related publication is required</p>
-        );
-      }
-      if (import_info === 'preprint' && !validPrimary(resource, 'preprint')) {
-        return (
-          <p className="error-text" id="doi_error">A valid DOI for the preprint is required</p>
-        );
-      }
+    const {publication_name, manuscript_number} = resource.resource_publication;
+    const {publication_name: preprint_server} = resource.resource_preprint || {};
+    if (['manuscript', 'published'].includes(import_info) && !publication_name) {
+      return (
+        <p className="error-text" id="journal_error">The journal of the related publication is required</p>
+      );
+    }
+    if (import_info === 'manuscript' && !manuscript_number) {
+      return (
+        <p className="error-text" id="msid_error">The manuscript number is required</p>
+      );
+    }
+    if (import_info === 'published' && !validPrimary(resource)) {
+      return (
+        <p className="error-text" id="doi_error">A valid DOI for the article is required</p>
+      );
+    }
+    if (import_info === 'preprint' && !preprint_server) {
+      return (
+        <p className="error-text" id="journal_error">The server of the related publication is required</p>
+      );
+    }
+    if (import_info === 'preprint' && !validPrimary(resource, 'preprint')) {
+      return (
+        <p className="error-text" id="doi_error">A valid DOI for the preprint is required</p>
+      );
     }
   }
   return false;

--- a/app/javascript/react/containers/Submission.jsx
+++ b/app/javascript/react/containers/Submission.jsx
@@ -38,7 +38,7 @@ function Submission({
       name: 'Title',
       index: 0,
       pass: publicationPass(resource),
-      fail: (review || publicationPass(resource)) && publicationFail(resource),
+      fail: (review || publicationPass(resource)) && publicationFail(resource, review),
       component: <Publication resource={resource} setResource={setResource} maxSize={config_maximums.merritt_size} />,
       help: <PublicationHelp />,
       preview: <PubPreview resource={resource} previous={previous} curator={user.curator} />,

--- a/app/models/stash_datacite/resource/dataset_validations.rb
+++ b/app/models/stash_datacite/resource/dataset_validations.rb
@@ -112,6 +112,7 @@ module StashDatacite
       end
 
       def funder
+        return false if @resource.identifier.publication_date.present?
         return 'Funding missing' if @resource.contributors.where(contributor_type: 'funder').blank? ||
           @resource.contributors.where(contributor_type: 'funder').first.contributor_name.blank?
 

--- a/app/models/stash_engine/curation_activity.rb
+++ b/app/models/stash_engine/curation_activity.rb
@@ -86,12 +86,6 @@ module StashEngine
     # ------------------------------------------
     before_validation :set_resource
 
-    # Once we are certain that we will be publishing this dataset, remove any "N/A" placeholders
-    # Note tht this uses "after_validation" to ensure it runs before all of the "after_create"
-    after_validation :remove_placeholder_funders, if: proc { |ca|
-      (ca.published? || ca.embargoed?) && curation_status_changed?
-    }
-
     after_create :process_dates, if: %i[curation_status_changed?]
 
     # the publication flags need to be set before creating datacite metadata (after create below)
@@ -271,12 +265,6 @@ module StashEngine
       # Copy only software and supplemental files to zenodo | resource.send_to_zenodo
       resource.send_software_to_zenodo(publish: true)
       resource.send_supp_to_zenodo(publish: true)
-    end
-
-    def remove_placeholder_funders
-      return unless resource.present?
-
-      resource.update(contributors: resource.contributors.reject { |funder| funder.contributor_name&.upcase == 'N/A' })
     end
 
     def remove_peer_review


### PR DESCRIPTION
We were removing our 'N/A' funders even though they are a requirement for submission and are already excluded from being sent to datacite. Stopped this, but also adjusted the validation for the historic data.

Adjusted the UI validation to require completion of the import form when selected, even after the title has been entered, to match the back.

Closes https://github.com/datadryad/dryad-product-roadmap/issues/4027