### PR TITLE
fix invoice on first publish

### DIFF
--- a/app/models/stash_engine/identifier.rb
+++ b/app/models/stash_engine/identifier.rb
@@ -626,7 +626,7 @@ module StashEngine
     end
 
     def previous_invoiced_file_size
-      last_invoiced_file_size.presence || latest_resource.previous_published_resource.total_file_size
+      last_invoiced_file_size.presence || latest_resource.previous_published_resource&.total_file_size
     end
 
     # ------------------------------------------------------------


### PR DESCRIPTION
Fixed:

```
A NoMethodError occurred in admin_dashboard#update:

 undefined method `total_file_size' for nil
 app/models/stash_engine/identifier.rb:629:in `previous_invoiced_file_size'

```