### PR TITLE
Fix tenant change appearing incorrectly

### DIFF
--- a/app/assets/stylesheets/scss/_submission.scss
+++ b/app/assets/stylesheets/scss/_submission.scss
@@ -810,13 +810,6 @@ dialog#submission-step[open] {
     ins, .ins, del {
       padding: 5px 0 3px;
     }
-    .ins {
-      background-color: $lightest-orange;
-    }
-    ins {
-      text-decoration: none;
-      background-color: $lightest-orange;
-    }
     del, .del {
       display: inline;
       background-color: $lightest-red;
@@ -825,6 +818,14 @@ dialog#submission-step[open] {
         background-color: $lightest-red;
         text-decoration: line-through;
       }
+    }
+    .ins {
+      text-decoration: none;
+      background-color: $lightest-orange;
+    }
+    ins {
+      text-decoration: none;
+      background-color: $lightest-orange;
     }
   }
 }

--- a/app/javascript/react/components/MetadataEntry/Agreements/Agreements.jsx
+++ b/app/javascript/react/components/MetadataEntry/Agreements/Agreements.jsx
@@ -169,7 +169,7 @@ export default function Agreements({
               <div className="callout">
                 <p>Payment for this submission is sponsored by <b>{resource.tenant.long_name}</b></p>
               </div>
-              {previous && resource.tenant !== previous.tenant && <p className="del ins">Partner institution changed</p>}
+              {previous && resource.tenant_id !== previous.tenant_id && <p className="del ins">Partner institution changed</p>}
             </>
           )}
           {!dpc.institution_will_pay && dpc.journal_will_pay && (


### PR DESCRIPTION
In curation, "Partner institution changed" was appearing even when the partner institution for the submission had not changed—I think it was including changes _within_ the partner institution information.