### PR TITLE
Adjust data-load for Safari

### DIFF
--- a/app/views/stash_datacite/resources/_show.html.erb
+++ b/app/views/stash_datacite/resources/_show.html.erb
@@ -26,7 +26,7 @@
 <% no_link = false unless defined?(no_link) %>
 <% if resource.identifier&.counter_stat&.citation_count > 0 && !no_link %>
   <h2 tabindex="0" id="citations" class="expand-button" role="button" aria-expanded="false" aria-controls="citations-sec">Works referencing this dataset</h2>
-  <div id="citations-section" data-load="<%= stash_url_helpers.show_citations_path(identifier_id: resource.identifier_id, format: :js) %>"></div>
+  <div id="citations-section" data-load="<%= stash_url_helpers.show_citations_url(identifier_id: resource.identifier_id, format: :js) %>"></div>
 <% end %>
 
 <script type="application/ld+json">

--- a/app/views/stash_engine/admin_dashboard/index.html.erb
+++ b/app/views/stash_engine/admin_dashboard/index.html.erb
@@ -18,7 +18,7 @@
   </div>
 </div>
 
-<div id="search_results" data-load="<%= stash_url_helpers.admin_dashboard_results_path(format: :js, search: params[:search], sort: params[:sort], direction: params[:direction], page_size: params[:page_size], page: params[:page]) %>"></div>
+<div id="search_results" data-load="<%= stash_url_helpers.admin_dashboard_results_url(format: :js, search: params[:search], sort: params[:sort], direction: params[:direction], page_size: params[:page_size], page: params[:page]) %>"></div>
 
 <div class="callout alt">
   <p style="text-align: center;">Please send your Admin dashboard feedback to <a href="mailto:community@datadryad.org?subject=Admin dashboard feedback">community@datadryad.org</a>.</p>

--- a/app/views/stash_engine/admin_datasets/index.html.erb
+++ b/app/views/stash_engine/admin_datasets/index.html.erb
@@ -6,7 +6,7 @@
   <h1 class="o-heading__level1"><%= r&.title %></h1>
   <%= @identifier.identifier %>
 </div>
-<div id="dupe_check" class="callout warn" data-load="<%= stash_url_helpers.dupe_check_resource_path(format: :js, id: r&.id, admin: true) %>"></div>
+<div id="dupe_check" class="callout warn" data-load="<%= stash_url_helpers.dupe_check_resource_url(format: :js, id: r&.id, admin: true) %>"></div>
 <div class="callout alt">
   <div id="activity-at-a-glance">
     <div class="input-stack">
@@ -139,7 +139,7 @@
     <% end %>
   <% end %>
 </div>
-<div id="activity_log" data-load="<%= stash_url_helpers.activity_path(format: :js, id: params[:id], direction: params[:direction], page_size: params[:page_size], page: params[:page]) %>"></div>
+<div id="activity_log" data-load="<%= stash_url_helpers.activity_url(format: :js, id: params[:id], direction: params[:direction], page_size: params[:page_size], page: params[:page]) %>"></div>
 
 <% if policy([:stash_engine, :admin_datasets]).create_salesforce_case? && Stash::Salesforce.sf_user %>
   <div class="activity-log-header">

--- a/app/views/stash_engine/dashboard/show.html.erb
+++ b/app/views/stash_engine/dashboard/show.html.erb
@@ -10,7 +10,7 @@
     <i class="fas fa-plus" aria-hidden="true"></i>Start new submission
   <% end %>
 </div>
-<div id="user_datasets" data-load="<%= stash_url_helpers.dashboard_user_datasets_path(format: :js) %>">
+<div id="user_datasets" data-load="<%= stash_url_helpers.dashboard_user_datasets_url(format: :js) %>">
   <p style="text-align: center;"><i class="fa fa-spin fa-spinner" aria-hidden="true" style="color: #888"></i></p>
 </div>
 <p style="text-align:right; font-size: .9em;"><a href="/feedback?m=4&l=dashboard" class="o-link__buttonlink"><i class="fa fa-commenting-o" aria-hidden="true" style="margin-right: .5ch"></i>Help direct the future of Dryad</a></p>

--- a/app/views/stash_engine/landing/_files.html.erb
+++ b/app/views/stash_engine/landing/_files.html.erb
@@ -32,7 +32,7 @@
               <%= link_to "<i class=\"fas fa-download\" aria-hidden=\"true\"></i>#{fu.upload_file_name.ellipsisize(200)}".html_safe, Rails.application.routes.url_helpers.download_stream_path(params),
                         title: fu.upload_file_name, target: '_blank', class: 'js-individual-dl' %>
               <% unless fu.preview_type.nil? %>
-                <div id="file_preview_check<%= fu.id %>" data-load="<%= preview_check_path(file_id: fu.id, format: :js) %>">
+                <div id="file_preview_check<%= fu.id %>" data-load="<%= preview_check_url(file_id: fu.id, format: :js) %>">
                   <i class="fa fa-spin fa-spinner" aria-hidden="true" style="color: #888"></i>
                 </div>
               <% end %>

--- a/app/views/stash_engine/landing/_sidebar.html.erb
+++ b/app/views/stash_engine/landing/_sidebar.html.erb
@@ -8,7 +8,7 @@
   </div>
 
   <div id="show_metrics"
-       data-load="<%= stash_url_helpers.show_metrics_path(identifier_id: @id.id) %>">
+       data-load="<%= stash_url_helpers.show_metrics_url(identifier_id: @id.id) %>">
     <i class="fa fa-spin fa-spinner" aria-hidden="true" style="color: #888"></i>
   </div>
   
@@ -20,7 +20,7 @@
 
   <% unless @resource&.resource_type&.resource_type == 'collection' %>
     <div id="show_license"
-         data-load="<%= metadata_url_helpers.license_details_path(resource_id: @resource.id, format: :js) %>">
+         data-load="<%= metadata_url_helpers.license_details_url(resource_id: @resource.id, format: :js) %>">
       <i class="fa fa-spin fa-spinner" aria-hidden="true" style="color: #888"></i>
     </div>
   <% end %>
@@ -30,7 +30,7 @@
   <div id="keyword_section">
     <h2>Subject keywords</h2>
     <div id="show_subjects"
-         data-load="<%= metadata_url_helpers.subjects_landing_path(resource_id: @resource.id, format: :js) %>">
+         data-load="<%= metadata_url_helpers.subjects_landing_url(resource_id: @resource.id, format: :js) %>">
       <i class="fa fa-spin fa-spinner" aria-hidden="true" style="color: #888"></i>
     </div>
   </div>

--- a/app/views/stash_engine/metadata_entry_pages/find_or_create.html.erb
+++ b/app/views/stash_engine/metadata_entry_pages/find_or_create.html.erb
@@ -5,6 +5,6 @@
 <%= stylesheet_pack_tag 'application' %>
 <% end %>
 <div id="find_or_create"
-    data-load="<%= stash_url_helpers.datacite_metadata_entry_pages_path(resource_id: params[:resource_id], display_validation: params[:display_validation], format: :js) %>">
+    data-load="<%= stash_url_helpers.datacite_metadata_entry_pages_url(resource_id: params[:resource_id], display_validation: params[:display_validation], format: :js) %>">
   <p style="text-align: center;"><i class="fa fa-spin fa-spinner" aria-hidden="true" style="color: #888"></i></p>
 </div>

--- a/app/views/stash_engine/pages/home.html.erb
+++ b/app/views/stash_engine/pages/home.html.erb
@@ -40,7 +40,7 @@
 <div class="o-home__group o-home__data_group">
   <h2 class="o-heading__level1-home top-row">Most recent datasets</h2>
   <%# Keep unless hostname below for rspec tests to pass %>
-  <div id="latest_tiles" <% unless @hostname == 'localhost' %>data-load="<%= main_app.latest_index_path(format: :js, q: '*:*') %>"<% end %>>
+  <div id="latest_tiles" <% unless @hostname == 'localhost' %>data-load="<%= main_app.latest_index_url(format: :js, q: '*:*') %>"<% end %>>
     <%= image_tag 'stash_engine/spinner.gif', size: '80x60', alt: 'Loading spinner' %>
   </div>
   <%= render partial: 'why_share' %>

--- a/public/javascript/dataload.js
+++ b/public/javascript/dataload.js
@@ -5,10 +5,11 @@ const load_data = function() {
     var path = $(this).attr('data-load');
     // $(this).load(path);
     $.ajax({
+      method: 'GET',
       url: path,
-      //data,
-      // success: success,
-      dataType: 'script'
+      dataType: 'script',
+      async: true,
+      cache: false,
     }).always(function() {
       // modernizeIt();
     });

--- a/public/javascript/dataload.js
+++ b/public/javascript/dataload.js
@@ -10,8 +10,6 @@ const load_data = function() {
       dataType: 'script',
       async: true,
       cache: false,
-    }).always(function() {
-      // modernizeIt();
     });
     $(this).attr('data-loaded')
   });


### PR DESCRIPTION
Closes https://github.com/datadryad/dryad-product-roadmap/issues/3984

Lots of people have issues with jQuery ajax calls not working in safari sporadically, but no two seem to be the same issue. Some have indicated using full instead of relative URLs and explicitly declaring the method might help.