### PR TITLE
Do not show negative fee value on storage decrease

### DIFF
--- a/app/controllers/payments_controller.rb
+++ b/app/controllers/payments_controller.rb
@@ -42,10 +42,11 @@ class PaymentsController < ApplicationController
   def callback
     payment = @resource.payment || @resource.build_payment
 
+    # do not update if a resource is already paid
+    #  - success page refresh
     return if payment.paid?
 
-    # do not do these updates multiple times
-    @resource.identifier.update(last_invoiced_file_size: @resource.total_file_size)
+    identifier.update(last_invoiced_file_size: @resource.total_file_size) if identifier.last_invoiced_file_size < @resource.total_file_size
 
     payment.update(
       status: :paid,
@@ -72,6 +73,10 @@ class PaymentsController < ApplicationController
 
   def load_resource
     @resource = StashEngine::Resource.find(params[:resource_id])
+  end
+
+  def identifier
+    @identifier ||= @resource.identifier
   end
 
   def create_params

--- a/app/controllers/payments_controller.rb
+++ b/app/controllers/payments_controller.rb
@@ -46,7 +46,7 @@ class PaymentsController < ApplicationController
     #  - success page refresh
     return if payment.paid?
 
-    identifier.update(last_invoiced_file_size: @resource.total_file_size) if identifier.last_invoiced_file_size < @resource.total_file_size
+    identifier.update(last_invoiced_file_size: @resource.total_file_size) if identifier.last_invoiced_file_size.to_i < @resource.total_file_size
 
     payment.update(
       status: :paid,

--- a/app/services/fee_calculator/base_service.rb
+++ b/app/services/fee_calculator/base_service.rb
@@ -125,7 +125,10 @@ module FeeCalculator
       paid_tier_price = price_by_range(storage_fee_tiers, paid_storage)
       new_tier_price = price_by_range(storage_fee_tiers, resource.total_file_size)
 
-      add_fee_to_total(:storage_size, new_tier_price - paid_tier_price)
+      diff = new_tier_price - paid_tier_price
+      diff = 0 if diff < 0
+
+      add_fee_to_total(:storage_size, diff)
     end
 
     def verify_max_storage_size

--- a/lib/stash/payments/stripe_invoicer.rb
+++ b/lib/stash/payments/stripe_invoicer.rb
@@ -36,7 +36,7 @@ module Stash
         resource.identifier.payment_type = stripe_user_waiver? ? 'waiver' : 'stripe'
         resource.identifier.save
         res = invoice.send_invoice
-        resource.identifier.update(last_invoiced_file_size: ds_size)
+        resource.identifier.update(last_invoiced_file_size: ds_size) if resource.identifier.last_invoiced_file_size < ds_size
         res
       end
 

--- a/lib/stash/payments/stripe_invoicer.rb
+++ b/lib/stash/payments/stripe_invoicer.rb
@@ -36,7 +36,7 @@ module Stash
         resource.identifier.payment_type = stripe_user_waiver? ? 'waiver' : 'stripe'
         resource.identifier.save
         res = invoice.send_invoice
-        resource.identifier.update(last_invoiced_file_size: ds_size) if resource.identifier.last_invoiced_file_size < ds_size
+        resource.identifier.update(last_invoiced_file_size: ds_size) if resource.identifier.last_invoiced_file_size.to_i < ds_size
         res
       end
 

--- a/spec/services/fee_calculator/individual_service_spec.rb
+++ b/spec/services/fee_calculator/individual_service_spec.rb
@@ -185,6 +185,21 @@ module FeeCalculator
               it { is_expected.to eq({ storage_fee: 5_269, total: 5_269 }) }
             end
 
+            context 'when storage changes decrease from one tier to another' do
+              let(:prev_files_size) { 100_000_000_001 }
+              let(:new_files_size) { 100_000_000_000 }
+
+              it { is_expected.to eq(no_charges_response) }
+            end
+
+            context 'when storage changes increase but the author already paid for the new tier' do
+              let(:prev_files_size) { 100_000_000_000 }
+              let(:new_files_size) { 100_000_000_001 }
+              let(:identifier) { create(:identifier, last_invoiced_file_size: 100_000_000_001) }
+
+              it { is_expected.to eq(no_charges_response) }
+            end
+
             context 'with storage_size over 2TB limit' do
               let(:new_files_size) { 10_000_000_000_000 }
 
@@ -230,6 +245,13 @@ module FeeCalculator
               let(:new_files_size) { 900_000_000_000 }
 
               it { is_expected.to eq({ storage_fee: 5_269, invoice_fee: 199, total: 5_468 }) }
+            end
+
+            context 'when storage changes decrease from one tier to another' do
+              let(:prev_files_size) { 100_000_000_001 }
+              let(:new_files_size) { 100_000_000_000 }
+
+              it { is_expected.to eq(no_charges_response) }
             end
 
             context 'with storage_size over 2TB limit' do

--- a/spec/services/fee_calculator/institution_service_spec.rb
+++ b/spec/services/fee_calculator/institution_service_spec.rb
@@ -351,6 +351,13 @@ module FeeCalculator
               it { is_expected.to eq(no_charges_response) }
             end
 
+            context 'when storage changes decrease from one tier to another' do
+              let(:prev_files_size) { 100_000_000_001 }
+              let(:new_files_size) { 100_000_000_000 }
+
+              it { is_expected.to eq(no_charges_response) }
+            end
+
             context 'with storage_size over 2TB limit' do
               let(:new_files_size) { 10_000_000_000_000 }
 
@@ -376,6 +383,13 @@ module FeeCalculator
               let(:new_files_size) { 900_000_000_000 }
 
               it { is_expected.to eq({ service_fee: 0, dpc_fee: 0, storage_fee: 3_883, total: 3_883, storage_fee_label: 'Large data fee' }) }
+            end
+
+            context 'when storage changes decrease from one tier to another' do
+              let(:prev_files_size) { 100_000_000_001 }
+              let(:new_files_size) { 100_000_000_000 }
+
+              it { is_expected.to eq(no_charges_response) }
             end
 
             context 'with storage_size over 2TB limit' do
@@ -416,6 +430,13 @@ module FeeCalculator
               it { is_expected.to eq(no_charges_response) }
             end
 
+            context 'when storage changes decrease from one tier to another' do
+              let(:prev_files_size) { 100_000_000_001 }
+              let(:new_files_size) { 100_000_000_000 }
+
+              it { is_expected.to eq(no_charges_response) }
+            end
+
             context 'with storage_size over 2TB limit' do
               let(:new_files_size) { 10_000_000_000_000 }
 
@@ -448,6 +469,13 @@ module FeeCalculator
                 is_expected.to eq({ service_fee: 0, dpc_fee: 0, storage_fee: 3_883, invoice_fee: 199, total: 4_082,
                                     storage_fee_label: 'Large data fee' })
               }
+            end
+
+            context 'when storage changes decrease from one tier to another' do
+              let(:prev_files_size) { 100_000_000_001 }
+              let(:new_files_size) { 100_000_000_000 }
+
+              it { is_expected.to eq(no_charges_response) }
             end
 
             context 'with storage_size over 2TB limit' do

--- a/spec/services/fee_calculator/publisher_service_spec.rb
+++ b/spec/services/fee_calculator/publisher_service_spec.rb
@@ -261,6 +261,13 @@ module FeeCalculator
               it { is_expected.to eq(no_charges_response) }
             end
 
+            context 'when storage changes decrease from one tier to another' do
+              let(:prev_files_size) { 100_000_000_001 }
+              let(:new_files_size) { 100_000_000_000 }
+
+              it { is_expected.to eq(no_charges_response) }
+            end
+
             context 'with storage_size over 2TB limit' do
               let(:new_files_size) { 10_000_000_000_000 }
 
@@ -286,6 +293,13 @@ module FeeCalculator
               let(:new_files_size) { 900_000_000_000 }
 
               it { is_expected.to eq({ service_fee: 0, dpc_fee: 0, storage_fee: 3_883, total: 3_883, storage_fee_label: 'Large data fee' }) }
+            end
+
+            context 'when storage changes decrease from one tier to another' do
+              let(:prev_files_size) { 100_000_000_001 }
+              let(:new_files_size) { 100_000_000_000 }
+
+              it { is_expected.to eq(no_charges_response) }
             end
 
             context 'with storage_size over 2TB limit' do
@@ -326,6 +340,13 @@ module FeeCalculator
               it { is_expected.to eq(no_charges_response) }
             end
 
+            context 'when storage changes decrease from one tier to another' do
+              let(:prev_files_size) { 100_000_000_001 }
+              let(:new_files_size) { 100_000_000_000 }
+
+              it { is_expected.to eq(no_charges_response) }
+            end
+
             context 'with storage_size over 2TB limit' do
               let(:new_files_size) { 10_000_000_000_000 }
 
@@ -358,6 +379,13 @@ module FeeCalculator
                 is_expected.to eq({ service_fee: 0, dpc_fee: 0, storage_fee: 3_883, invoice_fee: 199, total: 4_082,
                                     storage_fee_label: 'Large data fee' })
               }
+            end
+
+            context 'when storage changes decrease from one tier to another' do
+              let(:prev_files_size) { 100_000_000_001 }
+              let(:new_files_size) { 100_000_000_000 }
+
+              it { is_expected.to eq(no_charges_response) }
             end
 
             context 'with storage_size over 2TB limit' do


### PR DESCRIPTION
When a user already paid a certain storage fee, but then he changes the files and goes under the paid tier limit, the fees should not show