### PR TITLE
Fix abstract editor

### DIFF
--- a/app/javascript/react/components/MetadataEntry/Description/Description.jsx
+++ b/app/javascript/react/components/MetadataEntry/Description/Description.jsx
@@ -94,7 +94,7 @@ export default function Description({
   const checkSubmit = useCallback(debounce(submit, 1000), []);
 
   useEffect(() => {
-    //copy and do not rerender on change
+    // copy and do not rerender on change
     setDesc(`${dcsDescription.description}`);
   }, []);
 

--- a/app/javascript/react/components/MetadataEntry/Description/Description.jsx
+++ b/app/javascript/react/components/MetadataEntry/Description/Description.jsx
@@ -91,7 +91,7 @@ export default function Description({
     }
   };
 
-  const checkSubmit = useCallback(debounce(submit, 1000), []);
+  const checkSubmit = useCallback(debounce(submit, 600), []);
 
   useEffect(() => {
     // copy and do not rerender on change


### PR DESCRIPTION
Closes https://github.com/datadryad/dryad-product-roadmap/issues/4093

The Tiny MCE description editor continues to have weirdness between updating the database and updating state. We've fixed various issues in other PRs, but caused others as a result (updating the state along with the database causes the cursor to jump to the start of the text box every 3 seconds, too far after the database and the change is not reflected in the browser, and updating the state without using the clean response from the database causes an incorrect "abstract changed" message for users who have plugins like grammarly installed).

It seems that this fix _finally_ covers all the issues.