### PR TITLE
Updated stripe to latest version

### DIFF
--- a/app/controllers/payments_controller.rb
+++ b/app/controllers/payments_controller.rb
@@ -10,7 +10,7 @@ class PaymentsController < ApplicationController
 
   def create
     Stripe.api_key = APP_CONFIG.payments.key
-    Stripe.api_version = '2019-02-11; custom_checkout_beta=v1;'
+    Stripe.api_version = '2025-03-31.basil'
 
     payment_service = PaymentsService.new(current_user, @resource, create_params)
 

--- a/lib/stash/payments/invoicer.rb
+++ b/lib/stash/payments/invoicer.rb
@@ -14,7 +14,7 @@ module Stash
 
       # Settings used by all Stripe services
       Stripe.api_key = APP_CONFIG.payments.key
-      Stripe.api_version = '2022-11-15'
+      Stripe.api_version = '2025-03-31.basil'
 
       def self.find_recent_voids
         d = Date.today - 2.months
@@ -154,7 +154,7 @@ module Stash
           items.push(Stripe::InvoiceItem.create(
                        customer: customer_id,
                        invoice: invoice_id,
-                       unit_amount: APP_CONFIG.payments.additional_storage_chunk_cost,
+                       unit_amount_decimal: APP_CONFIG.payments.additional_storage_chunk_cost,
                        currency: 'usd',
                        quantity: over_chunks,
                        description: overage_message(over_bytes)

--- a/lib/stash/payments/stripe_invoicer.rb
+++ b/lib/stash/payments/stripe_invoicer.rb
@@ -14,7 +14,7 @@ module Stash
 
       # Settings used by all Stripe services
       Stripe.api_key = APP_CONFIG.payments.key
-      Stripe.api_version = '2022-11-15'
+      Stripe.api_version = '2025-03-31.basil'
 
       def initialize(resource)
         @resource = resource

--- a/spec/models/stash/payments/invoicer_spec.rb
+++ b/spec/models/stash/payments/invoicer_spec.rb
@@ -173,7 +173,7 @@ module Stash
                   customer: 'stripe_customer_id',
                   invoice: 1,
                   currency: 'usd',
-                  unit_amount: APP_CONFIG.payments.additional_storage_chunk_cost,
+                  unit_amount_decimal: APP_CONFIG.payments.additional_storage_chunk_cost,
                   quantity: 6,
                   description: <<~TEXT.squish
                     Oversize submission charges for #{identifier}. Overage amount is 53.81 GB @ $50.00
@@ -242,7 +242,7 @@ module Stash
                   customer: 'stripe_customer_id',
                   invoice: 2,
                   currency: 'usd',
-                  unit_amount: APP_CONFIG.payments.additional_storage_chunk_cost,
+                  unit_amount_decimal: APP_CONFIG.payments.additional_storage_chunk_cost,
                   quantity: 3,
                   description: <<~TEXT.squish
                     Oversize submission charges for #{identifier}. Overage amount is 26 GB @ $50.00


### PR DESCRIPTION
Closes: https://github.com/datadryad/dryad-product-roadmap/issues/4176

The curators are unable to publish because of API version differences are not the same on all pages where we use Stripe API and the calls work from some servers and do not on others 