### PR TITLE
Adjust email created by salesforce form

### DIFF
--- a/lib/stash/salesforce.rb
+++ b/lib/stash/salesforce.rb
@@ -106,7 +106,6 @@ module Stash
         FromAddress: email,
         FromName: sname,
         Incoming: true,
-        ParentId: case_id,
         RelatedToId: case_id,
         Status: 0
       )


### PR DESCRIPTION
I've no idea if this will ultimately have much of an effect on triggering the auto response email, but removing the ParentId setting (and using only the RelatedToId) does put the case activity in the correct order to match existing email-to-case cases (with the initial email appearing before the case is created)