### PR TITLE
Fix duplicate related works exception

### DIFF
--- a/app/models/stash_engine/resource.rb
+++ b/app/models/stash_engine/resource.rb
@@ -149,7 +149,7 @@ module StashEngine
         new_resource.related_identifiers.each_with_index do |ri, i|
           if new_resource.related_identifiers[0, i].any? { |r| ri.related_identifier == r.related_identifier }
             ri.delete
-          elsif ri.work_type == 'primary_article' && new_resource.related_identifiers[0, i].any? { |_r| ri.work_type == 'primary_article' }
+          elsif ri.work_type == 'primary_article' && new_resource.related_identifiers[0, i].any? { |r| r.work_type == 'primary_article' }
             ri.work_type = 'article'
           end
         end

--- a/app/models/stash_engine/resource.rb
+++ b/app/models/stash_engine/resource.rb
@@ -146,6 +146,14 @@ module StashEngine
           file.file_state = 'copied' if file.file_state == 'created'
         end
 
+        new_resource.related_identifiers.each_with_index do |ri, i|
+          if new_resource.related_identifiers[0, i].any? { |r| ri.related_identifier == r.related_identifier }
+            ri.delete
+          elsif ri.work_type == 'primary_article' && new_resource.related_identifiers[0, i].any? { |_r| ri.work_type == 'primary_article' }
+            ri.work_type = 'article'
+          end
+        end
+
         # I think there was something weird about Amoeba that required this approach
         deleted_files = new_resource.generic_files.select { |ar_record| ar_record.file_state == 'deleted' }
         deleted_files.each(&:destroy)


### PR DESCRIPTION
Fixes

```
An ActiveRecord::RecordInvalid occurred in metadata_entry_pages#new_version:

  Validation failed: is invalid
  app/helpers/stash_engine/metadata_entry_pages_helper.rb:7:in `duplicate_resource'
```

During the duplication of a resource for a new version, it deletes related_identifiers with duplicate URLs after the first instance, and changes the work_type of any secondary primary articles (that do not have duplicate URLs) after the first instance.

Closes https://github.com/datadryad/dryad-product-roadmap/issues/4209