### PR TITLE
Stop double clicking for loading duplication and deletions

### DIFF
--- a/app/views/layouts/blacklight/base.html.erb
+++ b/app/views/layouts/blacklight/base.html.erb
@@ -47,7 +47,7 @@
     </main>
     <%= render partial: "stash_engine/shared/footer" %>
     <%= render partial: 'shared/modal' %>
-    <script type="text/javascript" src="/javascript/interactions.js?20250327"></script>
+    <script type="text/javascript" src="/javascript/interactions.js?20250328"></script>
   </body>
 <% end %>
 

--- a/app/views/layouts/stash_engine/application.html.erb
+++ b/app/views/layouts/stash_engine/application.html.erb
@@ -14,7 +14,7 @@
   <%= yield %>
   </main>
   <%= render partial: "stash_engine/shared/footer" %>
-  <script type="text/javascript" src="/javascript/interactions.js?20250327"></script>
+  <script type="text/javascript" src="/javascript/interactions.js?20250328"></script>
   <%= render partial: "stash_engine/shared/dialog_confirm" %>
   <%= render partial: "stash_engine/shared/dialog_modal" %>
   <%= content_for :doc_end %>

--- a/app/views/stash_engine/admin_dashboard/results.js.erb
+++ b/app/views/stash_engine/admin_dashboard/results.js.erb
@@ -25,3 +25,9 @@ document.getElementById('clear_filters').removeEventListener('click', clearFilte
 document.getElementById('clear_filters').addEventListener('click', clearFilters)
 document.getElementById('count_form_button').click();
 <% if params[:pressed].present? %>document.querySelector('*[data-sort=<%=params[:pressed]%>]').focus()<% end %>
+
+var noClicks = Array.from(document.getElementsByClassName('prevent-click'));
+noClicks.forEach(button => {
+  button.removeEventListener('click', preventClicks);
+  button.addEventListener('click', preventClicks);
+});

--- a/app/views/stash_engine/admin_datasets/_dangerous_actions.html.erb
+++ b/app/views/stash_engine/admin_datasets/_dangerous_actions.html.erb
@@ -2,10 +2,9 @@
 <div id="dangerous_actions">
   <h2>Dangerous actions</h2>
   <div>
-    <%= form_with(url: stash_url_helpers.metadata_entry_pages_new_version_path,
-                  method: :post, :html => { onsubmit: "document.body.classList.add('prevent-clicks')" }) do -%>
+    <%= form_with(url: stash_url_helpers.metadata_entry_pages_new_version_path, method: :post) do -%>
       <p>
-        <button class="o-button__plain-text7"><i class="fas fa-pencil" aria-hidden="true"></i> Forcibly edit dataset</button>
+        <button class="o-button__plain-text7 prevent-click"><i class="fas fa-pencil" aria-hidden="true"></i> Forcibly edit dataset</button>
         &nbsp;Note: Forcibly editing a dataset will assign it to you, and begin an editing session. Please only do this if you know the author is unable/unwilling to submit it.
       </p>
       <%= hidden_field_tag :resource_id, r&.id, id: "resource_id_#{r&.id}" %>
@@ -13,9 +12,9 @@
   </div>
 
   <% if policy(@identifier).destroy? %>
-    <%= form_with(url: stash_url_helpers.ds_admin_destroy_path(id: @identifier&.id), method: :delete, :html => { onsubmit: "document.body.classList.add('prevent-clicks')" }) do -%>
+    <%= form_with(url: stash_url_helpers.ds_admin_destroy_path(id: @identifier&.id), method: :delete) do -%>
       <p>
-        <button class="o-button__plain-text7" data-confirm="Are you sure you want to permanently delete this dataset? This action cannot be undone."><i class="fas fa-trash" aria-hidden="true"></i> Remove dataset</button>
+        <button class="o-button__plain-text7 prevent-click" data-confirm="Are you sure you want to permanently delete this dataset? This action cannot be undone."><i class="fas fa-trash" aria-hidden="true"></i> Remove dataset</button>
         &nbsp;Note: Deleting a dataset will delete all its data and files.
       </p>
       <%= hidden_field_tag :id, @identifier.id, id: "identifier_id_#{@identifier.id}" %>
@@ -32,12 +31,11 @@
         end
         sel_idx = resource_list[-2]&.id || resource_list.last.id
       %>
-      <%= form_with(url: metadata_entry_pages_new_version_from_previous_path,
-                    method: :post, :html => { onsubmit: "document.body.classList.add('prevent-clicks')" }) do |f| -%>
+      <%= form_with(url: metadata_entry_pages_new_version_from_previous_path, method: :post) do |f| -%>
 
         <%= f.label :select_res, 'Select basis version:' %>
         <%= f.select(:resource_id, options_for_select(sel_list, sel_idx), {}, id: 'select_res', class: 'c-input__select') %>&nbsp;&nbsp;
-        <button class="o-button__submit">Create new version</button>
+        <button class="o-button__submit prevent-click">Create new version</button>
         <p>
           Note: Creating and editing a new version based on an old one does not duplicate the old files, but <em>just
           the user-entered metadata</em>. The files may need to be manually deleted or uploaded if the files in the

--- a/app/views/stash_engine/admin_datasets/index.html.erb
+++ b/app/views/stash_engine/admin_datasets/index.html.erb
@@ -212,4 +212,9 @@
       document.getElementById('c-input_publication_date').setAttribute('hidden', 'hidden');
     }
   }
+  var noClicks = Array.from(document.getElementsByClassName('prevent-click'));
+  noClicks.forEach(button => {
+    button.removeEventListener('click', preventClicks);
+    button.addEventListener('click', preventClicks);
+  });
 </script>

--- a/app/views/stash_engine/dashboard/_user_datasets.html.erb
+++ b/app/views/stash_engine/dashboard/_user_datasets.html.erb
@@ -53,7 +53,7 @@
                 <% end %>
               <% end %>
               <% if policy(dataset).delete? %>
-                <%= button_to stash_url_helpers.resource_path(dataset), method: :delete, data: { confirm: delete_confirm }, name: 'delete', form_class: 'o-button__inline-form', class: 'o-button__plain-text7', title: dataset&.stash_version.version > 1 ? 'Revert to previous version' : 'Delete dataset' do %>
+                <%= button_to stash_url_helpers.resource_path(dataset), method: :delete, data: { confirm: delete_confirm }, name: 'delete', form_class: 'o-button__inline-form', class: 'o-button__plain-text7 prevent-click', title: dataset&.stash_version.version > 1 ? 'Revert to previous version' : 'Delete dataset' do %>
                   <i class="fas fa-trash-can" aria-hidden="true"></i><%= dataset&.stash_version.version > 1 ? 'Revert' : 'Delete' %><span class="screen-reader-only"> <%= dataset.identifier.identifier %></span>
                 <% end %>
               <% end %>

--- a/app/views/stash_engine/dashboard/user_datasets.js.erb
+++ b/app/views/stash_engine/dashboard/user_datasets.js.erb
@@ -1,1 +1,7 @@
 document.getElementById('user_datasets').innerHTML = "<%= escape_javascript(render(partial: 'user_datasets')) %>";
+
+var noClicks = Array.from(document.getElementsByClassName('prevent-click'));
+noClicks.forEach(button => {
+  button.removeEventListener('click', preventClicks);
+  button.addEventListener('click', preventClicks);
+});

--- a/public/javascript/interactions.js
+++ b/public/javascript/interactions.js
@@ -16,6 +16,16 @@ function copyEmail(e) {
   });
 }
 
+function preventClicks(e) {
+  e.preventDefault();
+  const button = e.currentTarget;
+  const icon = button.querySelector('i');
+  icon.className = 'fas fa-spinner fa-spin';
+  document.body.classList.add('prevent-clicks');
+  if (button.form) button.form.submit();
+  button.disabled = true;
+}
+
 var emails = document.getElementsByClassName('emailr');
 for (var i=0; i < emails.length; i++) {
   const element = emails[i];
@@ -132,17 +142,6 @@ expandButtons.forEach(button => {
       e.preventDefault()
       expandButtonMenu(e)
     }
-  });
-});
-
-var noClicks = Array.from(document.getElementsByClassName('prevent-click'));
-noClicks.forEach(button => {
-  button.addEventListener('click', (e) => {
-    var icon = button.querySelector('i');
-    icon.className = 'fas fa-spinner fa-spin';
-    document.body.classList.add('prevent-clicks');
-    if (button.form) button.form.submit();
-    button.disabled = true;
   });
 });
 


### PR DESCRIPTION
Because of the order of loading for the javascript-inserted content, the general double-click prevention javascript was not effective for things like the user datasets list and the admin dashboard results. Everything is now moved around to be loaded correctly, so the code applies everywhere it is needed. Tested and works in all cases.

Related to https://github.com/datadryad/dryad-product-roadmap/issues/4035