### PR TITLE
Ensure resource destroy updated latest resource

### DIFF
--- a/app/models/stash_engine/resource.rb
+++ b/app/models/stash_engine/resource.rb
@@ -163,12 +163,20 @@ module StashEngine
     def remove_identifier_with_no_resources
       # if no more resources after a removal for a StashEngine::Identifier then there is no remaining content for that Identifier
       # only in-progress resources are destroyed, but there may be earlier submitted ones
-      return if identifier_id.nil?
+      return if identifier_id.nil? || identifier.nil?
 
-      res_count = Resource.where(identifier_id: identifier_id).count
-      return if res_count.positive?
+      identifier.reload
+      if identifier.resources.count.zero?
+        identifier.destroy
+      else
+        # ensure identifier latest_resource_id is being updated to previous resource
+        return unless identifier.latest_resource_id == id
 
-      Identifier.destroy(identifier_id) if Identifier.exists?(identifier_id)
+        prev = previous_resource
+        return if prev.nil?
+
+        identifier.update(latest_resource_id: prev.id)
+      end
     end
 
     def remove_s3_temp_files

--- a/app/services/stash_engine/delete_datasets_service.rb
+++ b/app/services/stash_engine/delete_datasets_service.rb
@@ -10,16 +10,12 @@ module StashEngine
 
     def call
       prev = resource.previous_resource
-      identifier = resource.identifier
       if prev && add_delete_note
         user_id = current_user&.id || 0
         note = "#{(user_id == 0 && 'System cleanup') || 'User'} deleted unsubmitted version #{resource.version_number}"
         StashEngine::CurationActivity.create(resource_id: prev.id, status: prev.current_curation_status, user_id: user_id, note: note)
       end
-      success = resource.destroy
-      identifier.update!(latest_resource_id: prev.id) if prev && success && identifier && identifier.latest_resource_id == resource.id
-
-      success
+      resource.destroy
     end
   end
 end

--- a/spec/models/stash_engine/resources_spec.rb
+++ b/spec/models/stash_engine/resources_spec.rb
@@ -2,6 +2,7 @@ module StashEngine
 
   describe Resource, type: :model do
     include Mocks::Salesforce
+    include Mocks::Aws
 
     attr_reader :user
     attr_reader :skip_emails
@@ -1659,5 +1660,64 @@ module StashEngine
       end
     end
 
+    describe '#destroy' do
+      let(:identifier) { create(:identifier, created_at: 2.minute.ago) }
+
+      before do
+        mock_aws!
+      end
+
+      context 'when the deleted resource is the only one on the identifier' do
+        let!(:resource) { create(:resource, identifier: identifier) }
+
+        it 'destroys the resource and the identifier' do
+          expect { resource.destroy }.to change { StashEngine::Resource.count }.by(-1)
+            .and change { StashEngine::Identifier.count }.by(-1)
+        end
+      end
+
+      context 'when the deleted resource is NOT the only one on the identifier' do
+        context 'when deleting the last resource' do
+          let!(:first_resource) { create(:resource, identifier: identifier, created_at: 1.minute.ago) }
+          let!(:resource) { create(:resource, identifier: identifier) }
+
+          it 'destroys only the resource' do
+            expect { resource.destroy }.to change { StashEngine::Resource.count }.by(-1)
+              .and change { StashEngine::Identifier.count }.by(0)
+              .and change { identifier.reload.latest_resource_id }.to(first_resource.id)
+          end
+
+          it 'updates identifier latest_resource_id' do
+            expect(identifier.reload.latest_resource_id).to eq(resource.id)
+            resource.destroy
+            expect(identifier.reload.latest_resource_id).to eq(first_resource.id)
+          end
+        end
+
+        context 'when deleting a resource that is not the last resource' do
+          let!(:first_resource) { create(:resource, identifier: identifier, created_at: 2.minutes.ago) }
+          let!(:ca1) { create(:curation_activity, resource: first_resource, status: 'submitted', created_at: 2.minutes.ago) }
+          let!(:resource) { create(:resource, identifier: identifier, created_at: 1.minute.ago) }
+          let!(:ca2) { create(:curation_activity, resource: resource, status: 'submitted', created_at: 1.minute.ago) }
+          let!(:last_resource) { create(:resource, identifier: identifier) }
+
+          before do
+            identifier.update!(latest_resource_id: last_resource.id)
+            identifier.reload
+          end
+
+          it 'destroys only the resource' do
+            expect { resource.destroy }.to change { StashEngine::Resource.count }.by(-1)
+              .and change { StashEngine::Identifier.count }.by(0)
+          end
+
+          it 'does not update the identifier latest_resource_id' do
+            expect(identifier.reload.latest_resource_id).to eq(last_resource.id)
+            expect { resource.destroy }.not_to(change { identifier.reload.latest_resource_id })
+            expect(identifier.reload.latest_resource_id).to eq(last_resource.id)
+          end
+        end
+      end
+    end
   end
 end


### PR DESCRIPTION
Closes: https://github.com/datadryad/dryad-product-roadmap/issues/3978

I added code to ensure that destroy action always updates identifier latest_resource_id 