### PR TITLE
Do not require scroll to reorder drag and drop elements

### DIFF
--- a/app/javascript/react/components/MetadataEntry/DragonDropList.jsx
+++ b/app/javascript/react/components/MetadataEntry/DragonDropList.jsx
@@ -112,10 +112,6 @@ export default function DragonDropList({
         },
       });
       savedWrapper.current = wrappingFunction;
-      dragon.on('grabbed', () => {
-        const sec = dragonRef.current.closest('section');
-        sec.style.minHeight = `${sec.offsetHeight}px`;
-      });
       dragon.on('dropped', () => {
         savedWrapper.current();
         dragonRef.current.closest('section').style.minHeight = 0;


### PR DESCRIPTION
Setting the section minHeight to 0 on drop seems to have fixed the weird overlap issue, so this was very easy to resolve.