### PR TITLE
unify api authors response format

### DIFF
--- a/app/models/stash_api/version/metadata/authors.rb
+++ b/app/models/stash_api/version/metadata/authors.rb
@@ -8,17 +8,7 @@ module StashApi
       class Authors < MetadataItem
 
         def value
-          @resource.authors.map do |a|
-            {
-              firstName: a.author_first_name,
-              lastName: a.author_last_name,
-              email: a.author_email,
-              affiliation: a.try(:affiliation).try(:smart_name),
-              affiliationROR: a.try(:affiliation).try(:ror_id),
-              orcid: a.author_orcid,
-              order: a.author_order
-            }
-          end
+          @resource.authors.map(&:as_json)
         end
       end
     end

--- a/app/models/stash_api/version/metadata/authors.rb
+++ b/app/models/stash_api/version/metadata/authors.rb
@@ -8,7 +8,7 @@ module StashApi
       class Authors < MetadataItem
 
         def value
-          @resource.authors.map(&:as_json)
+          @resource.authors.map(&:as_api_json)
         end
       end
     end

--- a/app/models/stash_datacite/affiliation.rb
+++ b/app/models/stash_datacite/affiliation.rb
@@ -93,6 +93,13 @@ module StashDatacite
       Affiliation.new(long_name: ror_org.name, ror_id: ror_org.id) if ror_org.present?
     end
 
+    def as_json(_options = {})
+      {
+        name: smart_name,
+        ror_id: ror_id
+      }
+    end
+
     private
 
     def strip_whitespace

--- a/app/models/stash_datacite/affiliation.rb
+++ b/app/models/stash_datacite/affiliation.rb
@@ -93,7 +93,7 @@ module StashDatacite
       Affiliation.new(long_name: ror_org.name, ror_id: ror_org.id) if ror_org.present?
     end
 
-    def as_json(_options = {})
+    def as_api_json
       {
         name: smart_name,
         ror_id: ror_id

--- a/app/models/stash_engine/author.rb
+++ b/app/models/stash_engine/author.rb
@@ -120,6 +120,19 @@ module StashEngine
       orcid_invite.landing(path)
     end
 
+    def as_json(_options = {})
+      {
+        firstName: author_first_name,
+        lastName: author_last_name,
+        email: author_email,
+        affiliation: affiliation&.smart_name,
+        affiliationROR: affiliation.ror_id,
+        affiliations: affiliations.map(&:as_json),
+        orcid: author_orcid,
+        order: author_order
+      }
+    end
+
     private
 
     def strip_whitespace

--- a/app/models/stash_engine/author.rb
+++ b/app/models/stash_engine/author.rb
@@ -120,14 +120,14 @@ module StashEngine
       orcid_invite.landing(path)
     end
 
-    def as_json(_options = {})
+    def as_api_json
       {
         firstName: author_first_name,
         lastName: author_last_name,
         email: author_email,
         affiliation: affiliation&.smart_name,
         affiliationROR: affiliation.ror_id,
-        affiliations: affiliations.map(&:as_json),
+        affiliations: affiliations.map(&:as_api_json),
         orcid: author_orcid,
         order: author_order
       }

--- a/app/models/stash_engine/resource.rb
+++ b/app/models/stash_engine/resource.rb
@@ -975,8 +975,8 @@ module StashEngine
       changed = []
       edits = []
       edits << { deleted: other_authors.length - authors.length } if other_authors.length > authors.length
-      this_authors = authors.map(&:as_json)
-      that_authors = other_authors.map(&:as_json)
+      this_authors = authors.map(&:as_api_json)
+      that_authors = other_authors.map(&:as_api_json)
       this_authors.each_with_index do |a, i|
         diff = a.diff(that_authors[i] || {})
         edits << { index: i }.merge(diff) unless diff.empty?

--- a/app/models/stash_engine/resource.rb
+++ b/app/models/stash_engine/resource.rb
@@ -975,12 +975,8 @@ module StashEngine
       changed = []
       edits = []
       edits << { deleted: other_authors.length - authors.length } if other_authors.length > authors.length
-      this_authors = authors.map do |a|
-        { author_full_name: a.author_full_name, affiliation: "#{a.affiliation&.long_name}#{a.affiliation&.ror_id}", email: a.author_email }
-      end
-      that_authors = other_authors.map do |a|
-        { author_full_name: a.author_full_name, affiliation: "#{a.affiliation&.long_name}#{a.affiliation&.ror_id}", email: a.author_email }
-      end
+      this_authors = authors.map(&:as_json)
+      that_authors = other_authors.map(&:as_json)
       this_authors.each_with_index do |a, i|
         diff = a.diff(that_authors[i] || {})
         edits << { index: i }.merge(diff) unless diff.empty?

--- a/public/openapi.yml
+++ b/public/openapi.yml
@@ -1166,6 +1166,11 @@ components:
         affiliationROR:
           type: string
           description: Preferred identifier for the author affiliation.
+        affiliations:
+          type: array
+          items:
+            name: string
+            ror_id: string
         affiliationISNI:
           type: string
         orcid:


### PR DESCRIPTION
Closes: https://github.com/datadryad/dryad-product-roadmap/issues/4137

- Unifying API response for author JSON in `changedFields` and resource view
- Add list of affiliations for each user
- Keep existing first affiliation fields 