### PR TITLE
Account for inexact manuscript number matches

### DIFF
--- a/app/controllers/stash_datacite/publications_controller.rb
+++ b/app/controllers/stash_datacite/publications_controller.rb
@@ -190,7 +190,7 @@ module StashDatacite
         @error = 'Journal not integrated with Dryad. Please fill in your title manually.'
         return
       end
-      manu = StashEngine::Manuscript.where(journal: journal, manuscript_number: @msid).first
+      manu = StashEngine::Manuscript.where('manuscript_number like ?', "%#{@msid}%").where(journal: journal).last
       if manu.blank?
         @error = 'We could not find metadata to import for this manuscript. Please fill in your title manually.'
         return

--- a/app/models/stash_engine/identifier.rb
+++ b/app/models/stash_engine/identifier.rb
@@ -63,6 +63,7 @@ module StashEngine
             class_name: 'StashEngine::Resource',
             primary_key: 'latest_resource_id',
             foreign_key: 'id'
+    has_many :manuscripts, class_name: 'StashEngine::Manuscript'
     belongs_to :software_license, class_name: 'StashEngine::SoftwareLicense', optional: true
     has_many :curation_activities, class_name: 'StashEngine::CurationActivity', through: :resources
     has_many :payments, class_name: 'ResourcePayment', through: :resources
@@ -312,7 +313,7 @@ module StashEngine
     end
 
     def latest_manuscript
-      latest_resource&.manuscript
+      StashEngine::Manuscript.where('manuscript_number like ?', "%#{manuscript_number}%").where(journal: journal).last
     end
 
     def preprint_issn

--- a/app/models/stash_engine/resource.rb
+++ b/app/models/stash_engine/resource.rb
@@ -107,7 +107,6 @@ module StashEngine
     has_many :processor_results, class_name: 'StashEngine::ProcessorResult', dependent: :destroy
     has_many :journal_issns, through: :resource_publications
     has_many :journals, through: :journal_issns
-    has_one :manuscript, through: :resource_publication
     has_one :journal_issn, through: :resource_publication
     has_one :journal, through: :journal_issn
     has_one :flag, class_name: 'StashEngine::Flag', as: :flaggable, dependent: :destroy

--- a/app/models/stash_engine/resource_publication.rb
+++ b/app/models/stash_engine/resource_publication.rb
@@ -24,6 +24,5 @@ module StashEngine
     # connecting a resource with the publication for a manuscript and/or a primary_article related_identifier
     belongs_to :resource
     belongs_to :journal_issn, class_name: 'StashEngine::JournalIssn', foreign_key: :publication_issn, optional: true
-    belongs_to :manuscript, class_name: 'StashEngine::Manuscript', primary_key: :manuscript_number, foreign_key: :manuscript_number, optional: true
   end
 end


### PR DESCRIPTION
Neither the metadata import, nor the `has_accepted_manuscript?` check (etc.) account for the fact that manuscript numbers are saved in the database with a variety of prefixes and suffixes—they have all been checking the database for exact matches. And as far as I can tell, this error has always been the case—[see previous version](https://github.com/datadryad/dryad-app/blame/9e8ae52d25a39ea7d9b6ca17285d4f3eafa83a94/app/models/stash_engine/identifier.rb#L338))

Also, the import was set to import the oldest data for a manuscript instead of the most recent.

Closes https://github.com/datadryad/dryad-product-roadmap/issues/4245