### PR TITLE
Improve duplicate check for curators

### DIFF
--- a/app/controllers/stash_engine/resources_controller.rb
+++ b/app/controllers/stash_engine/resources_controller.rb
@@ -183,12 +183,12 @@ module StashEngine
         primary_article = @resource.related_identifiers.find_by(work_type: 'primary_article')&.related_identifier
         manuscript = @resource.resource_publication.manuscript_number
         dupes = other_submissions.where(title: @resource.title)&.select(:id, :title, :identifier_id).to_a
-        if primary_article.present? && ['NA', 'N/A', 'TBD', 'unknown'].none? { |s| s.casecmp(primary_article) == 0 }
+        if primary_article.present? && ['NA', 'N/A', 'TBD', 'unknown'].none? { |s| s.casecmp?(primary_article) }
           dupes.concat(other_submissions.joins(:related_identifiers)
               .where(related_identifiers: { work_type: 'primary_article', related_identifier: primary_article })
               &.select(:id, :title, :identifier_id).to_a)
         end
-        if manuscript.present? && ['NA', 'N/A', 'TBD', 'unknown'].none? { |s| s.casecmp(manuscript) == 0 }
+        if manuscript.present? && ['NA', 'N/A', 'TBD', 'unknown'].none? { |s| s.casecmp?(manuscript) }
           dupes.concat(
             other_submissions.joins(:resource_publication).where(resource_publication: { manuscript_number: manuscript })
             &.select(:id, :title, :identifier_id).to_a


### PR DESCRIPTION
1. Remove modify_permission check from dupe_check so all curators can see the results, not just the curator assigned to the submission
2. Make the check for bad strings (`NA, N/A, TBD, unknown`) case insensitive (the submission in question had 'n/a', lowercase)

Closes https://github.com/datadryad/dryad-product-roadmap/issues/4107