### PR TITLE
Fix too-wide file list table

### DIFF
--- a/app/assets/stylesheets/scss/_upload-table.scss
+++ b/app/assets/stylesheets/scss/_upload-table.scss
@@ -49,6 +49,8 @@
 
   a {
     @extend %o-link__primary;
+    word-break: normal;
+    overflow-wrap: anywhere;
   }
 
   button {

--- a/app/assets/stylesheets/scss/_upload-table.scss
+++ b/app/assets/stylesheets/scss/_upload-table.scss
@@ -47,6 +47,10 @@
     font-weight: normal;
   }
 
+  td:last-child {
+    text-align: center;
+  }
+
   a {
     @extend %o-link__primary;
     word-break: normal;

--- a/app/javascript/react/components/UploadFiles/FileList/BadList.jsx
+++ b/app/javascript/react/components/UploadFiles/FileList/BadList.jsx
@@ -63,7 +63,7 @@ export default function BadList(props) {
             </li>
             <li>Review the local copy of your file and make any desired changes.</li>
             <li>
-              If you would like to replace the file, click &quot;Remove&quot; in the <em>Actions</em> column to delete the current upload.
+              If you would like to replace the file, click the button in the <em>Remove</em> column to delete the current upload.
             </li>
             <li>
               Re-upload the corrected file using the &quot;Choose files&quot; or &quot;Enter URLs&quot; button above.

--- a/app/javascript/react/components/UploadFiles/FileList/File.jsx
+++ b/app/javascript/react/components/UploadFiles/FileList/File.jsx
@@ -50,7 +50,7 @@ export default function File({file, clickRemove, clickValidationReport}) {
   };
 
   const getTabularInfo = () => {
-    if (removing) return 'Removing...';
+    if (removing) return null;
     switch (file.tabularCheckStatus) {
     case TabularCheckStatus.checking:
       return (
@@ -126,10 +126,10 @@ export default function File({file, clickRemove, clickValidationReport}) {
       <td className="c-uploadtable-size">{file.sizeKb}</td>
       <td>
         {removing ? (
-          <i className="fa fa-circle-o-notch fa-spin" aria-hidden="true" />
+          <i className="fas fa-circle-notch fa-spin" aria-hidden="true" />
         ) : (
-          <button onClick={removeClick} type="button" className="o-button__plain-textlink">
-            <i className="fas fa-trash-can" aria-hidden="true" style={{marginRight: '.5ch'}} />Remove
+          <button onClick={removeClick} type="button" className="o-button__plain-textlink" aria-label="Remove file">
+            <i className="fas fa-trash-can" aria-hidden="true" style={{marginRight: '.5ch'}} />
           </button>
         )}
       </td>

--- a/app/javascript/react/components/UploadFiles/FileList/FileList.jsx
+++ b/app/javascript/react/components/UploadFiles/FileList/FileList.jsx
@@ -30,7 +30,7 @@ const file_list = ({
             <th scope="col">Download</th>
             <th scope="col">Type</th>
             <th scope="col">Size</th>
-            <th scope="col">Actions</th>
+            <th scope="col">Remove</th>
           </tr>
         </thead>
         <tbody>

--- a/app/javascript/react/components/UploadFiles/ModalValidationReport/ModalValidationReport.jsx
+++ b/app/javascript/react/components/UploadFiles/ModalValidationReport/ModalValidationReport.jsx
@@ -114,8 +114,8 @@ const ModalValidationReport = React.forwardRef(({file, clickedClose}, ref) => {
       <ol>
         <li>Review the local copy of your file and make any desired changes.</li>
         <li>
-          To replace the file, close this dialog, and click &quot;Remove&quot; in the
-          {' '}<em>Actions</em> column to delete the current upload.
+          To replace the file, close this dialog, and click the button in the
+          {' '}<em>Remove</em> column to delete the current upload.
         </li>
         <li>
           Re-upload the corrected file using the &quot;Choose files&quot; or &quot;Enter URLs&quot; button.

--- a/spec/features/stash_engine/upload_files_spec.rb
+++ b/spec/features/stash_engine/upload_files_spec.rb
@@ -261,9 +261,9 @@ RSpec.feature 'UploadFiles', type: :feature, js: true do
 
     it 'shows empty progress bar if file has 0 size' do
       # Remove already attached files
-      first(:button, 'Remove').click
-      first(:button, 'Remove').click
-      first(:button, 'Remove').click
+      first(:button, 'Remove file').click
+      first(:button, 'Remove file').click
+      first(:button, 'Remove file').click
 
       attach_file('data', "#{Rails.root}/spec/fixtures/stash_engine/empty_file.txt", make_visible: { opacity: 1 })
       expect(page.has_css?('progress[value]')).to be true
@@ -336,7 +336,7 @@ RSpec.feature 'UploadFiles', type: :feature, js: true do
     end
 
     it 'does not allow to select new FILES from file system with the same name of manifest FILES' do
-      first(:button, 'Remove').click
+      first(:button, 'Remove file').click
 
       build_valid_stub_request('http://example.org/file_10.ods')
       click_button('data_manifest')

--- a/spec/javascript/react/components/UploadFiles/UploadFiles.test.js
+++ b/spec/javascript/react/components/UploadFiles/UploadFiles.test.js
@@ -227,11 +227,10 @@ describe('UploadFiles', () => {
     info.resource.generic_files = [loaded];
     render(<UploadFiles {...info} />);
 
-    const button = screen.getByText('Remove');
+    const button = screen.getByLabelText('Remove file');
     userEvent.click(button);
 
-    expect(screen.queryByText('Remove')).not.toBeInTheDocument();
-    expect(screen.getByText('Removing...')).toBeInTheDocument();
+    expect(screen.queryByLabelText('Remove file')).not.toBeInTheDocument();
 
     await waitFor(() => 'OK');
 

--- a/spec/support/capybara.rb
+++ b/spec/support/capybara.rb
@@ -28,6 +28,7 @@ end
 # change all :selenium_chrome_headless to just :selenium_chrome in this file in order to see your tests and troubleshoot in browser.
 # also, comment out --headless option.  Also change default_driver from :rack_test to :selenium_chrome
 Capybara.asset_host = 'http://localhost:33000'
+Capybara.enable_aria_label = true
 
 # Webdrivers.install_dir = '~/.webdrivers'
 # Selenium::WebDriver::Chrome.path = '~/.webdrivers/chromedriver'


### PR DESCRIPTION
Closes https://github.com/datadryad/dryad-product-roadmap/issues/4089

Breaks long filenames to prevent the file list table from extending beyond page width. Also fixes a couple weird things in the table (The "Actions" column only ever contained "Remove", so it was silly to call it "Actions"; the text "Removing..." would appear under the "Tabular data check" table header, which made no sense)