### PR TITLE
Fix auto-selection of Dryad partner

### DIFF
--- a/app/javascript/react/components/MetadataEntry/Agreements/Agreements.jsx
+++ b/app/javascript/react/components/MetadataEntry/Agreements/Agreements.jsx
@@ -75,13 +75,13 @@ export default function Agreements({
       formRef.current.append(active_form);
     }
     if (!!dpc.aff_tenant && existing) {
-      document.getElementById('edit_tenant').hidden = true;
+      document.getElementById('dryad-member').hidden = true;
       document.getElementById('edit-tenant-form').hidden = false;
       document.getElementById('searchselect-tenant__value').value = dpc.aff_tenant.id;
       document.getElementById('searchselect-tenant__label').value = dpc.aff_tenant.short_name;
       document.getElementById('searchselect-tenant__input').value = dpc.aff_tenant.short_name;
     }
-  }, [dpc, formRef]);
+  }, [dpc, formRef.current]);
 
   useEffect(() => {
     if (resource.identifier.pub_state === 'published') {


### PR DESCRIPTION
When a submitter has a Dryad partner as an affiliation, but has not verified that as their tenant, the form should automatically select that affiliation from the add-an-institution suggestion dropdown. It seems like there was a bug in this where the auto-selection wasn't happening (see https://github.com/datadryad/dryad-product-roadmap/issues/3226)