### PR TITLE
Add script to automatically restart puma

### DIFF
--- a/Gemfile
+++ b/Gemfile
@@ -21,7 +21,7 @@ gem 'ed25519', '>= 1.2', '< 2.0'
 gem 'rdoc', '~> 6.1.1' # for some reason needs to be installed for capistrano to work right
 gem 'rubocop', '~> 1.67.0', require: false
 # Use Puma as the app server
-gem 'puma', '6.5.0', group: :puma, require: false
+gem 'puma', '6.6.0', group: :puma, require: false
 
 # ############################################################
 # UI

--- a/Gemfile.lock
+++ b/Gemfile.lock
@@ -493,7 +493,7 @@ GEM
     pry-rails (0.3.11)
       pry (>= 0.13.0)
     public_suffix (6.0.1)
-    puma (6.5.0)
+    puma (6.6.0)
       nio4r (~> 2.0)
     pundit (2.4.0)
       activesupport (>= 3.0.0)
@@ -837,7 +837,7 @@ DEPENDENCIES
   posix-spawn (~> 0.3.15)
   pry
   pry-rails
-  puma (= 6.5.0)
+  puma (= 6.6.0)
   pundit (~> 2.3)
   rack-attack
   rack-mini-profiler

--- a/documentation/external_services/amazon_cloudwatch_config.md
+++ b/documentation/external_services/amazon_cloudwatch_config.md
@@ -84,6 +84,13 @@ sudo vim etc/amazon-cloudwatch-agent.d/logs_config.json
             "log_group_name": "production-others",
             "log_stream_name": "{ip_address}_{instance_id}",
             "retention_in_days": 30
+          },
+          {
+            "file_path": "/home/ec2-user/deploy/current/log/check_puma.log",
+            "log_group_class": "STANDARD",
+            "log_group_name": "production-puma",
+            "log_stream_name": "{ip_address}_{instance_id}",
+            "retention_in_days": 90
           }
         ]
       }
@@ -111,7 +118,7 @@ and create the `crons/`folder and run the following command
 cd ~/deploy/current/log/
 mkdir crons
 cd crons
-ln -s ../!(production.log*|api_requests.log|crons) ./
+ln -s ../!(production.log*|api_requests.log|crons|check_puma.log) ./
 ```
   
 Start and enable the service

--- a/script/server-utils/check_and_restart_puma.sh
+++ b/script/server-utils/check_and_restart_puma.sh
@@ -1,0 +1,46 @@
+#!/bin/bash
+
+SERVICE_NAME="puma"
+CPU_LIMIT=90.0
+MAX_STRIKES=5
+STRIKE_FILE="/tmp/puma_cpu_strikes"
+
+# Get Puma's main PID
+MAIN_PID=$(systemctl show -p MainPID --value "$SERVICE_NAME")
+
+if [[ "$MAIN_PID" -eq 0 ]]; then
+  echo "$(date) - Puma is not running."
+  exit 1
+fi
+
+# Get all Puma-related PIDs (main + children)
+PIDS=$(pgrep -P "$MAIN_PID")
+PIDS="$MAIN_PID $PIDS"
+
+# Calculate total CPU usage
+TOTAL_CPU=0
+for PID in $PIDS; do
+  CPU=$(ps -p "$PID" -o %cpu= | awk '{print $1}')
+  TOTAL_CPU=$(echo "$TOTAL_CPU + $CPU" | bc)
+done
+
+# Read existing strike count (or default to 0)
+STRIKES=$(cat "$STRIKE_FILE" 2>/dev/null || echo 0)
+
+# Compare and update strike logic
+if (( $(echo "$TOTAL_CPU > $CPU_LIMIT" | bc -l) )); then
+  STRIKES=$((STRIKES + 1))
+  echo "$(date) - High CPU: $TOTAL_CPU%. Strike $STRIKES/$MAX_STRIKES."
+else
+  STRIKES=0
+  echo "$(date) - CPU back to normal: $TOTAL_CPU%. Strikes reset."
+fi
+
+echo "$STRIKES" > "$STRIKE_FILE"
+
+# Restart if threshold hit
+if [[ "$STRIKES" -ge "$MAX_STRIKES" ]]; then
+  echo "$(date) - Restarting Puma due to sustained high CPU..."
+  sudo systemctl restart "$SERVICE_NAME"
+  echo 0 > "$STRIKE_FILE"
+fi


### PR DESCRIPTION
The script is set up on all 3 production servers.
Every 1 minute the script checks for puma CPU%. If it is grater than 90% for 5 consecutive times, it will restart puma service. 