### PR TITLE
Use internal links for submission system file downloads

### DIFF
--- a/app/controllers/stash_datacite/metadata_entry_pages_controller.rb
+++ b/app/controllers/stash_datacite/metadata_entry_pages_controller.rb
@@ -42,7 +42,7 @@ module StashDatacite
 
     def find_files
       @submission[:generic_files] = @resource.generic_files.includes(:frictionless_report).validated_table.as_json(
-        methods: %i[type dl_url], include: { frictionless_report: { only: %i[report status] } }
+        methods: %i[type uploaded], include: { frictionless_report: { only: %i[report status] } }
       )
       return unless @resource.previous_curated_resource.present?
 

--- a/app/controllers/stash_engine/downloads_controller.rb
+++ b/app/controllers/stash_engine/downloads_controller.rb
@@ -115,7 +115,7 @@ module StashEngine
       share = (params[:share].blank? ? nil : StashEngine::Share.where(secret_id: params[:share]).first)
 
       # can see if they had permission or the Share matches the identifier
-      if res && (res&.may_view?(ui_user: current_user) || share&.identifier_id == res&.identifier&.id) &&
+      if res && (res&.may_download?(ui_user: current_user) || share&.identifier_id == res&.identifier&.id) &&
           [StashEngine::SuppFile, StashEngine::SoftwareFile].include?(zen_upload.class)
         if res.zenodo_published?
           redirect_to zen_upload.public_zenodo_download_url

--- a/app/controllers/stash_engine/generic_files_controller.rb
+++ b/app/controllers/stash_engine/generic_files_controller.rb
@@ -124,7 +124,7 @@ module StashEngine
       files = files.select { |f| f&.frictionless_report&.report.present? && f&.frictionless_report&.status != 'checking' }
 
       render json: files.as_json(
-        methods: %i[type dl_url], include: { frictionless_report: { only: %i[report status] } }
+        methods: %i[type uploaded], include: { frictionless_report: { only: %i[report status] } }
       )
     end
 

--- a/app/controllers/stash_engine/generic_files_controller.rb
+++ b/app/controllers/stash_engine/generic_files_controller.rb
@@ -77,7 +77,7 @@ module StashEngine
             )
           json_file = db_file.as_json
           json_file[:type] = db_file.type
-          json_file[:dl_url] = db_file.s3_staged_presigned_url
+          json_file[:uploaded] = db_file.s3_staged_presigned_url.present?
           render json: { new_file: json_file }
         end
       end

--- a/app/javascript/react/components/UploadFiles/FileList/File.jsx
+++ b/app/javascript/react/components/UploadFiles/FileList/File.jsx
@@ -29,7 +29,7 @@ const statusCss = (status) => {
 };
 
 function S3Check({file}) {
-  if (file.file_state === 'copied' || file.dl_url) {
+  if (file.file_state === 'copied' || file.uploaded) {
     return (
       <div className="c-uploadtable-time">
         {moment(file.upload_updated_at || file.updated_at).format('YYYY/MM/DD H:mm')} <i className="fas fa-check" role="img" aria-label="complete" />
@@ -111,8 +111,13 @@ export default function File({file, clickRemove, clickValidationReport}) {
             {ellipsize(file.url)}
           </a>
         )}
-        {!file.url && file.dl_url && (
-          <a href={file.dl_url} download title={`Download from ${file.uploadType === 'data' ? 'Dryad' : 'Zenodo'}`} target="_blank" rel="noreferrer">
+        {!file.url && file.uploaded && (
+          <a
+            href={`/downloads/pre_submit/${file.id}`}
+            title={`Download from ${file.uploadType === 'data' ? 'Dryad' : 'Zenodo'}`}
+            target="_blank"
+            rel="noreferrer"
+          >
             {file.sanitized_name}
           </a>
         )}

--- a/app/javascript/react/components/UploadFiles/UploadFiles.jsx
+++ b/app/javascript/react/components/UploadFiles/UploadFiles.jsx
@@ -336,7 +336,7 @@ export default function UploadFiles({
                   c.id = new_file.id;
                   c.sanitized_name = new_file.upload_file_name;
                   c.status = 'Uploaded';
-                  c.dl_url = new_file.dl_url;
+                  c.uploaded = new_file.uploaded;
                 }
                 return c;
               }));
@@ -412,7 +412,7 @@ export default function UploadFiles({
 
     if (!files.valid_urls.length) return;
     let successfulUrls = files.valid_urls.map((f) => {
-      f.dl_url = f.url;
+      f.uploaded = true;
       return f;
     });
     if (chosenFiles.length) {

--- a/app/javascript/react/components/UploadFiles/index.jsx
+++ b/app/javascript/react/components/UploadFiles/index.jsx
@@ -75,7 +75,7 @@ export const filesCheck = (resource, superuser, maximums) => {
         </p>
       );
     }
-    const uploadErrors = data.filter((f) => !f.dl_url && (f.status === 'Uploaded' || f.file_state === 'created'));
+    const uploadErrors = data.filter((f) => !f.uploaded && (f.status === 'Uploaded' || f.file_state === 'created'));
     if (uploadErrors.length > 0) {
       return (
         <p className="error-text" id="data_error">

--- a/app/models/stash_engine/generic_file.rb
+++ b/app/models/stash_engine/generic_file.rb
@@ -234,23 +234,15 @@ module StashEngine
       in_str[first_brace..last_brace]
     end
 
-    def dl_url
+    def uploaded_success_url
       dl_url = s3_staged_presigned_url if file_state.nil? || file_state == 'created'
       dl_url ||= public_download_url
       dl_url ||= url
       dl_url
     end
 
-    def download_file
-      http = HTTP.use(
-        normalize_uri: { normalizer: Stash::Download::NORMALIZER }
-      ).timeout(connect: 10, read: 10).follow(max_hops: 10)
-      begin
-        http.get(dl_url)
-      rescue HTTP::Error => e
-        logger.error("Error downloading file: #{e.message}")
-        e
-      end
+    def uploaded
+      uploaded_success_url.present?
     end
 
     def set_extension

--- a/config/routes.rb
+++ b/config/routes.rb
@@ -160,6 +160,7 @@ Rails.application.routes.draw do
     match 'downloads/capture_email/:resource_id', to: 'downloads#capture_email', as: 'download_capture_email', via: %i[get post]
     get 'downloads/file_stream/:file_id', to: 'downloads#file_stream', as: 'download_stream'
     get 'downloads/zenodo_file/:file_id', to: 'downloads#zenodo_file', as: 'download_zenodo'
+    get 'downloads/pre_submit/:file_id', to: 'downloads#presubmit_file_stream', as: 'download_presubmit'
     get 'data_file/preview_check/:file_id', to: 'downloads#preview_check', as: 'preview_check'
     get 'data_file/preview/:file_id', to: 'downloads#preview_file', as: 'preview_file'
     get 'share/:id', to: 'downloads#share', as: 'share'

--- a/spec/support/helpers/generic_files_helper.rb
+++ b/spec/support/helpers/generic_files_helper.rb
@@ -41,7 +41,7 @@ module GenericFilesHelper
     new_file = StashEngine::GenericFile.first
     with_dl = new_file.as_json
     with_dl[:type] = new_file.type
-    with_dl[:dl_url] = new_file.s3_staged_presigned_url
+    with_dl[:uploaded] = new_file.s3_staged_presigned_url.present?
     expect(body['new_file'].to_json).to eql(with_dl.to_json)
   end
 


### PR DESCRIPTION
Closes https://github.com/datadryad/dryad-product-roadmap/issues/4075

Also adds standard permissions check, so the URLs won't work if shared with users not logged in and with the correct permissions