### PR TITLE
Allow blank for related identifier uniqueness validation

### DIFF
--- a/app/models/stash_datacite/related_identifier.rb
+++ b/app/models/stash_datacite/related_identifier.rb
@@ -68,7 +68,7 @@ module StashDatacite
 
     enum :added_by, { default: 0, zenodo: 1, simple_relation: 2, api_simple: 3 }
 
-    validates :related_identifier, uniqueness: { scope: :resource_id, message: 'The DOI or URL is already added to the dataset' }
+    validates :related_identifier, uniqueness: { allow_blank: true, scope: :resource_id, message: 'The DOI or URL is already added to the dataset' }
     validates :work_type, uniqueness: { scope: :resource_id, conditions: -> {
       where(work_type: :primary_article)
     }, message: 'Only one Primary article is allowed' }


### PR DESCRIPTION
Users should be allowed to create a bunch of blank related works and fill in the DOIs later