### PR TITLE
Updated CC payment product name

### DIFF
--- a/app/models/stash_datacite/resource/dataset_validations.rb
+++ b/app/models/stash_datacite/resource/dataset_validations.rb
@@ -191,7 +191,7 @@ module StashDatacite
 
       def check_payment
         fee = ResourceFeeCalculatorService.new(@resource).calculate({})
-        return false if fee[:total].zero?
+        return false if fee[:old_payment_system] || fee[:total].zero?
 
         "You need to pay a #{fee[:storage_fee_label]} of $#{fee[:total]} in order to submit."
       end

--- a/app/services/payments_service.rb
+++ b/app/services/payments_service.rb
@@ -6,7 +6,7 @@ class PaymentsService
     @resource = resource
     @options = options
     @fees = ResourceFeeCalculatorService.new(resource).calculate(options)
-    @fees = @fees.except(:storage_fee_label)
+    @storage_fee_label = @fees.delete(:storage_fee_label)
   end
 
   def checkout_options
@@ -33,10 +33,15 @@ class PaymentsService
       price_data: {
         currency: 'usd',
         product_data: {
-          name: PRODUCT_NAME_MAPPER[fee_key]
+          name: product_name(fee_key)
         },
         unit_amount: value * 100 # Convert to cents
       }
     }
+  end
+
+  def product_name(fee_key)
+    name = fee_key == :storage_fee ? @storage_fee_label : PRODUCT_NAME_MAPPER[fee_key]
+    "#{name} for #{resource.identifier} (#{filesize(resource.total_file_size)})"
   end
 end

--- a/spec/fixtures/stash_api/metadata.rb
+++ b/spec/fixtures/stash_api/metadata.rb
@@ -132,6 +132,17 @@ module Fixtures
         )
       end
 
+      def add_journal(journal = nil)
+        if journal
+          @metadata[:publicationISSN] = journal.issns.first.id
+          @metadata[:publicationName] = journal.title
+          return
+        end
+
+        @metadata[:publicationISSN] = "#{Faker::Number.number(digits: 4)}-#{Faker::Number.number(digits: 4)}"
+        @metadata[:publicationName] = Faker::Company.unique.industry
+      end
+
       def create_key_and_array(key:)
         @metadata[key] = [] unless @metadata[key]
       end

--- a/spec/services/payments_service_spec.rb
+++ b/spec/services/payments_service_spec.rb
@@ -1,0 +1,45 @@
+describe PaymentsService do
+
+  let(:user) { create(:user) }
+  let(:identifier) { create(:identifier) }
+  let(:resource) { create(:resource, identifier: identifier, total_file_size: 6_234_567_890) }
+  let(:options) { {} }
+  let(:subject) { PaymentsService.new(user, resource, options) }
+
+  describe '#initialize' do
+    it 'sets proper attributes' do
+      expect(subject.user).to eq(user)
+      expect(subject.resource).to eq(resource)
+      expect(subject.options).to eq(options)
+    end
+  end
+
+  describe '#total_amount' do
+    it 'sets proper attributes' do
+      expect(subject.total_amount).to eq(180)
+    end
+  end
+
+  describe '#checkout_options' do
+    let(:checkout_options) do
+      {
+        mode: 'payment',
+        ui_mode: 'embedded',
+        line_items: [{
+          quantity: 1,
+          price_data: {
+            currency: 'usd',
+            product_data: {
+              name: "Data Publishing Charge for #{identifier} (6.23 GB)"
+            },
+            unit_amount: 18_000
+          }
+        }]
+      }
+    end
+
+    it 'has correct values' do
+      expect(subject.checkout_options).to eq(checkout_options)
+    end
+  end
+end

--- a/spec/shared_examples/api_examples.rb
+++ b/spec/shared_examples/api_examples.rb
@@ -1,0 +1,117 @@
+# This expects @metadata_hash to be set in parent test
+RSpec.shared_examples('API submission flow') do |can_submit, submit_response|
+  it 'has proper flow' do
+    metadata_hash = @metadata_hash
+
+    ### Test token - returns welcome message and authenticated user id
+    post '/api/v2/test', headers: headers
+    json_response = response_body_hash
+    expect(/Welcome application owner.+$/).to match(json_response[:message])
+    expect(user.id).to eql(json_response[:user_id])
+
+    ### LIST dataset - returns no datasets
+    get '/api/v2/datasets', headers: headers
+    json_response = response_body_hash
+    expect(json_response[:total]).to eq(0)
+
+    response_code = post '/api/v2/datasets', params: metadata_hash.to_json, headers: headers
+    json_response = response_body_hash
+    expect(response_code).to eq(201)
+
+    doi = json_response[:identifier]
+    identifier = StashEngine::Identifier.find_by(identifier: doi.split(':').last)
+    resource_id = json_response[:id]
+    in_author = metadata_hash[:authors].first
+    out_author = json_response[:authors].first
+    # Update user as primary author
+    user.update(orcid: out_author[:orcid])
+
+    expect(/doi:10./).to match(doi)
+    expect(metadata_hash[:title]).to eq(json_response[:title])
+    expect(metadata_hash[:abstract]).to eq(json_response[:abstract])
+    expect(json_response[:id]).to eq(resource_id)
+    expect(out_author[:email]).to eq(in_author[:email])
+    expect(out_author[:affiliation]).to eq(in_author[:affiliation])
+    expect(out_author[:affiliation]).to eq(journal.title)
+    expect(json_response[:title]).to eq(title)
+    expect(json_response[:keywords]).to eq(metadata_hash[:keywords])
+    expect(json_response[:fieldOfScience]).to eq(metadata_hash[:fieldOfScience])
+    expect(json_response[:versionNumber]).to eq(1)
+    expect(json_response[:versionStatus]).to eq('in_progress')
+    expect(json_response[:curationStatus]).to eq('In progress')
+    expect(json_response[:lastModificationDate]).to eq(Date.today.to_s)
+    expect(json_response[:visibility]).to eq('restricted')
+    expect(json_response[:userId]).to eq(user.id)
+    expect(json_response[:license]).to eq(Stash::Wrapper::License::CC_ZERO.uri.to_s)
+    expect(json_response[:editLink]).to eq("/edit/#{CGI.escape(doi)}/#{identifier.edit_code}")
+
+    ### SHOW dataset
+    response_code = get "/api/v2/datasets/#{CGI.escape(doi)}", headers: headers
+    json_response = response_body_hash
+    expect(response_code).to eq(200)
+    expect(json_response[:identifier]).to eq(doi)
+    expect(json_response[:id]).to eq(resource_id)
+
+    ### UPDATE dataset
+    update_params = metadata_hash.merge({ abstract: 'New abstract', methods: 'New Method' })
+    response_code = put "/api/v2/datasets/#{CGI.escape(doi)}", params: update_params.to_json, headers: headers
+    json_response = response_body_hash
+    expect(response_code).to eq(200)
+    expect(json_response[:identifier]).to eq(doi)
+    expect(json_response[:id]).to eq(resource_id)
+    expect(json_response[:abstract]).to eq(update_params[:abstract])
+    expect(json_response[:methods]).to eq(update_params[:methods])
+
+    ### UPLOAD file
+    file = fixture_file_upload('spec/fixtures/zipfiles/test_zip.zip')
+    response_code = put "/api/v2/datasets/#{CGI.escape(doi)}/files/test_zip.zip", params: { file: file }, headers: headers
+    json_response = response_body_hash
+    expect(response_code).to eq(201)
+    expect(json_response[:url]).to be_nil
+    expect(json_response[:path]).to eq('test_zip.zip')
+    expect(json_response[:status]).to eq('created')
+
+    ### UPLOAD README file
+    file = fixture_file_upload('spec/fixtures/README.md')
+    response_code = put "/api/v2/datasets/#{CGI.escape(doi)}/files/README.md", params: { file: file }, headers: headers
+    json_response = response_body_hash
+    expect(response_code).to eq(201)
+    expect(json_response[:url]).to be_nil
+    expect(json_response[:path]).to eq('README.md')
+    expect(json_response[:status]).to eq('created')
+
+    ### LIST dataset versions
+    response_code = get "/api/v2/datasets/#{CGI.escape(doi)}/versions", headers: headers
+    json_response = response_body_hash
+    expect(response_code).to eq(200)
+    expect(json_response[:count]).to eq(1)
+    expect(json_response[:total]).to eq(1)
+    expect(json_response[:_embedded]['stash:versions'].first[:title]).to eq(title)
+    expect(json_response[:_embedded]['stash:versions'].first[:versionNumber]).to eq(1)
+    version_files_path = json_response[:_embedded]['stash:versions'].first['_links']['stash:files'][:href]
+
+    ### LIST dataset version files
+    response_code = get version_files_path, headers: headers
+    json_response = response_body_hash
+    expect(response_code).to eq(200)
+    expect(json_response[:count]).to eq(2)
+    expect(json_response[:total]).to eq(2)
+    expect(json_response[:_embedded]['stash:files'].map { |f| f[:path] }).to match_array(['README.md', 'test_zip.zip'])
+    expect(json_response[:_embedded]['stash:files'].map { |f| f[:status] }).to match_array(%w[created created])
+
+    ### SUBMIT dataset
+    params = { op: 'replace', path: '/versionStatus', value: 'submitted' }
+    response_code = patch "/api/v2/datasets/#{CGI.escape(doi)}", params: params.to_json, headers: headers
+    json_response = response_body_hash
+    expect(response_code).to eq(submit_response[:status])
+
+    if can_submit
+      expect(json_response[:identifier]).to eq(doi)
+      expect(json_response[:id]).to eq(resource_id)
+      expect(json_response[:versionStatus]).to eq('processing')
+      expect(json_response[:curationStatus]).to eq('In progress')
+    else
+      expect(json_response[:error]).to eq(submit_response[:error])
+    end
+  end
+end

--- a/spec/shared_examples/fee_calculator.rb
+++ b/spec/shared_examples/fee_calculator.rb
@@ -1,0 +1,6 @@
+RSpec.shared_examples('calling FeeCalculatorService') do |type|
+  it "calculates with #{type} type" do
+    expect(FeeCalculatorService).to receive_message_chain(:new, :calculate).with(type).with(options, resource: resource).and_return({})
+    described_class.new(resource).calculate(options)
+  end
+end

--- a/spec/shared_examples/resource_email_rake_tasks.rb
+++ b/spec/shared_examples/resource_email_rake_tasks.rb
@@ -13,10 +13,3 @@ RSpec.shared_examples('send email notifications tasks') do |count, date|
     end
   end
 end
-
-RSpec.shared_examples('calling FeeCalculatorService') do |type|
-  it "calculates with #{type} type" do
-    expect(FeeCalculatorService).to receive_message_chain(:new, :calculate).with(type).with(options, resource: resource).and_return({})
-    described_class.new(resource).calculate(options)
-  end
-end


### PR DESCRIPTION
Closes: https://github.com/datadryad/dryad-product-roadmap/issues/4162

Updated to:
![image](https://github.com/user-attachments/assets/a9b4d795-e2f9-4bdd-8d5f-58996eabc629)

This PR also fixed the errors that are commitn by email  like:
```
A NoMethodError occurred in datasets#update:

 undefined method `zero?' for nil
 app/models/stash_datacite/resource/dataset_validations.rb:194:in `check_payment'
```