### PR TITLE
Always error for more than 100 zenodo files

### DIFF
--- a/app/javascript/react/components/UploadFiles/index.jsx
+++ b/app/javascript/react/components/UploadFiles/index.jsx
@@ -28,26 +28,26 @@ export const filesCheck = (resource, superuser, maximums) => {
           </p>
         );
       }
-      if (software.length > maxFiles) {
-        return (
-          <p className="error-text" id="software_error">
-          A maximum of {maxFiles} software files can be uploaded per dataset.
-          To reduce the number, package (.zip, .tar.gz) related files locally, remove the individual files from this dataset, and upload the packages.
-          </p>
-        );
-      }
-      if (supp.length > maxFiles) {
-        return (
-          <p className="error-text" id="supp_error">
-          A maximum of {maxFiles} supplemental files can be uploaded per dataset.
-          To reduce the number, package (.zip, .tar.gz) related files locally, remove the individual files from this dataset, and upload the packages.
-          </p>
-        );
-      }
     } else if (files.length > 1000) {
       return (
         <p className="error-text" id="data_error">
         A maximum of 1000 files can be uploaded per dataset.
+        To reduce the number, package (.zip, .tar.gz) related files locally, remove the individual files from this dataset, and upload the packages.
+        </p>
+      );
+    }
+    if (software.length > maxFiles) {
+      return (
+        <p className="error-text" id="software_error">
+        A maximum of {maxFiles} software files can be uploaded per dataset.
+        To reduce the number, package (.zip, .tar.gz) related files locally, remove the individual files from this dataset, and upload the packages.
+        </p>
+      );
+    }
+    if (supp.length > maxFiles) {
+      return (
+        <p className="error-text" id="supp_error">
+        A maximum of {maxFiles} supplemental files can be uploaded per dataset.
         To reduce the number, package (.zip, .tar.gz) related files locally, remove the individual files from this dataset, and upload the packages.
         </p>
       );

--- a/app/models/stash_datacite/resource/dataset_validations.rb
+++ b/app/models/stash_datacite/resource/dataset_validations.rb
@@ -155,20 +155,23 @@ module StashDatacite
 
         files_date = '2025-03-12'
         if (@resource.identifier.publication_date.blank? || @resource.identifier.publication_date > files_date) &&
-          (@resource.data_files.present_files.count > APP_CONFIG.maximums.files ||
-            @resource.software_files.present_files.count > APP_CONFIG.maximums.files ||
-            @resource.supp_files.present_files.count > APP_CONFIG.maximums.files)
-          return 'Too many files'
+          (@resource.data_files.present_files.count > APP_CONFIG.maximums.files)
+          return 'Too many data files (more than 100)'
+        end
+
+        if @resource.software_files.present_files.count > APP_CONFIG.maximums.files ||
+            @resource.supp_files.present_files.count > APP_CONFIG.maximums.files
+          return 'Too many zenodo upload files (more than 100)'
         end
 
         if !@resource.identifier.new_upload_size_limit
           return 'Over file size limit' if @resource.data_files.present_files.sum(:upload_file_size) > APP_CONFIG.maximums.merritt_size &&
           !@user&.superuser?
         elsif @resource.data_files.present_files.sum(:upload_file_size) > APP_CONFIG.maximums.upload_size
-          return 'Over file size limit'
+          return 'Over dataset file size limit'
         end
 
-        return 'Over file size limit' if @resource.software_files.present_files.sum(:upload_file_size) > APP_CONFIG.maximums.zenodo_size ||
+        return 'Over zenodo file size limit' if @resource.software_files.present_files.sum(:upload_file_size) > APP_CONFIG.maximums.zenodo_size ||
           @resource.supp_files.present_files.sum(:upload_file_size) > APP_CONFIG.maximums.zenodo_size
 
         false

--- a/spec/models/stash_datacite/dataset_validations_spec.rb
+++ b/spec/models/stash_datacite/dataset_validations_spec.rb
@@ -320,7 +320,7 @@ module StashDatacite
 
           validations = DatasetValidations.new(resource: @resource)
           error = validations.over_max
-          expect(error).to eq('Too many files')
+          expect(error).to eq('Too many data files (more than 100)')
         end
 
         it 'gives an error if over file size for data files' do
@@ -332,7 +332,7 @@ module StashDatacite
 
           validations = DatasetValidations.new(resource: @resource)
           error = validations.over_max
-          expect(error).to eq('Over file size limit')
+          expect(error).to eq('Over dataset file size limit')
         end
 
         it 'gives an error if over file size for merritt data files' do
@@ -356,7 +356,7 @@ module StashDatacite
 
           validations = DatasetValidations.new(resource: @resource)
           error = validations.over_max
-          expect(error).to eq('Over file size limit')
+          expect(error).to eq('Over zenodo file size limit')
         end
 
         it 'gives an error if over file size for zenodo supplemental files' do
@@ -368,7 +368,7 @@ module StashDatacite
 
           validations = DatasetValidations.new(resource: @resource)
           error = validations.over_max
-          expect(error).to eq('Over file size limit')
+          expect(error).to eq('Over zenodo file size limit')
         end
       end
 


### PR DESCRIPTION
While the older system did not show this error for zenodo uploads over 100 files (instead having a total max 1000 files for all uploads error), each zenodo upload does in fact have a hard limit of 100 files and we need users not to be able to try to send more, regardless of their publication date.