### PR TITLE
Load files separately for submission editing

### DIFF
--- a/app/javascript/react/components/ReadMeWizard/index.jsx
+++ b/app/javascript/react/components/ReadMeWizard/index.jsx
@@ -5,6 +5,7 @@ export {default as ReadMePreview} from './ReadMePreview';
 
 export const readmeCheck = (resource) => {
   const {descriptions, identifier: {publication_date}, generic_files: files} = resource;
+  if (files === undefined) return false;
   const readme = descriptions.find((d) => d.description_type === 'technicalinfo')?.description;
   const markdownFile = files.filter((f) => f.file_state !== 'deleted' && f.type === 'StashEngine::DataFile' && f.upload_file_name === 'README.md');
   const readmeFile = files.filter((f) => f.file_state !== 'deleted' && f.type === 'StashEngine::DataFile' && f.upload_file_name.startsWith('README'));

--- a/app/javascript/react/components/UploadFiles/FilesPreview.jsx
+++ b/app/javascript/react/components/UploadFiles/FilesPreview.jsx
@@ -10,9 +10,7 @@ const fileList = (list, previous) => {
     <>
       <ul className="c-review-files__list">
         {list.map((f) => {
-          const isNew = f.file_state === 'created'
-            || !previous?.some((p) => f.upload_file_name === p.upload_file_name
-                && f.digest === p.digest && f.storage_version_id === p.storage_version_id);
+          const isNew = f.file_state === 'created';
           const listing = <>{f.upload_file_name} <span className="file_size">{formatSizeUnits(f.upload_file_size)}</span></>;
           return (
             <li key={f.id}>

--- a/app/javascript/react/components/UploadFiles/index.jsx
+++ b/app/javascript/react/components/UploadFiles/index.jsx
@@ -7,6 +7,7 @@ export {default as FilesPreview} from './FilesPreview';
 export const filesCheck = (resource, superuser, maximums) => {
   const {generic_files: files, identifier: {publication_date}} = resource;
   const {files: maxFiles, zenodo_size: maxZenodo, merritt_size: maxSize} = maximums;
+  if (files === undefined) return false;
   if (files.length > 0) {
     const present = files.filter((f) => f.file_state !== 'deleted');
     const data = present.filter((f) => f.type === 'StashEngine::DataFile' && f.upload_file_name !== 'README.md');

--- a/config/routes.rb
+++ b/config/routes.rb
@@ -459,6 +459,7 @@ Rails.application.routes.draw do
 
     # get composite views or items that begin at the resource level
     get 'metadata_entry_pages/find_or_create', to: 'metadata_entry_pages#find_or_create', as: :datacite_metadata_entry_pages
+    get 'metadata_entry_pages/:resource_id/files', to: 'metadata_entry_pages#find_files', as: 'find_files'
     get 'resources/review', to: 'resources#review'
     match 'resources/submission' => 'resources#submission', as: :resources_submission, via: :post
     get 'resources/show', to: 'resources#show'


### PR DESCRIPTION
Closes https://github.com/datadryad/dryad-product-roadmap/issues/4145

As a first step, we'll just load file information separately from the rest of the submission data for editing. If this is not sufficient for the problem of large numbers of files, we'll move to possibly loading the files in chunks, and any previous submission files even more separately.