### PR TITLE
Update Apache config with better Anubis settings

### DIFF
--- a/documentation/external_services/datadryad.org.conf
+++ b/documentation/external_services/datadryad.org.conf
@@ -98,8 +98,14 @@ RemoteIPTrustedProxy 172.31.0.0/16
     RewriteCond %{REQUEST_URI} !/Shibboleth.sso
     RewriteCond %{REQUEST_URI} !/shibboleth-ds/
 
-    # Send everything else to port 3000, the Rails application
+    # Send searches and downloads to Anubis
+    # everything else to port 3000, the Rails application
+    RewriteRule ^/search(.*)$ balancer://anubis_cluster%{REQUEST_URI} [P,QSA,L,NE]
+    RewriteRule ^/downloads/zip_assembly(.*)$ balancer://puma_cluster%{REQUEST_URI} [P,QSA,L,NE]
+    RewriteRule ^/downloads(.*)$ balancer://anubis_cluster%{REQUEST_URI} [P,QSA,L,NE]
+    RewriteRule ^/.within(.*)$ balancer://anubis_cluster%{REQUEST_URI} [P,QSA,L,NE]
     RewriteRule ^/(.*)$ balancer://puma_cluster%{REQUEST_URI} [P,QSA,L,NE]
+    
 
     # Set X-Real-IP header
     RequestHeader set X-Real-IP "%{REMOTE_ADDR}s"


### PR DESCRIPTION
Only protect /search and /downloads URLs, so we are not blocking legitimate bots, proxies, and other machine traffic.