### PR TITLE
Remove readme editor text specific validation

### DIFF
--- a/app/models/stash_datacite/resource/dataset_validations.rb
+++ b/app/models/stash_datacite/resource/dataset_validations.rb
@@ -183,7 +183,7 @@ module StashDatacite
         if @resource.identifier.publication_date.blank? || @resource.identifier.publication_date > readme_md_require_date
           return 'README file missing' if readme_md_files.count.zero? && no_techinfo
         elsif @resource.identifier.publication_date > readme_require_date
-          return 'README file missing' if readme_files.count.zero?
+          return 'README file missing' if readme_files.count.zero? && no_techinfo
         end
 
         false

--- a/app/models/stash_datacite/resource/dataset_validations.rb
+++ b/app/models/stash_datacite/resource/dataset_validations.rb
@@ -167,7 +167,6 @@ module StashDatacite
       end
 
       def readme_required
-        readme_editor_date = '2023-08-29'
         readme_md_require_date = '2022-09-28'
         readme_require_date = '2021-12-20'
 
@@ -181,10 +180,8 @@ module StashDatacite
           false
         end
 
-        if @resource.identifier.publication_date.blank? || @resource.identifier.publication_date > readme_editor_date
-          return 'README missing' if no_techinfo
-        elsif @resource.identifier.publication_date > readme_md_require_date
-          return 'README file missing' if readme_md_files.count.zero?
+        if @resource.identifier.publication_date.blank? || @resource.identifier.publication_date > readme_md_require_date
+          return 'README file missing' if readme_md_files.count.zero? && no_techinfo
         elsif @resource.identifier.publication_date > readme_require_date
           return 'README file missing' if readme_files.count.zero?
         end

--- a/spec/models/stash_datacite/dataset_validations_spec.rb
+++ b/spec/models/stash_datacite/dataset_validations_spec.rb
@@ -364,7 +364,7 @@ module StashDatacite
           @resource.descriptions.type_technical_info.first.destroy
           validations = DatasetValidations.new(resource: @resource)
           error = validations.readme_required
-          expect(error).to eq('README missing')
+          expect(error).to eq('README file missing')
         end
       end
     end


### PR DESCRIPTION
- Allow README markdown file uploads in all cases, instead of requiring README editor use for new submissions
- Allow README editor use in the case of old submissions, instead of requiring a README file upload