### PR TITLE
Reload README file list after file changes

### DIFF
--- a/app/controllers/stash_engine/resources_controller.rb
+++ b/app/controllers/stash_engine/resources_controller.rb
@@ -118,7 +118,7 @@ module StashEngine
 
     # rubocop:disable Metrics/AbcSize
     def prepare_readme
-      @file_list = @resource.data_files.reject { |f| f.upload_file_name == 'README.md' }.map do |f|
+      @file_list = @resource.data_files.present_files.reject { |f| f.upload_file_name == 'README.md' }.map do |f|
         h = { name: f.upload_file_name }
         if f.upload_file_name.end_with?('.csv', '.tsv', '.xlsx', '.xls', '.rdata', '.rda', '.mat', '.txt')
           h[:variables] = []

--- a/app/javascript/react/components/ReadMeWizard/ReadMeWizard.jsx
+++ b/app/javascript/react/components/ReadMeWizard/ReadMeWizard.jsx
@@ -11,13 +11,13 @@ import {showSavedMsg, showSavingMsg} from '../../../lib/utils';
 export default function ReadMeWizard({resource, setResource, step}) {
   const [desc, setDesc] = useState(null);
   const [fileList, setFileList] = useState([]);
-  const [readmeFile, setFile] = useState(null);
+  const [readmeFile, setReadmeFile] = useState(null);
 
   const getFiles = async () => {
     axios.get(`/resources/${resource.id}/prepare_readme`).then((data) => {
       const {file_list, readme_file} = data.data;
       setFileList(file_list);
-      setFile(readme_file);
+      setReadmeFile(readme_file);
     });
   };
 

--- a/app/javascript/react/components/ReadMeWizard/ReadMeWizard.jsx
+++ b/app/javascript/react/components/ReadMeWizard/ReadMeWizard.jsx
@@ -10,15 +10,35 @@ import {showSavedMsg, showSavingMsg} from '../../../lib/utils';
 
 export default function ReadMeWizard({resource, setResource, step}) {
   const [desc, setDesc] = useState(null);
+  const [fileList, setFileList] = useState([]);
+  const [readmeFile, setFile] = useState(null);
+
+  const getFiles = async () => {
+    axios.get(`/resources/${resource.id}/prepare_readme`).then((data) => {
+      const {file_list, readme_file} = data.data;
+      setFileList(file_list);
+      setFile(readme_file);
+    });
+  };
 
   useEffect(() => {
     if (step === 'README') {
+      getFiles();
       setDesc(JSON.parse(JSON.stringify(resource.descriptions.find((d) => d.description_type === 'technicalinfo'))));
     }
   }, [step]);
 
   if (desc?.id) {
-    return <ReadMe dcsDescription={desc} title={resource.title} doi={resource.identifier.identifier} setResource={setResource} />;
+    return (
+      <ReadMe
+        dcsDescription={desc}
+        title={resource.title}
+        doi={resource.identifier.identifier}
+        setResource={setResource}
+        fileList={fileList}
+        readmeFile={readmeFile}
+      />
+    );
   }
   return (
     <p style={{display: 'flex', alignItems: 'center', gap: '.5ch'}}>
@@ -29,11 +49,10 @@ export default function ReadMeWizard({resource, setResource, step}) {
 }
 
 function ReadMe({
-  dcsDescription, title, doi, setResource,
+  dcsDescription, title, doi, setResource, fileList, readmeFile,
 }) {
   const [initialValue, setInitialValue] = useState(null);
   const [replaceValue, setReplaceValue] = useState(null);
-  const [fileList, setFileList] = useState([]);
   const [wizardContent, setWizardContent] = useState(null);
   const [wizardStep, setWizardStep] = useState(0);
 
@@ -103,19 +122,6 @@ function ReadMe({
   }, [wizardStep]);
 
   useEffect(() => {
-    async function getFiles() {
-      axios.get(`/resources/${dcsDescription.resource_id}/prepare_readme`).then((data) => {
-        const {file_list, readme_file} = data.data;
-        setFileList(file_list);
-        if (!dcsDescription.description) {
-          if (readme_file) {
-            setReplaceValue(readme_file);
-          } else {
-            setWizardContent({title, doi, step: 0});
-          }
-        }
-      });
-    }
     if (dcsDescription.description) {
       try {
         const template = JSON.parse(dcsDescription.description);
@@ -124,8 +130,11 @@ function ReadMe({
       } catch {
         setInitialValue(dcsDescription.description);
       }
+    } else if (readmeFile) {
+      setReplaceValue(readmeFile);
+    } else {
+      setWizardContent({title, doi, step: 0});
     }
-    getFiles();
   }, []);
 
   if (initialValue || replaceValue) {


### PR DESCRIPTION
Bug fix: when the README is regenerated, or the unedited Files and variables screen is revisited, the generated file list should match the latest files

Blocking https://github.com/datadryad/dryad-product-roadmap/issues/4248