### PR TITLE
Normalize loading icon and section accessibility

### DIFF
--- a/app/assets/javascripts/dataload.js
+++ b/app/assets/javascripts/dataload.js
@@ -13,6 +13,7 @@ const load_data = function() {
       // modernizeIt();
     });
     $(this).attr('data-loaded')
+    $(this).attr('aria-busy', false)
   });
 }
 
@@ -35,6 +36,7 @@ if (!!document.getElementById('blog-latest-posts')) {
       sec.appendChild(div)
       return i < limit
     })
+    sec.setAttribute('aria-busy', false)
   })
 }     
 

--- a/app/assets/javascripts/interactions.js
+++ b/app/assets/javascripts/interactions.js
@@ -21,12 +21,12 @@ function preventClicks(e) {
   const icon = button.querySelector('i');
   if (button.form) {
     button.form.addEventListener('submit', () => {
-      icon.className = 'fas fa-spinner fa-spin';
+      icon.className = 'fas fa-circle-notch fa-spin';
       document.body.classList.add('prevent-clicks');
       button.disabled = true;
     })
   } else {
-    icon.className = 'fas fa-spinner fa-spin';
+    icon.className = 'fas fa-circle-notch fa-spin';
     document.body.classList.add('prevent-clicks');
     button.disabled = true;
   }

--- a/app/assets/stylesheets/scss/_text-styles.scss
+++ b/app/assets/stylesheets/scss/_text-styles.scss
@@ -89,3 +89,11 @@ pre {
     display: block;
   }
 }
+
+p:has(.fa-spinner) {
+  text-align: center;
+}
+
+.fa-spinner {
+  color: $medium-gray;
+}

--- a/app/assets/stylesheets/scss/_upload-file.scss
+++ b/app/assets/stylesheets/scss/_upload-file.scss
@@ -128,10 +128,6 @@
 	font-weight: bold;
 }
 
-.c-upload__loading-spinner {
-	text-align: center;
-}
-
 img.c-upload__spinner {
 	display: block;
 	width: 50%;

--- a/app/javascript/react/components/MetadataEntry/Agreements/Agreements.jsx
+++ b/app/javascript/react/components/MetadataEntry/Agreements/Agreements.jsx
@@ -95,7 +95,7 @@ export default function Agreements({
 
   if (!dpc.dpc) {
     return (
-      <p><i className="fa fa-spinner fa-spin" role="img" aria-label="Loading..." /></p>
+      <p><i className="fas fa-spinner fa-spin" role="img" aria-label="Loading..." /></p>
     );
   }
   return (

--- a/app/javascript/react/components/MetadataEntry/Autocomplete.jsx
+++ b/app/javascript/react/components/MetadataEntry/Autocomplete.jsx
@@ -178,7 +178,7 @@ export default function Autocomplete(
           tabIndex={-1}
           hidden={!isOpen}
         >
-          {!inputItems.length && <li><i className="fa fa-circle-notch fa-spin" aria-hidden="true" /></li>}
+          {!inputItems.length && <li><i className="fas fa-circle-notch fa-spin" aria-hidden="true" /></li>}
           {inputItems.map((item, index) => {
             const id = idFunc(item);
             const name = nameFunc(item);

--- a/app/javascript/react/components/MetadataEntry/Publication/PublicationForm.jsx
+++ b/app/javascript/react/components/MetadataEntry/Publication/PublicationForm.jsx
@@ -236,7 +236,7 @@ function PublicationForm({
           <p id="population-warnings" className="o-metadata__autopopulate-message">
             {importError}
           </p>
-          {loading && <p><i className="fa fa fa-spinner fa-spin" aria-hidden="true" /><span className="screen-reader-only">Loading...</span></p>}
+          {loading && <p><i className="fas fa-spinner fa-spin" role="img" aria-label="Loading..." /></p>}
           <dialog
             id="overwrite-dialog"
             className="modalDialog"

--- a/app/javascript/react/components/ReadMeWizard/ReadMeWizard.jsx
+++ b/app/javascript/react/components/ReadMeWizard/ReadMeWizard.jsx
@@ -223,7 +223,7 @@ export default function ReadMe({dcsDescription, resource, setResource}) {
   }
   return (
     <p style={{display: 'flex', alignItems: 'center', gap: '.5ch'}}>
-      <i className="fas fa-spin fa-spinner" aria-hidden="true"></i>
+      <i className="fas fa-spin fa-spinner" aria-hidden="true" />
       Loading README generator
     </p>
   );

--- a/app/javascript/react/components/ReadMeWizard/ReadMeWizard.jsx
+++ b/app/javascript/react/components/ReadMeWizard/ReadMeWizard.jsx
@@ -222,9 +222,9 @@ export default function ReadMe({dcsDescription, resource, setResource}) {
     );
   }
   return (
-    <p style={{display: 'flex', alignItems: 'center'}}>
-      <img src="../../../images/spinner.gif" alt="Loading spinner" style={{height: '1.5rem', marginRight: '.5ch'}} />
-          Loading README generator
+    <p style={{display: 'flex', alignItems: 'center', gap: '.5ch'}}>
+      <i className="fas fa-spin fa-spinner" aria-hidden="true"></i>
+      Loading README generator
     </p>
   );
 }

--- a/app/javascript/react/components/UploadFiles/UploadFiles.jsx
+++ b/app/javascript/react/components/UploadFiles/UploadFiles.jsx
@@ -586,13 +586,13 @@ export default function UploadFiles({
             totalSize={chosenFiles.reduce((s, f) => s + f.upload_file_size, 0)}
           />
           {loading && (
-            <p><i className="fas fa-spin fa-spinner" role="img" aria-label="Loading"/></p>
+            <p><i className="fas fa-spin fa-spinner" role="img" aria-label="Loading" /></p>
           )}
         </>
       ) : (
         <div>
           {loading ? (
-            <p><i className="fas fa-spin fa-spinner" role="img" aria-label="Loading"/></p>
+            <p><i className="fas fa-spin fa-spinner" role="img" aria-label="Loading" /></p>
           ) : <div className="callout"><p>No files have been selected.</p></div> }
         </div>
       )}

--- a/app/javascript/react/components/UploadFiles/UploadFiles.jsx
+++ b/app/javascript/react/components/UploadFiles/UploadFiles.jsx
@@ -586,17 +586,13 @@ export default function UploadFiles({
             totalSize={chosenFiles.reduce((s, f) => s + f.upload_file_size, 0)}
           />
           {loading && (
-            <p className="c-upload__loading-spinner">
-              <i className="fa fa-spin fa-spinner" role="img" aria-label="Loading" style={{color: '#888'}} />
-            </p>
+            <p><i className="fas fa-spin fa-spinner" role="img" aria-label="Loading"/></p>
           )}
         </>
       ) : (
         <div>
           {loading ? (
-            <p className="c-upload__loading-spinner">
-              <i className="fa fa-spin fa-spinner" role="img" aria-label="Loading" style={{color: '#888'}} />
-            </p>
+            <p><i className="fas fa-spin fa-spinner" role="img" aria-label="Loading"/></p>
           ) : <div className="callout"><p>No files have been selected.</p></div> }
         </div>
       )}

--- a/app/views/stash_datacite/resources/_show.html.erb
+++ b/app/views/stash_datacite/resources/_show.html.erb
@@ -26,7 +26,7 @@
 <% no_link = false unless defined?(no_link) %>
 <% if resource.identifier&.counter_stat&.citation_count > 0 && !no_link %>
   <h2 class="expand-button"><button id="citations" aria-expanded="false" aria-controls="citations-sec">Works referencing this dataset</button></h2>
-  <div id="citations-section" data-load="<%= stash_url_helpers.show_citations_path(identifier_id: resource.identifier_id, format: :js) %>"></div>
+  <div id="citations-section" data-load="<%= stash_url_helpers.show_citations_path(identifier_id: resource.identifier_id, format: :js) %>" aria-busy="true" aria-live="polite"></div>
 <% end %>
 
 <script type="application/ld+json">

--- a/app/views/stash_engine/admin_dashboard/count.js.erb
+++ b/app/views/stash_engine/admin_dashboard/count.js.erb
@@ -1,2 +1,3 @@
 document.getElementById('count_and_export').innerHTML = `<span><b><%= number_with_delimiter(@count) %></b> results</span><%= link_to "Export results as CSV", stash_url_helpers.admin_dashboard_results_path(format: :csv, search: params[:search]), class: 'o-link__buttonlink' %>`;
+document.getElementById('count_and_export').setAttribute('aria-busy', false)
 document.getElementById('admin-pagination').innerHTML = "<%= escape_javascript(render(partial: 'pagination', locals: {count: @count, page: params[:page], page_size: params[:page_size], sort: params[:sort], direction: params[:direction], search: params[:search]})) %>";

--- a/app/views/stash_engine/admin_dashboard/index.html.erb
+++ b/app/views/stash_engine/admin_dashboard/index.html.erb
@@ -13,12 +13,12 @@
     <%= render partial: 'search_form' %>
   </div>  
   <div class="admin-dashboard-results" id="save_buttons" <% if unaltered %>hidden<% end %>></div>
-  <div class="admin-dashboard-results" style="font-size: .9em;" id="count_and_export" role="status">
-    <i class="fa fa-spin fa-spinner" aria-label="Loading" aria-role="img" style="color: #888"></i>
+  <div class="admin-dashboard-results" style="font-size: .9em;" id="count_and_export" role="status" aria-busy="true">
+    <i class="fas fa-spin fa-spinner" aria-hidden="true"></i>
   </div>
 </div>
 
-<div id="search_results" data-load="<%= stash_url_helpers.admin_dashboard_results_path(format: :js, search: params[:search], sort: params[:sort], direction: params[:direction], page_size: params[:page_size], page: params[:page]) %>"></div>
+<div id="search_results" data-load="<%= stash_url_helpers.admin_dashboard_results_path(format: :js, search: params[:search], sort: params[:sort], direction: params[:direction], page_size: params[:page_size], page: params[:page]) %>" aria-busy="true" aria-live="polite"></div>
 
 <div class="callout alt">
   <p style="text-align: center;">Please send your Admin dashboard feedback to <a href="mailto:community@datadryad.org?subject=Admin dashboard feedback">community@datadryad.org</a>.</p>
@@ -56,7 +56,8 @@
     const params = new URL(window.location.href).searchParams
     params.delete('clear')
     window.history.pushState({}, null, `${window.location.pathname}?${params.toString()}`);
-    document.getElementById('count_and_export').innerHTML = '<i class="fa fa-spin fa-spinner" aria-hidden="true" style="color: #888"></i>'
+    document.getElementById('count_and_export').innerHTML = '<i class="fas fa-spin fa-spinner" aria-hidden="true"></i>'
+    document.getElementById('count_and_export').setAttribute('aria-busy', true)
   }
   const checkForm = () => {
     const form = document.querySelector('#search_form form')

--- a/app/views/stash_engine/admin_dashboard/results.js.erb
+++ b/app/views/stash_engine/admin_dashboard/results.js.erb
@@ -5,6 +5,7 @@ urlparams.set('page', '<%= params[:page] %>')
 <% if params[:page_size].present? %>urlparams.set('page_size', '<%= params[:page_size] %>')<% end %>
 window.history.pushState({}, null, `${window.location.pathname}?${urlparams.toString()}`)
 document.getElementById('search_results').innerHTML = "<%= escape_javascript(render(partial: 'results')) %>";
+document.getElementById('search_results').setAttribute('aria-busy', false);
 document.getElementById('save_buttons').innerHTML = "<%= escape_javascript(render(partial: 'save_buttons')) %>";
 $('#search_form').html = "<%= escape_javascript(render(partial: 'search_form')) %>";
 document.getElementById('edit_fields-help').removeEventListener('click', fieldsHelp)

--- a/app/views/stash_engine/admin_datasets/index.html.erb
+++ b/app/views/stash_engine/admin_datasets/index.html.erb
@@ -6,7 +6,7 @@
   <h1 class="o-heading__level1"><%= r&.title %></h1>
   <%= @identifier.identifier %>
 </div>
-<div id="dupe_check" class="callout warn" data-load="<%= stash_url_helpers.dupe_check_resource_path(format: :js, id: r&.id, admin: true) %>"></div>
+<div id="dupe_check" class="callout warn" data-load="<%= stash_url_helpers.dupe_check_resource_path(format: :js, id: r&.id, admin: true) %>" aria-busy="true" role="alert"></div>
 <div class="callout alt">
   <div id="activity-at-a-glance">
     <div class="input-stack">
@@ -139,8 +139,8 @@
     <% end %>
   <% end %>
 </div>
-<div id="activity_log" data-load="<%= stash_url_helpers.activity_path(format: :js, id: params[:id], direction: params[:direction], page_size: params[:page_size], page: params[:page]) %>">
-  <p style="text-align: center;"><i class="fa fa-spin fa-spinner" aria-hidden="true" style="color: #888"></i></p>
+<div id="activity_log" data-load="<%= stash_url_helpers.activity_path(format: :js, id: params[:id], direction: params[:direction], page_size: params[:page_size], page: params[:page]) %>" aria-busy="true" aria-live="polite">
+  <p><i class="fas fa-spin fa-spinner" aria-hidden="true"></i></p>
 </div>
 
 <% if policy([:stash_engine, :admin_datasets]).create_salesforce_case? && Stash::Salesforce.sf_user %>

--- a/app/views/stash_engine/dashboard/show.html.erb
+++ b/app/views/stash_engine/dashboard/show.html.erb
@@ -10,7 +10,7 @@
     <i class="fas fa-plus" aria-hidden="true"></i>Start new submission
   <% end %>
 </div>
-<div id="user_datasets" data-load="<%= stash_url_helpers.dashboard_user_datasets_path(format: :js) %>">
-  <p style="text-align: center;"><i class="fa fa-spin fa-spinner" aria-hidden="true" style="color: #888"></i></p>
+<div id="user_datasets" data-load="<%= stash_url_helpers.dashboard_user_datasets_path(format: :js) %>" aria-live="polite" aria-busy="true">
+  <p><i class="fas fa-spin fa-spinner" aria-hidden="true"></i></p>
 </div>
 <p style="text-align:right; font-size: .9em;"><a href="/feedback?m=4&l=dashboard" class="o-link__buttonlink"><i class="fa fa-commenting-o" aria-hidden="true" style="margin-right: .5ch"></i>Help direct the future of Dryad</a></p>

--- a/app/views/stash_engine/downloads/_preview_file.html.erb
+++ b/app/views/stash_engine/downloads/_preview_file.html.erb
@@ -3,7 +3,7 @@
 <% if @preview %>
   <% case @file.preview_type %>
   <% when 'pdf' %>
-    <div id="pdf_loading" style="text-align: center; margin-top: 1rem"><i class="fa fa-spin fa-spinner" aria-hidden="true" style="color: #888"></i></div>
+    <p id="pdf_loading"><i class="fas fa-spin fa-spinner" aria-label="Loading..." role="img"></i></p>
     <canvas id="pdf_canvas"></canvas>
   <% when 'img' %>
     <img src="<%= @file.digest.present? ? @file.s3_permanent_presigned_url : @file.s3_staged_presigned_url %>"/>

--- a/app/views/stash_engine/landing/_files.html.erb
+++ b/app/views/stash_engine/landing/_files.html.erb
@@ -32,8 +32,8 @@
               <%= link_to "<i class=\"fas fa-download\" role=\"img\" aria-label=\"Download \"></i>#{fu.upload_file_name.ellipsisize(200)}".html_safe, Rails.application.routes.url_helpers.download_stream_path(params),
                         title: fu.upload_file_name, target: '_blank', class: 'js-individual-dl' %>
               <% unless fu.preview_type.nil? %>
-                <div id="file_preview_check<%= fu.id %>" data-load="<%= preview_check_path(file_id: fu.id, format: :js) %>">
-                  <i class="fa fa-spin fa-spinner" aria-hidden="true" style="color: #888"></i>
+                <div id="file_preview_check<%= fu.id %>" data-load="<%= preview_check_path(file_id: fu.id, format: :js) %>" aria-live="polite" aria-busy="true">
+                  <i class="fas fa-spin fa-spinner" aria-hidden="true"></i>
                 </div>
               <% end %>
               </span>
@@ -52,7 +52,7 @@
         </ul>
       </details>
     <% end %>
-    <div id="file_preview_box"></div>
+    <div id="file_preview_box" role="status"></div>
     <!-- full download second -->
     <%= render partial: 'stash_engine/downloads/download', locals: { dataset_identifier: dataset_identifier, resource: dl_resource, share: share.present? ? share[:code] : nil } %>
   <% else %>
@@ -63,7 +63,7 @@
 <script type="text/javascript">
   const load_preview = (n) => {
     const box = document.getElementById('file_preview_box');
-    box.innerHTML = `<div class="file_preview"><p role="heading" level="3" id="preview_file_name"><span>Preview: ${n}</span></p><p style="text-align:center"><i class="fa fa-spin fa-spinner" aria-label="Loading" role="img" style="color: #888"></i></p></div>`;
+    box.innerHTML = `<div class="file_preview"><p role="heading" level="3" id="preview_file_name"><span>Preview: ${n}</span></p><p><i class="fa fa-spin fa-spinner" aria-label="Loading" role="img"></i></p></div>`;
     box.scrollIntoView();
   }
   const close_preview = () => {

--- a/app/views/stash_engine/landing/_sidebar.html.erb
+++ b/app/views/stash_engine/landing/_sidebar.html.erb
@@ -8,8 +8,8 @@
   </div>
 
   <div id="show_metrics"
-       data-load="<%= stash_url_helpers.show_metrics_path(identifier_id: @id.id) %>">
-    <i class="fa fa-spin fa-spinner" aria-hidden="true" style="color: #888"></i>
+       data-load="<%= stash_url_helpers.show_metrics_path(identifier_id: @id.id) %>" aria-live="polite" aria-busy="true">
+    <i class="fas fa-spin fa-spinner" aria-hidden="true"></i>
   </div>
   
   <% if @resource&.identifier&.pub_state == 'published' %>
@@ -20,8 +20,8 @@
 
   <% unless @resource&.resource_type&.resource_type == 'collection' %>
     <div id="show_license"
-         data-load="<%= metadata_url_helpers.license_details_path(resource_id: @resource.id, format: :js) %>">
-      <i class="fa fa-spin fa-spinner" aria-hidden="true" style="color: #888"></i>
+         data-load="<%= metadata_url_helpers.license_details_path(resource_id: @resource.id, format: :js) %>" aria-live="polite" aria-busy="true">
+      <i class="fas fa-spin fa-spinner" aria-hidden="true"></i>
     </div>
   <% end %>
 </div>
@@ -30,8 +30,8 @@
   <div id="keyword_section">
     <h2>Subject keywords</h2>
     <div id="show_subjects"
-         data-load="<%= metadata_url_helpers.subjects_landing_path(resource_id: @resource.id, format: :js) %>">
-      <i class="fa fa-spin fa-spinner" aria-hidden="true" style="color: #888"></i>
+         data-load="<%= metadata_url_helpers.subjects_landing_path(resource_id: @resource.id, format: :js) %>" aria-live="polite" aria-busy="true">
+      <i class="fas fa-spin fa-spinner" aria-hidden="true"></i>
     </div>
   </div>
   <%= render partial: "stash_datacite/contributors/show", locals: { contributors: review.contributors, highlight_fields: [] } %>
@@ -42,8 +42,8 @@
 <div class="sidebox" id="sidebox-related_works">
   <h2>Related works</h2>
   <div id="show_related_works"
-       data-load="<%= metadata_url_helpers.related_identifiers_show_path(resource_id: @resource.id, format: :js) %>">
-    <p><i class="fa fa-spin fa-spinner" aria-hidden="true" style="color: #888"></i></p>
+       data-load="<%= metadata_url_helpers.related_identifiers_show_path(resource_id: @resource.id, format: :js) %>" aria-live="polite" aria-busy="true">
+    <p><i class="fas fa-spin fa-spinner" aria-hidden="true"></i></p>
   </div>
 </div>
 <% end %>

--- a/app/views/stash_engine/landing/show.html.erb
+++ b/app/views/stash_engine/landing/show.html.erb
@@ -38,8 +38,6 @@
 <div class="c-columns">
 	<main class="t-landing__main c-columns__content">
 		<div id="display_resource">
-		  <%# image_tag 'stash_engine/spinner.gif', size: '80x60', alt: 'Loading spinner' %>
-      <%# render(partial: 'stash_datacite/resources/show') %>
       <% if @resource&.resource_type&.resource_type == 'collection' %>
 	      <%= render(partial: metadata_render_path('resources', 'show_collection')) %>
   		<% else %>

--- a/app/views/stash_engine/metadata_entry_pages/find_or_create.html.erb
+++ b/app/views/stash_engine/metadata_entry_pages/find_or_create.html.erb
@@ -5,6 +5,6 @@
 <%= stylesheet_pack_tag 'application' %>
 <% end %>
 <div id="find_or_create"
-    data-load="<%= stash_url_helpers.datacite_metadata_entry_pages_path(resource_id: params[:resource_id], display_validation: params[:display_validation], format: :js) %>">
-  <p style="text-align: center;"><i class="fa fa-spin fa-spinner" aria-hidden="true" style="color: #888"></i></p>
+    data-load="<%= stash_url_helpers.datacite_metadata_entry_pages_path(resource_id: params[:resource_id], display_validation: params[:display_validation], format: :js) %>" aria-live="assertive">
+  <p><i class="fas fa-spin fa-spinner" aria-hidden="true"></i></p>
 </div>

--- a/app/views/stash_engine/pages/_what_we_do.html.md
+++ b/app/views/stash_engine/pages/_what_we_do.html.md
@@ -16,8 +16,8 @@ See [how Dryad compares with other platforms](https://doi.org/10.5281/zenodo.794
 
 ## Latest news
 
-<div id="blog-latest-posts" data-count="3">
-  <%= image_tag 'stash_engine/spinner.gif', size: '80x60', alt: 'Loading spinner' %>
+<div id="blog-latest-posts" data-count="3" aria-live="polite" aria-busy="true">
+  <p><i class="fas fa-spin fa-spinner" aria-hidden="true"></i></p>
 </div>
 <p style="text-align:right"><a href="https://blog.datadryad.org">More news from Dryad →</a></p>
 

--- a/app/views/stash_engine/pages/home.html.erb
+++ b/app/views/stash_engine/pages/home.html.erb
@@ -42,16 +42,16 @@
 <div class="o-home__group o-home__data_group">
   <h2 class="o-heading__level1-home top-row">Most recent datasets</h2>
   <%# Keep unless hostname below for rspec tests to pass %>
-  <div id="latest_tiles" <% unless @hostname == 'localhost' %>data-load="<%= main_app.latest_index_path(format: :js, q: '*:*') %>"<% end %>>
-    <%= image_tag 'stash_engine/spinner.gif', size: '80x60', alt: 'Loading spinner' %>
+  <div id="latest_tiles" <% unless @hostname == 'localhost' %>data-load="<%= main_app.latest_index_path(format: :js, q: '*:*') %>"<% end %> aria-busy="true" aria-live="polite">
+    <p><i class="fas fa-spin fa-spinner" aria-hidden="true"></i></p>
   </div>
   <%= render partial: 'why_share' %>
 </div>
 <div class="o-home__group o-home__news_group">
   <%= render partial: 'why_use' %>
   <h2 class="o-heading__level1-home">Latest news</h2>
-  <div id="blog-latest-posts" data-count="5">
-    <%= image_tag 'stash_engine/spinner.gif', size: '80x60', alt: 'Loading spinner' %>
+  <div id="blog-latest-posts" data-count="5" aria-live="polite" aria-busy="true">
+    <p><i class="fas fa-spin fa-spinner" aria-hidden="true"></i></p>
   </div>
 </div>
 <p style="text-align:right; font-size:.9em; margin-top: -2rem;"><a href="https://blog.datadryad.org">More news from Dryad →</a></p>

--- a/app/views/stash_engine/shared/_search_select.html.erb
+++ b/app/views/stash_engine/shared/_search_select.html.erb
@@ -58,7 +58,7 @@
         status.innerHTML = 'Results loaded'
       } else {
         status.innerHTML = 'Loading results'
-        list.innerHTML = '<li aria-hidden="true"><i class="fa fa-circle-notch fa-spin" aria-hidden="true"></i></li>'
+        list.innerHTML = '<li aria-hidden="true"><i class="fas fa-circle-notch fa-spin" aria-hidden="true"></i></li>'
       }
     }
     const select = ({label, value}) => {

--- a/app/views/stash_engine/submission_queue/index.html.erb
+++ b/app/views/stash_engine/submission_queue/index.html.erb
@@ -1,7 +1,7 @@
 <h1 id="queue-label">Repository submission queue</h1>
-<div id="status_table" data-load="<%= stash_url_helpers.url_for(controller: 'stash_engine/submission_queue', action: 'refresh_table', params: sortable_table_params, only_path: true) %>">
+<div id="status_table" data-load="<%= stash_url_helpers.url_for(controller: 'stash_engine/submission_queue', action: 'refresh_table', params: sortable_table_params, only_path: true) %>" aria-live="polite" aria-busy="true">
   <%# render partial: 'status_table' %>
-  <%= image_tag 'stash_engine/spinner.gif', size: '80x60', alt: 'Loading spinner' %>
+  <p><i class="fas fa-spin fa-spinner" aria-hidden="true"></i></p>
 </div>
 
 <h2>Actions you can take</h2>


### PR DESCRIPTION
The site was using 3 different loading icons seemingly at random, which was driving me a little crazy. I've narrowed this down to 2.

- [fa-spinner](https://fontawesome.com/icons/spinner?s=solid) for auto-loading content
- [fa-circle-notch](https://fontawesome.com/icons/circle-notch?s=solid) for loading caused by user actions (buttons presses, file uploads, etc.)

I've also tried to normalize the accessibility and aria attributes around loading content (an aria-busy section is hidden from screen reader users and announced when it is no longer busy, so the loading icon within can also be aria-hidden—otherwise the loading icon should have an img role and label text)