### PR TITLE
fixed production errors

### DIFF
--- a/app/controllers/stash_datacite/related_identifiers_controller.rb
+++ b/app/controllers/stash_datacite/related_identifiers_controller.rb
@@ -40,7 +40,7 @@ module StashDatacite
     def update
       respond_to do |format|
         if @related_identifier.update(calc_related_identifier_params)
-          @related_identifier.update(verified: @related_identifier.live_url_valid?) unless @related_indentifier.verified?
+          @related_identifier.update(verified: @related_identifier.live_url_valid?) unless @related_identifier.verified?
           @resource.reload
           release_resource(@resource) if @resource.identifier&.publication_article_doi
           format.js do

--- a/app/models/stash_engine/author.rb
+++ b/app/models/stash_engine/author.rb
@@ -126,7 +126,7 @@ module StashEngine
         lastName: author_last_name,
         email: author_email,
         affiliation: affiliation&.smart_name,
-        affiliationROR: affiliation.ror_id,
+        affiliationROR: affiliation&.ror_id,
         affiliations: affiliations.map(&:as_api_json),
         orcid: author_orcid,
         order: author_order


### PR DESCRIPTION
Fixing errors:
```
A NoMethodError occurred in related_identifiers#update:

 undefined method `verified?' for nil
 app/controllers/stash_datacite/related_identifiers_controller.rb:43:in `block in update'
```

AND

```
A NoMethodError occurred in datasets#search:

 undefined method `ror_id' for nil
 app/models/stash_engine/author.rb:129:in `as_api_json'
```