### PR TITLE
NoMethodError fix for dupe check

### DIFF
--- a/app/controllers/stash_engine/resources_controller.rb
+++ b/app/controllers/stash_engine/resources_controller.rb
@@ -181,7 +181,7 @@ module StashEngine
         other_submissions = params.key?(:admin) ? StashEngine::Resource.all : current_user.resources
         other_submissions = other_submissions.latest_per_dataset.where.not(identifier_id: @resource.identifier_id)
         primary_article = @resource.related_identifiers.find_by(work_type: 'primary_article')&.related_identifier
-        manuscript = @resource.resource_publication.manuscript_number
+        manuscript = @resource.resource_publication&.manuscript_number
         dupes = other_submissions.where('LOWER(title) = LOWER(?)', @resource.title)&.select(:id, :title, :identifier_id).to_a
         if primary_article.present? && ['NA', 'N/A', 'TBD', 'unknown'].none? { |s| s.casecmp?(primary_article) }
           dupes.concat(other_submissions.joins(:related_identifiers)


### PR DESCRIPTION
```
A NoMethodError occurred in resources#dupe_check:

  undefined method `manuscript_number' for nil
  app/controllers/stash_engine/resources_controller.rb:184:in `dupe_check'
```