### PR TITLE
Create fee calculator UI

### DIFF
--- a/app/assets/stylesheets/scss/_contact.scss
+++ b/app/assets/stylesheets/scss/_contact.scss
@@ -27,7 +27,7 @@
   padding: .5ch;
   background-color: white;
   text-align: center;
-  &:before {
-    content: '$';
+  &:empty:before {
+    content: '\00a0';
   }
 }

--- a/app/assets/stylesheets/scss/_contact.scss
+++ b/app/assets/stylesheets/scss/_contact.scss
@@ -7,3 +7,27 @@
   direction: rtl;
   white-space: nowrap;
 }
+
+.range-grid {
+  display: grid;
+  grid-template-columns: 13ch 1fr 5ch;
+  align-items: center;
+  column-gap: 1ch;
+  row-gap: 2ch;
+  max-width: 90%;
+
+  output:after {
+    content: '%';
+  }
+}
+
+#total_estimate {
+  flex: 1;
+  font-size: 1.25rem;
+  padding: .5ch;
+  background-color: white;
+  text-align: center;
+  &:before {
+    content: '$';
+  }
+}

--- a/app/assets/stylesheets/scss/_input.scss
+++ b/app/assets/stylesheets/scss/_input.scss
@@ -24,6 +24,11 @@ input {
 		justify-content: space-between;
   	align-items: baseline;
   }
+
+  &.center {
+  	align-items: center;
+  	column-gap: 1ch;
+  }
 }
 
 .input-label {
@@ -140,7 +145,7 @@ label.optional:after {
 .c-input__select {
 	@extend %c-input__element;
 	height: $input-height;
-	padding: 0 35px 0 5px;
+	padding: 0 38px 0 5px;
 	border-radius: 0;
 	background: url('/images/scss/icon_up-down-arrows.svg') right 10px center / 12px no-repeat, linear-gradient($light-blue, $light-blue) right / $input-height $input-height no-repeat;
 	background-color: white;

--- a/app/controllers/fee_calculator_controller.rb
+++ b/app/controllers/fee_calculator_controller.rb
@@ -28,9 +28,10 @@ class FeeCalculatorController < ApplicationController
   def institution_permit_params
     attrs = params.permit(
       :low_middle_income_country,
-      :dpc_tier, :service_tier, storage_usage: %w[0 1 2 3 4 5 6]
+      :dpc_tier, :service_tier, :cover_storage_fee, storage_usage: %w[0 1 2 3 4 5 6]
     )
     attrs[:low_middle_income_country] = ActiveModel::Type::Boolean.new.cast(attrs[:low_middle_income_country])
+    attrs[:cover_storage_fee] = ActiveModel::Type::Boolean.new.cast(attrs[:cover_storage_fee])
     attrs
   end
 

--- a/app/services/fee_calculator/base_service.rb
+++ b/app/services/fee_calculator/base_service.rb
@@ -32,7 +32,7 @@ module FeeCalculator
     ].freeze
     # rubocop:enable Layout/SpaceInsideRangeLiteral, Layout/ExtraSpacing
 
-    def initialize(options, for_dataset: false)
+    def initialize(options = {}, for_dataset: false)
       @sum = 0
       @options = options
       @sum_options = {}

--- a/app/services/fee_calculator/institution_service.rb
+++ b/app/services/fee_calculator/institution_service.rb
@@ -19,24 +19,6 @@ module FeeCalculator
     ].freeze
     # rubocop:enable Layout/SpaceInsideRangeLiteral, Layout/ExtraSpacing
 
-    def self.service_fee_tiers
-      NORMAL_SERVICE_FEE
-    end
-
-    def self.low_middle_tiers
-      LOW_MIDDLE_SERVICE_FEE
-    end
-
-    def self.storage_fee_tiers
-      ESTIMATED_FILES_SIZE
-    end
-
-    def self.dpc_fee_tiers
-      ESTIMATED_DATASETS
-    end
-
-    private
-
     def service_fee_tiers
       return LOW_MIDDLE_SERVICE_FEE if options[:low_middle_income_country]
 

--- a/app/services/fee_calculator/institution_service.rb
+++ b/app/services/fee_calculator/institution_service.rb
@@ -19,6 +19,22 @@ module FeeCalculator
     ].freeze
     # rubocop:enable Layout/SpaceInsideRangeLiteral, Layout/ExtraSpacing
 
+    def self.service_fee_tiers
+      NORMAL_SERVICE_FEE
+    end
+
+    def self.low_middle_tiers
+      LOW_MIDDLE_SERVICE_FEE
+    end
+
+    def self.storage_fee_tiers
+      ESTIMATED_FILES_SIZE
+    end
+
+    def self.dpc_fee_tiers
+      ESTIMATED_DATASETS
+    end
+
     private
 
     def service_fee_tiers

--- a/app/services/fee_calculator/publisher_service.rb
+++ b/app/services/fee_calculator/publisher_service.rb
@@ -15,28 +15,8 @@ module FeeCalculator
     ].freeze
     # rubocop:enable Layout/SpaceInsideRangeLiteral, Layout/ExtraSpacing
 
-    def self.service_fee_tiers
-      SERVICE_FEE
-    end
-
-    def self.dpc_fee_tiers
-      ESTIMATED_DATASETS
-    end
-
-    def self.storage_fee_tiers
-      ESTIMATED_FILES_SIZE
-    end
-
-    private
-
     def service_fee_tiers
       SERVICE_FEE
-    end
-
-    def add_storage_usage_fees
-      return unless options[:cover_storage_fee]
-
-      super
     end
 
     def storage_fee_tiers
@@ -45,6 +25,14 @@ module FeeCalculator
 
     def dpc_fee_tiers
       ESTIMATED_DATASETS
+    end
+
+    private
+
+    def add_storage_usage_fees
+      return unless options[:cover_storage_fee]
+
+      super
     end
   end
 end

--- a/app/services/fee_calculator/publisher_service.rb
+++ b/app/services/fee_calculator/publisher_service.rb
@@ -15,6 +15,18 @@ module FeeCalculator
     ].freeze
     # rubocop:enable Layout/SpaceInsideRangeLiteral, Layout/ExtraSpacing
 
+    def self.service_fee_tiers
+      SERVICE_FEE
+    end
+
+    def self.dpc_fee_tiers
+      ESTIMATED_DATASETS
+    end
+
+    def self.storage_fee_tiers
+      ESTIMATED_FILES_SIZE
+    end
+
     private
 
     def service_fee_tiers

--- a/app/views/fee_calculator/_institution.html.erb
+++ b/app/views/fee_calculator/_institution.html.erb
@@ -40,7 +40,7 @@
   </p>
   <div class="input-line spaced" style="justify-content: stretch;">
     <h3 style="font-weight: bold">Annual partner fee estimate:</h3>
-    <p id="total_estimate">5000</p>
+    <output id="total_estimate" for="service_tier dpc_tier">5000</output>
     <p><%= form.submit 'Recalculate', class: 'o-button__plain-text2' %></p>
   </div>
 <% end %>

--- a/app/views/fee_calculator/_institution.html.erb
+++ b/app/views/fee_calculator/_institution.html.erb
@@ -10,22 +10,22 @@
   </p>
   <p class="input-line center" id="service_tier0">
     <%= form.label :service_tier, 'Your annual research expenditure:' %>
-    <%= form.select :service_tier, options_for_select(FeeCalculator::InstitutionService.service_fee_tiers.map {|t| [t[:range].to_s.split('..').map {|n| n.to_i.to_s == n ? (n.to_i > 999999 ? number_to_currency(number_to_human(n), precision: 0) : number_to_currency(n, precision: 0)) : nil}.join('-').gsub(/\-$/, '+').downcase, t[:tier]]}), {}, {class: 'c-input__select'} %>
+    <%= form.select :service_tier, options_for_select(FeeCalculator::InstitutionService.new.service_fee_tiers.map {|t| [t[:range].to_s.split('..').map {|n| n.to_i.to_s == n ? (n.to_i > 999999 ? number_to_currency(number_to_human(n), precision: 0) : number_to_currency(n, precision: 0)) : nil}.join('-').gsub(/\-$/, '+').downcase, t[:tier]]}), {}, {class: 'c-input__select'} %>
   </p>
   <p class="input-line center" id="service_tier1" hidden>
     <%= form.label :service_tier, 'Your annual research expenditure:' %>
-    <%= form.select :service_tier, options_for_select(FeeCalculator::InstitutionService.low_middle_tiers.map {|t| [t[:range].to_s.split('..').map {|n| n.to_i.to_s == n ? (n.to_i > 999999 ? number_to_currency(number_to_human(n), precision: 0) : number_to_currency(n, precision: 0)) : nil}.join('-').gsub(/\-$/, '+').downcase, t[:tier]]}), {}, {class: 'c-input__select', disabled: true} %>
+    <%= form.select :service_tier, options_for_select(FeeCalculator::InstitutionService.new({low_middle_income_country: true}).service_fee_tiers.map {|t| [t[:range].to_s.split('..').map {|n| n.to_i.to_s == n ? (n.to_i > 999999 ? number_to_currency(number_to_human(n), precision: 0) : number_to_currency(n, precision: 0)) : nil}.join('-').gsub(/\-$/, '+').downcase, t[:tier]]}), {}, {class: 'c-input__select', disabled: true} %>
   </p>
   <p class="input-line center">
     <%= form.label :dpc_tier, 'Estimated number of datasets sent to Dryad each year:' %>
-    <%= form.select :dpc_tier, options_for_select(FeeCalculator::InstitutionService.dpc_fee_tiers.map {|t| [t[:range].to_s.gsub('..', '-'), t[:tier]]}), {}, {class: 'c-input__select'} %>
+    <%= form.select :dpc_tier, options_for_select(FeeCalculator::InstitutionService.new.dpc_fee_tiers.map {|t| [t[:range].to_s.gsub('..', '-'), t[:tier]]}), {}, {class: 'c-input__select'} %>
   </p>
   <p id="legend" style="margin-top: 2rem;">The estimated percentages of these datasets that will be of the size ranges:</p>
   <div role="group" aria-labeledby="legend" class="range-grid">
     <label for="sft0">0-10GB</label>
     <%= form.range_field 'storage_usage[0]', min: 0, max: 100, value: 100, id: 'sft0' %>
     <output for="sft0">100</output>
-    <% FeeCalculator::InstitutionService.storage_fee_tiers.each do |sft| %>
+    <% FeeCalculator::InstitutionService.new.storage_fee_tiers.each do |sft| %>
       <label for="sft<%= sft[:tier] %>"><%= sft[:range].to_s.split('..').map {|n| filesize(n.to_i) }.join('-') %></label>
       <%= form.range_field "storage_usage[#{sft[:tier]}]", min: 0, max: 100, value: 0, id: "sft#{sft[:tier]}" %>
       <output for="sft<%= sft[:tier] %>">0</output>
@@ -40,7 +40,7 @@
   </p>
   <div class="input-line spaced" style="justify-content: stretch;">
     <h3 style="font-weight: bold">Annual partner fee estimate:</h3>
-    <output id="total_estimate" for="service_tier dpc_tier">5000</output>
+    <output id="total_estimate" for="service_tier dpc_tier"></output>
     <p><%= form.submit 'Recalculate', class: 'o-button__plain-text2' %></p>
   </div>
 <% end %>

--- a/app/views/fee_calculator/_institution.html.erb
+++ b/app/views/fee_calculator/_institution.html.erb
@@ -1,0 +1,62 @@
+<%= form_with(url: stash_url_helpers.fee_calculator_path, method: :get, local: false, html: {class: 'callout alt', style: 'padding: 0 2ch'} ) do |form| %>
+  <h2 style="font-weight: bold; text-align: center; padding-top: 1ch">Fee calculator</h2>
+  <%= form.hidden_field 'type', value: 'institution' %>
+  <p class="input-line center">
+    <span id="legend3">Are you based in a lower- or middle-income country?</span>
+    <span role="group" aria-labelledby="legend3" class="radio_choice" id="low_middle">
+      <label><input type="radio" name="low_middle_income_country" value="1"/>Yes</label>
+      <label><input type="radio" name="low_middle_income_country" value="0" checked/>No</label>
+    </span>
+  </p>
+  <p class="input-line center" id="service_tier0">
+    <%= form.label :service_tier, 'Your annual research expenditure:' %>
+    <%= form.select :service_tier, options_for_select(FeeCalculator::InstitutionService.service_fee_tiers.map {|t| [t[:range].to_s.split('..').map {|n| n.to_i.to_s == n ? (n.to_i > 999999 ? number_to_currency(number_to_human(n), precision: 0) : number_to_currency(n, precision: 0)) : nil}.join('-').gsub(/\-$/, '+').downcase, t[:tier]]}), {}, {class: 'c-input__select'} %>
+  </p>
+  <p class="input-line center" id="service_tier1" hidden>
+    <%= form.label :service_tier, 'Your annual research expenditure:' %>
+    <%= form.select :service_tier, options_for_select(FeeCalculator::InstitutionService.low_middle_tiers.map {|t| [t[:range].to_s.split('..').map {|n| n.to_i.to_s == n ? (n.to_i > 999999 ? number_to_currency(number_to_human(n), precision: 0) : number_to_currency(n, precision: 0)) : nil}.join('-').gsub(/\-$/, '+').downcase, t[:tier]]}), {}, {class: 'c-input__select', disabled: true} %>
+  </p>
+  <p class="input-line center">
+    <%= form.label :dpc_tier, 'Estimated number of datasets sent to Dryad each year:' %>
+    <%= form.select :dpc_tier, options_for_select(FeeCalculator::InstitutionService.dpc_fee_tiers.map {|t| [t[:range].to_s.gsub('..', '-'), t[:tier]]}), {}, {class: 'c-input__select'} %>
+  </p>
+  <p id="legend" style="margin-top: 2rem;">The estimated percentages of these datasets that will be of the size ranges:</p>
+  <div role="group" aria-labeledby="legend" class="range-grid">
+    <label for="sft0">0-10GB</label>
+    <%= form.range_field 'storage_usage[0]', min: 0, max: 100, value: 100, id: 'sft0' %>
+    <output for="sft0">100</output>
+    <% FeeCalculator::InstitutionService.storage_fee_tiers.each do |sft| %>
+      <label for="sft<%= sft[:tier] %>"><%= sft[:range].to_s.split('..').map {|n| filesize(n.to_i) }.join('-') %></label>
+      <%= form.range_field "storage_usage[#{sft[:tier]}]", min: 0, max: 100, value: 0, id: "sft#{sft[:tier]}" %>
+      <output for="sft<%= sft[:tier] %>">0</output>
+    <% end %>
+  </div>
+  <p class="input-line center" style="margin-top: 2rem;">
+    <span id="legend2">Will you cover large data storage fees for your authors?</span>
+    <span role="group" aria-labelledby="legend2" class="radio_choice">
+      <label><input type="radio" name="cover_storage_fee" value="1" checked/>Yes</label>
+      <label><input type="radio" name="cover_storage_fee" value="0"/>No</label>
+    </span>
+  </p>
+  <div class="input-line spaced" style="justify-content: stretch;">
+    <h3 style="font-weight: bold">Annual partner fee estimate:</h3>
+    <p id="total_estimate">5000</p>
+    <p><%= form.submit 'Recalculate', class: 'o-button__plain-text2' %></p>
+  </div>
+<% end %>
+
+<script type="text/javascript">
+  document.querySelectorAll('#low_middle input').forEach(r =>
+    r.addEventListener('click', e => {
+      if (r.checked) {
+        const show = document.getElementById(`service_tier${r.value}`)
+        const hide = document.getElementById(`service_tier${r.value == 0 ? 1 : 0}`)
+        show.querySelector('select').disabled = false
+        hide.querySelector('select').disabled = true
+        hide.hidden = true
+        show.hidden = false
+      }
+    })
+  )
+</script>
+<script type="text/javascript" src="javascript/calculator.js" ></script>

--- a/app/views/fee_calculator/_publisher.html.erb
+++ b/app/views/fee_calculator/_publisher.html.erb
@@ -3,18 +3,18 @@
   <%= form.hidden_field 'type', value: 'publisher' %>
   <p class="input-line center">
     <%= form.label :service_tier, 'Your annual publishing revenue/expenditure:' %>
-    <%= form.select :service_tier, options_for_select(FeeCalculator::PublisherService.service_fee_tiers.map {|t| [t[:range].to_s.split('..').map {|n| n.to_i.to_s == n ? (n.to_i > 999999 ? number_to_currency(number_to_human(n), precision: 0) : number_to_currency(n, precision: 0)) : nil}.join('-').gsub(/\-$/, '+').downcase, t[:tier]]}), {}, {class: 'c-input__select'} %>
+    <%= form.select :service_tier, options_for_select(FeeCalculator::PublisherService.new.service_fee_tiers.map {|t| [t[:range].to_s.split('..').map {|n| n.to_i.to_s == n ? (n.to_i > 999999 ? number_to_currency(number_to_human(n), precision: 0) : number_to_currency(n, precision: 0)) : nil}.join('-').gsub(/\-$/, '+').downcase, t[:tier]]}), {}, {class: 'c-input__select'} %>
   </p>
   <p class="input-line center">
     <%= form.label :dpc_tier, 'Estimated number of datasets sent to Dryad each year:' %>
-    <%= form.select :dpc_tier, options_for_select(FeeCalculator::PublisherService.dpc_fee_tiers.map {|t| [t[:range].to_s.gsub('..', '-'), t[:tier]]}), {}, {class: 'c-input__select'} %>
+    <%= form.select :dpc_tier, options_for_select(FeeCalculator::PublisherService.new.dpc_fee_tiers.map {|t| [t[:range].to_s.gsub('..', '-'), t[:tier]]}), {}, {class: 'c-input__select'} %>
   </p>
   <p id="legend" style="margin-top: 2rem;">The estimated percentages of these datasets that will be of the size ranges:</p>
   <div role="group" aria-labeledby="legend" class="range-grid">
     <label for="sft0">0-10GB</label>
     <%= form.range_field 'storage_usage[0]', min: 0, max: 100, value: 100, id: 'sft0' %>
     <output for="sft0">100</output>
-    <% FeeCalculator::PublisherService.storage_fee_tiers.each do |sft| %>
+    <% FeeCalculator::PublisherService.new.storage_fee_tiers.each do |sft| %>
       <label for="sft<%= sft[:tier] %>"><%= sft[:range].to_s.split('..').map {|n| filesize(n.to_i) }.join('-') %></label>
       <%= form.range_field "storage_usage[#{sft[:tier]}]", min: 0, max: 100, value: 0, id: "sft#{sft[:tier]}" %>
       <output for="sft<%= sft[:tier] %>">0</output>
@@ -29,7 +29,7 @@
   </p>
   <div class="input-line spaced" style="justify-content: stretch;">
     <h3 style="font-weight: bold">Annual partner fee estimate:</h3>
-    <output id="total_estimate" for="service_tier dpc_tier">1000</output>
+    <output id="total_estimate" for="service_tier dpc_tier"></output>
     <p><%= form.submit 'Recalculate', class: 'o-button__plain-text2' %></p>
   </div>
 <% end %>

--- a/app/views/fee_calculator/_publisher.html.erb
+++ b/app/views/fee_calculator/_publisher.html.erb
@@ -29,7 +29,7 @@
   </p>
   <div class="input-line spaced" style="justify-content: stretch;">
     <h3 style="font-weight: bold">Annual partner fee estimate:</h3>
-    <p id="total_estimate">1000</p>
+    <output id="total_estimate" for="service_tier dpc_tier">1000</output>
     <p><%= form.submit 'Recalculate', class: 'o-button__plain-text2' %></p>
   </div>
 <% end %>

--- a/app/views/fee_calculator/_publisher.html.erb
+++ b/app/views/fee_calculator/_publisher.html.erb
@@ -3,7 +3,7 @@
   <%= form.hidden_field 'type', value: 'publisher' %>
   <p class="input-line center">
     <%= form.label :service_tier, 'Your annual publishing revenue/expenditure:' %>
-    <%= form.select :service_tier, options_for_select(FeeCalculator::PublisherService.new.service_fee_tiers.map {|t| [t[:range].to_s.split('..').map {|n| n.to_i.to_s == n ? (n.to_i > 999999 ? number_to_currency(number_to_human(n), precision: 0) : number_to_currency(n, precision: 0)) : nil}.join('-').gsub(/\-$/, '+').downcase, t[:tier]]}), {}, {class: 'c-input__select'} %>
+    <%= form.select :service_tier, options_for_select(FeeCalculator::PublisherService.new.service_fee_tiers.map {|t| [t[:range].to_s.split('..').map {|n| n.to_i.to_s == n ? (n.to_i > 999999 ? number_to_currency(number_to_human(n), precision: 0) : number_to_currency(n.to_i.round(-1), precision: 0)) : nil}.join('-').gsub(/\-$/, '+').downcase, t[:tier]]}), {}, {class: 'c-input__select'} %>
   </p>
   <p class="input-line center">
     <%= form.label :dpc_tier, 'Estimated number of datasets sent to Dryad each year:' %>

--- a/app/views/fee_calculator/_publisher.html.erb
+++ b/app/views/fee_calculator/_publisher.html.erb
@@ -1,0 +1,36 @@
+<%= form_with(url: stash_url_helpers.fee_calculator_path, method: :get, local: false, html: {class: 'callout alt', style: 'padding: 0 2ch'} ) do |form| %>
+  <h2 style="font-weight: bold; text-align: center; padding-top: 1ch">Fee calculator</h2>
+  <%= form.hidden_field 'type', value: 'publisher' %>
+  <p class="input-line center">
+    <%= form.label :service_tier, 'Your annual publishing revenue/expenditure:' %>
+    <%= form.select :service_tier, options_for_select(FeeCalculator::PublisherService.service_fee_tiers.map {|t| [t[:range].to_s.split('..').map {|n| n.to_i.to_s == n ? (n.to_i > 999999 ? number_to_currency(number_to_human(n), precision: 0) : number_to_currency(n, precision: 0)) : nil}.join('-').gsub(/\-$/, '+').downcase, t[:tier]]}), {}, {class: 'c-input__select'} %>
+  </p>
+  <p class="input-line center">
+    <%= form.label :dpc_tier, 'Estimated number of datasets sent to Dryad each year:' %>
+    <%= form.select :dpc_tier, options_for_select(FeeCalculator::PublisherService.dpc_fee_tiers.map {|t| [t[:range].to_s.gsub('..', '-'), t[:tier]]}), {}, {class: 'c-input__select'} %>
+  </p>
+  <p id="legend" style="margin-top: 2rem;">The estimated percentages of these datasets that will be of the size ranges:</p>
+  <div role="group" aria-labeledby="legend" class="range-grid">
+    <label for="sft0">0-10GB</label>
+    <%= form.range_field 'storage_usage[0]', min: 0, max: 100, value: 100, id: 'sft0' %>
+    <output for="sft0">100</output>
+    <% FeeCalculator::PublisherService.storage_fee_tiers.each do |sft| %>
+      <label for="sft<%= sft[:tier] %>"><%= sft[:range].to_s.split('..').map {|n| filesize(n.to_i) }.join('-') %></label>
+      <%= form.range_field "storage_usage[#{sft[:tier]}]", min: 0, max: 100, value: 0, id: "sft#{sft[:tier]}" %>
+      <output for="sft<%= sft[:tier] %>">0</output>
+    <% end %>
+  </div>
+  <p class="input-line center" style="margin-top: 2rem;">
+    <span id="legend2">Will you cover large data storage fees for your authors?</span>
+    <span role="group" aria-labelledby="legend2" class="radio_choice">
+      <label><input type="radio" name="cover_storage_fee" value="1" checked/>Yes</label>
+      <label><input type="radio" name="cover_storage_fee" value="0"/>No</label>
+    </span>
+  </p>
+  <div class="input-line spaced" style="justify-content: stretch;">
+    <h3 style="font-weight: bold">Annual partner fee estimate:</h3>
+    <p id="total_estimate">1000</p>
+    <p><%= form.submit 'Recalculate', class: 'o-button__plain-text2' %></p>
+  </div>
+<% end %>
+<script type="text/javascript" src="javascript/calculator.js"></script>

--- a/app/views/fee_calculator/_table_asf.html.erb
+++ b/app/views/fee_calculator/_table_asf.html.erb
@@ -1,0 +1,8 @@
+<% tiers = calc_model.service_fee_tiers %>
+<% tiers.each do |t| %>
+  <tr>
+    <td><%= t[:tier]%></td>
+    <td><%= t[:range].to_s.split('..').map {|n| n.to_i.to_s == n ? (n.to_i > 999999 ? number_to_currency(number_to_human(n), precision: 0) : number_to_currency(n.to_i.round(-1), precision: 0)) : nil}.join('-').gsub(/\-$/, '+').downcase %></td>
+    <td><%= number_to_currency(t[:price], precision: 0) %></td>
+  </tr>
+<% end %>

--- a/app/views/fee_calculator/_table_dpc.html.erb
+++ b/app/views/fee_calculator/_table_dpc.html.erb
@@ -1,0 +1,15 @@
+<% tiers = FeeCalculator::InstitutionService.new.dpc_fee_tiers %>
+<% tiers.each do |t| %>
+  <tr>
+    <td><%= t[:tier]%></td>
+    <td><%= t[:range].to_s.gsub('..', '-') %></td>
+    <td><%= number_to_currency(t[:price], precision: 0) %></td>
+  </tr>
+  <% if t == tiers.last %>
+    <tr>
+      <td><%= t[:tier] + 1 %></td>
+      <td>><%= t[:range].to_s.split('..').last %></td>
+      <td>Contact us to discuss rates</td>
+    </tr>
+  <% end %>
+<% end %>

--- a/app/views/fee_calculator/_table_ldf.html.erb
+++ b/app/views/fee_calculator/_table_ldf.html.erb
@@ -1,0 +1,7 @@
+<% tiers = FeeCalculator::InstitutionService.new.storage_fee_tiers %>
+<% tiers.each do |t| %>
+  <tr>
+    <td><%= t[:range].to_s.split('..').map {|n| filesize(n.to_i) }.join('-') %></td>
+    <td><%= number_to_currency(t[:price], precision: 0) %></td>
+  </tr>
+<% end %>

--- a/app/views/fee_calculator/_table_myc.html.erb
+++ b/app/views/fee_calculator/_table_myc.html.erb
@@ -1,0 +1,10 @@
+<% tiers = calc_model.service_fee_tiers %>
+<% tiers.each do |t| %>
+  <tr>
+    <td><%= t[:tier]%></td>
+    <td><%= t[:range].to_s.split('..').map {|n| n.to_i.to_s == n ? (n.to_i > 999999 ? number_to_currency(number_to_human(n), precision: 0) : number_to_currency(n.to_i.round(-1), precision: 0)) : nil}.join('-').gsub(/\-$/, '+').downcase %></td>
+    <td><%= number_to_currency((t[:price] / 2), precision: 0) %></td>
+    <td><%= number_to_currency((t[:price] * 0.75), precision: 0) %></td>
+    <td><%= number_to_currency(t[:price], precision: 0) %></td>
+  </tr>
+<% end %>

--- a/app/views/stash_engine/pages/_fees_institution.html.md
+++ b/app/views/stash_engine/pages/_fees_institution.html.md
@@ -135,9 +135,7 @@ The DPC is based on the variable costs of curating, publishing, and preserving o
 </div>
 </div>
 
-
-Datasets larger than 10GB are billed individually as follows.
-
+Datasets larger than 10GB are billed individually as follows. Institutional partners may opt to cover large data fees or assign them to the author.
 
 <div style="text-align: center;">
 <div class="table-wrapper" role="region" tabindex="0" style="margin: 0 auto">
@@ -309,11 +307,9 @@ To promote transparency and equity among our partners Dryad does not offer indiv
 </div>
 </div>
 
-
 #### Lower- and middle-income countries
 
 Annual Service Fees for institutions based in lower- and middle-income countries are as follows.
-
 
 <div style="text-align: center;">
 <div class="table-wrapper" role="region" tabindex="0" style="margin: 0 auto">

--- a/app/views/stash_engine/pages/_fees_institution.html.md
+++ b/app/views/stash_engine/pages/_fees_institution.html.md
@@ -16,9 +16,9 @@ Our institution and research partners also benefit from:
 
 The annual partner fee is calculated as a total of the anticipated Data Publication Charge (DPC) for the coming year, plus the Annual Service Fee. DPCs are adjusted to reflect actual usage at year-end.
 
-Read on for a detailed fee schedule.
+Estimate your organization’s total fees using our fee calculator, or read on for a detailed fee schedule.
 
-[Estimate your organization’s total fees using our fee calculator, or read on for a detailed fee schedule.]: #
+<%= render partial: 'fee_calculator/institution' %>
 
 <a href="mailto:partnerships@datadryad.org?subject=Dryad partnership inquiry">Contact us</a> with questions, to discuss partnership, or to confirm the estimated partner fee for your organization.
 

--- a/app/views/stash_engine/pages/_fees_institution.html.md
+++ b/app/views/stash_engine/pages/_fees_institution.html.md
@@ -45,91 +45,7 @@ The DPC is based on the variable costs of curating, publishing, and preserving o
       </tr>
     </thead>
     <tbody>
-      <tr>
-        <td>1</td>
-        <td>0-5</td>
-        <td>$0</td>
-      </tr>
-      <tr>
-        <td>2</td>
-        <td>6-15</td>
-        <td>$1,650</td>
-      </tr>
-      <tr>
-        <td>3</td>
-        <td>16-25</td>
-        <td>$2,700</td>
-      </tr>
-      <tr>
-        <td>4</td>
-        <td>26-50</td>
-        <td>$5,350</td>
-      </tr>
-      <tr>
-        <td>5</td>
-        <td>51-75</td>
-        <td>$7,950</td>
-      </tr>
-      <tr>
-        <td>6</td>
-        <td>76-100</td>
-        <td>$10,500</td>
-      </tr>
-      <tr>
-        <td>7</td>
-        <td>101-150</td>
-        <td>$15,600</td>
-      </tr>
-      <tr>
-        <td>8</td>
-        <td>151-200</td>
-        <td>$20,500</td>
-      </tr>
-      <tr>
-        <td>9</td>
-        <td>201-250</td>
-        <td>$25,500</td>
-      </tr>
-      <tr>
-        <td>10</td>
-        <td>251-300</td>
-        <td>$30,250</td>
-      </tr>
-      <tr>
-        <td>11</td>
-        <td>301-350</td>
-        <td>$35,000</td>
-      </tr>
-      <tr>
-        <td>12</td>
-        <td>351-400</td>
-        <td>$39,500</td>
-      </tr>
-      <tr>
-        <td>13</td>
-        <td>401-450</td>
-        <td>$44,000</td>
-      </tr>
-      <tr>
-        <td>14</td>
-        <td>451-500</td>
-        <td>$48,750</td>
-      </tr>
-      <tr>
-        <td>15</td>
-        <td>501-550</td>
-        <td>$53,500</td>
-      </tr>
-      <tr>
-        <td>16</td>
-        <td>551-600</td>
-        <td>$58,250</td>
-      </tr>
-      <tr>
-        <td>17</td>
-        <td>>600</td>
-        <td>Contact us to discuss rates</td>
-      </tr>
+      <%= render partial: 'fee_calculator/table_dpc' %>
     </tbody>
   </table>
 </div>
@@ -151,30 +67,7 @@ Datasets larger than 10GB are billed individually as follows. Institutional part
       </tr>
     </thead>
     <tbody>
-      <tr>
-        <td>10-50GB</td>
-        <td>$259</td>
-      </tr>
-      <tr>
-        <td>50-100GB</td>
-        <td>$464</td>
-      </tr>
-      <tr>
-        <td>100-250GB</td>
-        <td>$1,132</td>
-      </tr>
-      <tr>
-        <td>250-500GB</td>
-        <td>$2,153</td>
-      </tr>
-      <tr>
-        <td>500GB-1TB</td>
-        <td>$4,347</td>
-      </tr>
-      <tr>
-        <td>1-2TB</td>
-        <td>$8,809</td>
-      </tr>
+      <%= render partial: 'fee_calculator/table_ldf' %>
     </tbody>
   </table>
 </div>
@@ -201,36 +94,7 @@ The annual fee for institutions is based on annual research expenditure.
       </tr>
     </thead>
     <tbody>
-      <tr>
-        <td>1</td>
-        <td>Up to $99 million</td>
-        <td>$5,000</td>
-      </tr>
-      <tr>
-        <td>2</td>
-        <td>$100-$250 million</td>
-        <td>$10,000</td>
-      </tr>
-      <tr>
-        <td>3</td>
-        <td>$250-$500 million</td>
-        <td>$20,000</td>
-      </tr>
-      <tr>
-        <td>4</td>
-        <td>$500-$750 million</td>
-        <td>$30,000</td>
-      </tr>
-      <tr>
-        <td>5</td>
-        <td>$750 million-$1 billion</td>
-        <td>$40,000</td>
-      </tr>
-      <tr>
-        <td>6</td>
-        <td>$1 billion+</td>
-        <td>$50,000</td>
-      </tr>
+      <%= render partial: 'fee_calculator/table_asf', locals: {calc_model: FeeCalculator::InstitutionService.new} %>
     </tbody>
   </table>
 </div>
@@ -260,48 +124,7 @@ To promote transparency and equity among our partners Dryad does not offer indiv
       </tr>
     </thead>
     <tbody>
-      <tr>
-        <td>1</td>
-        <td>Up to $99 million</td>
-        <td>$2,500</td>
-        <td>$3,750</td>
-        <td>$5,000</td>
-      </tr>
-      <tr>
-        <td>2</td>
-        <td>$100-$250 million</td>
-        <td>$5,000</td>
-        <td>$7,500</td>
-        <td>$10,000</td>
-      </tr>
-      <tr>
-        <td>3</td>
-        <td>$250-$500 million</td>
-        <td>$10,000</td>
-        <td>$15,000</td>
-        <td>$20,000</td>
-      </tr>
-      <tr>
-        <td>4</td>
-        <td>$500-$750 million</td>
-        <td>$15,000</td>
-        <td>$22,500</td>
-        <td>$30,000</td>
-      </tr>
-      <tr>
-        <td>5</td>
-        <td>$750 million-$1 billion</td>
-        <td>$20,000</td>
-        <td>$30,000</td>
-        <td>$40,000</td>
-      </tr>
-      <tr>
-        <td>6</td>
-        <td>$1 billion+</td>
-        <td>$25,000</td>
-        <td>$37,500</td>
-        <td>$50,000</td>
-      </tr>
+      <%= render partial: 'fee_calculator/table_myc', locals: {calc_model: FeeCalculator::InstitutionService.new} %>
     </tbody>
   </table>
 </div>
@@ -326,31 +149,7 @@ Annual Service Fees for institutions based in lower- and middle-income countries
       </tr>
     </thead>
     <tbody>
-      <tr>
-        <td>1</td>
-        <td><$5 million</td>
-        <td>$1,000</td>
-      </tr>
-      <tr>
-        <td>2</td>
-        <td>$5-$25 million</td>
-        <td>$1,500</td>
-      </tr>
-      <tr>
-        <td>3</td>
-        <td>$25-$50 million</td>
-        <td>$2,500</td>
-      </tr>
-      <tr>
-        <td>4</td>
-        <td>$50-$100 million</td>
-        <td>$5,000</td>
-      </tr>
-      <tr>
-        <td>5</td>
-        <td>$100 million+</td>
-        <td>$7,500</td>
-      </tr>
+      <%= render partial: 'fee_calculator/table_asf', locals: {calc_model: FeeCalculator::InstitutionService.new({low_middle_income_country: true})} %>
     </tbody>
   </table>
 </div>

--- a/app/views/stash_engine/pages/_fees_publisher.html.md
+++ b/app/views/stash_engine/pages/_fees_publisher.html.md
@@ -45,91 +45,7 @@ The DPC is based on the variable costs of curating, publishing, and preserving o
       </tr>
     </thead>
     <tbody>
-      <tr>
-        <td>1</td>
-        <td>0-5</td>
-        <td>$0</td>
-      </tr>
-      <tr>
-        <td>2</td>
-        <td>6-15</td>
-        <td>$1,650</td>
-      </tr>
-      <tr>
-        <td>3</td>
-        <td>16-25</td>
-        <td>$2,700</td>
-      </tr>
-      <tr>
-        <td>4</td>
-        <td>26-50</td>
-        <td>$5,350</td>
-      </tr>
-      <tr>
-        <td>5</td>
-        <td>51-75</td>
-        <td>$7,950</td>
-      </tr>
-      <tr>
-        <td>6</td>
-        <td>76-100</td>
-        <td>$10,500</td>
-      </tr>
-      <tr>
-        <td>7</td>
-        <td>101-150</td>
-        <td>$15,600</td>
-      </tr>
-      <tr>
-        <td>8</td>
-        <td>151-200</td>
-        <td>$20,500</td>
-      </tr>
-      <tr>
-        <td>9</td>
-        <td>201-250</td>
-        <td>$25,500</td>
-      </tr>
-      <tr>
-        <td>10</td>
-        <td>251-300</td>
-        <td>$30,250</td>
-      </tr>
-      <tr>
-        <td>11</td>
-        <td>301-350</td>
-        <td>$35,000</td>
-      </tr>
-      <tr>
-        <td>12</td>
-        <td>351-400</td>
-        <td>$39,500</td>
-      </tr>
-      <tr>
-        <td>13</td>
-        <td>401-450</td>
-        <td>$44,000</td>
-      </tr>
-      <tr>
-        <td>14</td>
-        <td>451-500</td>
-        <td>$48,750</td>
-      </tr>
-      <tr>
-        <td>15</td>
-        <td>501-550</td>
-        <td>$53,500</td>
-      </tr>
-      <tr>
-        <td>16</td>
-        <td>551-600</td>
-        <td>$58,250</td>
-      </tr>
-      <tr>
-        <td>17</td>
-        <td>>600</td>
-        <td>Contact us to discuss rates</td>
-      </tr>
+      <%= render partial: 'fee_calculator/table_dpc' %>
     </tbody>
   </table>
 </div>
@@ -151,30 +67,7 @@ Datasets larger than 10GB are billed individually as follows. Publisher and soci
       </tr>
     </thead>
     <tbody>
-      <tr>
-        <td>10-50GB</td>
-        <td>$259</td>
-      </tr>
-      <tr>
-        <td>50-100GB</td>
-        <td>$464</td>
-      </tr>
-      <tr>
-        <td>100-250GB</td>
-        <td>$1,132</td>
-      </tr>
-      <tr>
-        <td>250-500GB</td>
-        <td>$2,153</td>
-      </tr>
-      <tr>
-        <td>500GB-1TB</td>
-        <td>$4,347</td>
-      </tr>
-      <tr>
-        <td>1-2TB</td>
-        <td>$8,809</td>
-      </tr>
+      <%= render partial: 'fee_calculator/table_ldf' %>
     </tbody>
   </table>
 </div>
@@ -201,56 +94,7 @@ Annual Service Fees for Dryad publisher and society partners are tiered accordin
       </tr>
     </thead>
     <tbody>
-      <tr>
-        <td>1</td>
-        <td>$500,000 and below</td>
-        <td>$1,000</td>
-      </tr>
-      <tr>
-        <td>2</td>
-        <td>$500,000-$1 million</td>
-        <td>$2,500</td>
-      </tr>
-      <tr>
-        <td>3</td>
-        <td>$1-$5 million</td>
-        <td>$5,000</td>
-      </tr>
-      <tr>
-        <td>4</td>
-        <td>$5-$10 million</td>
-        <td>$7,500</td>
-      </tr>
-      <tr>
-        <td>5</td>
-        <td>$10-25 million</td>
-        <td>$10,000</td>
-      </tr>
-      <tr>
-        <td>6</td>
-        <td>$25-$50 million</td>
-        <td>$12,500</td>
-      </tr>
-      <tr>
-        <td>7</td>
-        <td>$50-$100 million</td>
-        <td>$15,000</td>
-      </tr>
-      <tr>
-        <td>8</td>
-        <td>$100-$200 million</td>
-        <td>$22,500</td>
-      </tr>
-      <tr>
-        <td>9</td>
-        <td>$200-500 million</td>
-        <td>$30,000</td>
-      </tr>
-      <tr>
-        <td>10</td>
-        <td>$500 million +</td>
-        <td>$40,000</td>
-      </tr>
+      <%= render partial: 'fee_calculator/table_asf', locals: {calc_model: FeeCalculator::PublisherService.new} %>
     </tbody>
   </table>
 </div>
@@ -280,76 +124,7 @@ To promote transparency and equity among our partners Dryad does not offer indiv
       </tr>
     </thead>
     <tbody>
-      <tr>
-        <td>1</td>
-        <td>$500,000 and below</td>
-        <td>$500</td>
-        <td>$750</td>
-        <td>$1,000</td>
-      </tr>
-      <tr>
-        <td>2</td>
-        <td>$500,000-$1 million</td>
-        <td>$1,250</td>
-        <td>$1,875</td>
-        <td>$2,500</td>
-      </tr>
-      <tr>
-        <td>3</td>
-        <td>$1-$5 million</td>
-        <td>$2,500</td>
-        <td>$3,750</td>
-        <td>$5,000</td>
-      </tr>
-      <tr>
-        <td>4</td>
-        <td>$5-$10 million</td>
-        <td>$3,750</td>
-        <td>$5,625</td>
-        <td>$7,500</td>
-      </tr>
-      <tr>
-        <td>5</td>
-        <td>$10-25 million</td>
-        <td>$5,000</td>
-        <td>$7,500</td>
-        <td>$10,000</td>
-      </tr>
-      <tr>
-        <td>6</td>
-        <td>$25-$50 million</td>
-        <td>$6,250</td>
-        <td>$9,375</td>
-        <td>$12,500</td>
-      </tr>
-      <tr>
-        <td>7</td>
-        <td>$50-$100 million</td>
-        <td>$7,500</td>
-        <td>$11,250</td>
-        <td>$15,000</td>
-      </tr>
-      <tr>
-        <td>8</td>
-        <td>$100-$200 million</td>
-        <td>$11,250</td>
-        <td>$16,875</td>
-        <td>$22,500</td>
-      </tr>
-      <tr>
-        <td>9</td>
-        <td>$200-500 million</td>
-        <td>$15,000</td>
-        <td>$22,500</td>
-        <td>$30,000</td>
-      </tr>
-      <tr>
-        <td>10</td>
-        <td>$500 million +</td>
-        <td>$20,000</td>
-        <td>$30,000</td>
-        <td>$40,000</td>
-      </tr>
+      <%= render partial: 'fee_calculator/table_myc', locals: {calc_model: FeeCalculator::PublisherService.new} %>
     </tbody>
   </table>
 </div>

--- a/app/views/stash_engine/pages/_fees_publisher.html.md
+++ b/app/views/stash_engine/pages/_fees_publisher.html.md
@@ -14,12 +14,11 @@ Our publisher and society partners also benefit from:
   <p style="text-align: center;">Learn more about <a href="/join_us">Dryad services and partner benefits</a></p>
 </div>
 
-
 The annual partner fee is calculated as a total of the anticipated Data Publication Charge (DPC) for the coming year, plus the Annual Service Fee. DPCs are adjusted to reflect actual usage at year-end.
 
-Read on for a detailed fee schedule.
+Estimate your organization’s total fees using our fee calculator, or read on for a detailed fee schedule.
 
-[Estimate your organization’s total fees using our fee calculator, or read on for a detailed fee schedule.]: #
+<%= render partial: 'fee_calculator/publisher' %>
 
 <a href="mailto:partnerships@datadryad.org?subject=Dryad partnership inquiry">Contact us</a> with questions, to discuss partnership, or to confirm the estimated partner fee for your organization.
 

--- a/app/views/stash_engine/pages/_join_us.html.md
+++ b/app/views/stash_engine/pages/_join_us.html.md
@@ -84,9 +84,7 @@ Institutions, publishers, academic societies, and others partner with Dryad to m
 
 <a href="mailto:partnerships@datadryad.org?subject=Dryad partnership inquiry">Contact us to learn more</a> about becoming a Dryad partner. 
 
-Consult the links below to explore our detailed fee schedule.
-
-[Consult the links below to estimate fees with our fee calculator and explore our detailed fee schedule.]: #
+Consult the links below to estimate fees with our fee calculator and explore our detailed fee schedule.
 
 <div style="display: flex; align-items: center; column-gap: 2ch; row-gap: 1ch; text-align: center; flex-wrap: wrap;">
   <a href="/institutions" class="o-link__buttonlink" style="flex: 1;"><i class="fas fa-building-columns" aria-hidden="true" style="font-size: 2em;"></i><br/>Institutional partnership fees</a>

--- a/public/javascript/calculator.js
+++ b/public/javascript/calculator.js
@@ -22,9 +22,12 @@ ranges.forEach(r => {
     }
   })
 })
-$(document).on("ajax:complete", function(status, response){
+$(window).on('load', function(){
+  document.querySelector('input[value="Recalculate"]').click();
+})
+$(document).on('ajax:complete', function(status, response){
   if (response.status === 200) {
     const {fees: {total}} = response.responseJSON;
-    document.getElementById('total_estimate').innerHTML = total;
+    document.getElementById('total_estimate').innerHTML = total.toLocaleString('en-US', {style: 'currency', currency: 'USD', maximumFractionDigits: 0});
   }
 })

--- a/public/javascript/calculator.js
+++ b/public/javascript/calculator.js
@@ -1,0 +1,30 @@
+const ranges = document.querySelectorAll('input[type=range]')
+ranges.forEach(r => {
+  r.addEventListener('change', () => {
+    r.nextElementSibling.value = r.value
+    const max = 100 - parseInt(r.value)
+    const taken = Array.from(ranges).reduce((t, ra) => ra.id !== r.id ? t += parseInt(ra.value) : t, 0)
+    const set = Array.from(ranges).reduce((s, ra) => {
+      if (ra.id !== r.id && parseInt(ra.value) > 0) s.push(ra)
+      return s
+    }, []).sort((a, b) => parseInt(b.value) - parseInt(a.value));
+    if (taken > max) {
+      let subt = taken - max;
+      set.forEach(or => {
+        if (subt > 0) {
+          let newVal = Math.round(parseInt(or.value) - subt);
+          if (newVal < 0) newVal = 0;
+          subt = subt - Math.round(parseInt(or.value));
+          or.value = newVal;
+          or.nextElementSibling.value = newVal;
+        }
+      })
+    }
+  })
+})
+$(document).on("ajax:complete", function(status, response){
+  if (response.status === 200) {
+    const {fees: {total}} = response.responseJSON;
+    document.getElementById('total_estimate').innerHTML = total;
+  }
+})

--- a/spec/requests/fee_calculator_controller_spec.rb
+++ b/spec/requests/fee_calculator_controller_spec.rb
@@ -3,7 +3,7 @@ RSpec.describe 'FeeCalculatorController', type: :request do
   describe '#institutional fee' do
     let(:type) { 'institution' }
     let(:service_instance) { double(:FeeCalculatorService) }
-    let(:options) { { 'low_middle_income_country' => nil } }
+    let(:options) { { 'low_middle_income_country' => nil, 'cover_storage_fee' => nil } }
 
     describe '#fee_calculator_url' do
       let(:url) { fee_calculator_url }
@@ -34,6 +34,7 @@ RSpec.describe 'FeeCalculatorController', type: :request do
         let(:options) do
           {
             'low_middle_income_country' => true,
+            'cover_storage_fee' => false,
             'dpc_tier' => '1',
             'service_tier' => '3',
             'storage_usage' => {
@@ -89,6 +90,7 @@ RSpec.describe 'FeeCalculatorController', type: :request do
         let(:options) do
           {
             'low_middle_income_country' => true,
+            'cover_storage_fee' => false,
             'dpc_tier' => '1',
             'service_tier' => '3',
             'storage_usage' => {


### PR DESCRIPTION
Closes https://github.com/datadryad/dryad-product-roadmap/issues/3989

I also added the `covers_storage_fee` option for the calculator for institutions, as we were directed to do.

The oversized storage percentage selector is, by default, set to 100% at tier 0 (under 10GB). The calculator service controller is using a `get_tier_by_value` method that apparently defaults to tier 1, ignoring tier 0, so it returns an incorrect total (treating the tier 0 items, which should have no charge, as if they should be charged at tier 1).

I figure @alinvetian will fix this bug? Probably in https://github.com/datadryad/dryad-app/pull/2106 ? But let me know if I should fix it instead.