### PR TITLE
Send less verification code emails

### DIFF
--- a/app/controllers/stash_engine/sessions_controller.rb
+++ b/app/controllers/stash_engine/sessions_controller.rb
@@ -120,7 +120,7 @@ module StashEngine
     def email_sso
       @tenant = StashEngine::Tenant.find(params[:tenant_id])
       return unless current_user.email&.end_with?(@tenant.authentication&.email_domain)
-      return if current_user.email_token || params.key?(:refresh)
+      return if current_user.email_token && !params.key?(:refresh)
 
       current_user.create_email_token(tenant_id: @tenant.id)
       current_user.email_token.send_token
@@ -163,7 +163,7 @@ module StashEngine
 
     def email_validate
       return unless current_user&.email&.present?
-      return if current_user.email_token && params.key?(:refresh)
+      return if current_user.email_token && !params.key?(:refresh)
 
       current_user.create_email_token
       current_user.email_token.send_token

--- a/app/controllers/stash_engine/sessions_controller.rb
+++ b/app/controllers/stash_engine/sessions_controller.rb
@@ -120,6 +120,7 @@ module StashEngine
     def email_sso
       @tenant = StashEngine::Tenant.find(params[:tenant_id])
       return unless current_user.email&.end_with?(@tenant.authentication&.email_domain)
+      return unless !current_user.email_token.exists? || params.key?(:refresh)
 
       current_user.create_email_token(tenant_id: @tenant.id)
       current_user.email_token.send_token
@@ -127,14 +128,14 @@ module StashEngine
 
     def validate_sso_email
       if current_user.email_token.expired?
-        redirect_to email_sso_path(tenant_id: current_user.email_token.tenant_id),
+        redirect_to email_sso_path(tenant_id: current_user.email_token.tenant_id, refresh: true),
                     flash: { info: 'The code entered has expired. Check your email for a new code.' }
       elsif params[:token].downcase == current_user.email_token.token&.downcase
         current_user.roles.tenant_roles.delete_all if current_user.tenant_id != current_user.email_token.tenant_id
         current_user.update(tenant_id: current_user.email_token.tenant_id, tenant_auth_date: Time.current, validated: true)
         do_redirect
       else
-        redirect_to email_sso_path(tenant_id: current_user.email_token.tenant_id), flash: { alert: 'Invalid code. Check your email for a new code.' }
+        redirect_to email_sso_path(tenant_id: current_user.email_token.tenant_id), flash: { alert: 'The code is invalid, please try again.' }
       end
     end
 
@@ -162,6 +163,7 @@ module StashEngine
 
     def email_validate
       return unless current_user&.email&.present?
+      return unless !current_user.email_token.exists? || params.key?(:refresh)
 
       current_user.create_email_token
       current_user.email_token.send_token
@@ -169,13 +171,13 @@ module StashEngine
 
     def validate_email
       if current_user.email_token.expired?
-        redirect_to email_validate_path, flash: { info: 'The code entered has expired. Check your email for a new code.' }
+        redirect_to email_validate_path(refresh: true), flash: { info: 'The code entered has expired. Check your email for a new code.' }
       elsif params[:token].downcase == current_user.email_token.token&.downcase
         current_user.update(validated: true)
         flash[:notice] = 'Your email has been validated. It can be modified on the My account page.'
         do_redirect
       else
-        redirect_to email_validate_path, flash: { alert: 'Invalid code. Check your email for a new code.' }
+        redirect_to email_validate_path, flash: { alert: 'The code is invalid, please try again.' }
       end
     end
 

--- a/app/controllers/stash_engine/sessions_controller.rb
+++ b/app/controllers/stash_engine/sessions_controller.rb
@@ -120,7 +120,7 @@ module StashEngine
     def email_sso
       @tenant = StashEngine::Tenant.find(params[:tenant_id])
       return unless current_user.email&.end_with?(@tenant.authentication&.email_domain)
-      return unless !current_user.email_token.exists? || params.key?(:refresh)
+      return if current_user.email_token || params.key?(:refresh)
 
       current_user.create_email_token(tenant_id: @tenant.id)
       current_user.email_token.send_token
@@ -163,7 +163,7 @@ module StashEngine
 
     def email_validate
       return unless current_user&.email&.present?
-      return unless !current_user.email_token.exists? || params.key?(:refresh)
+      return if current_user.email_token && params.key?(:refresh)
 
       current_user.create_email_token
       current_user.email_token.send_token

--- a/app/views/stash_engine/sessions/email_sso.html.erb
+++ b/app/views/stash_engine/sessions/email_sso.html.erb
@@ -11,7 +11,7 @@
         </div>
       <% end %>
       <p>If you do not see the email, please check your spam filter.</p>
-      <p>The code sent will expire after 15 minutes. <a href="<%= email_sso_path(tenant_id: @tenant.id) %>">Send another code</a></p>
+      <p>The code sent will expire after 15 minutes. <a href="<%= email_sso_path(tenant_id: @tenant.id, refresh: true) %>">Send another code</a></p>
       Is the email address incorrect?
       <%= form_with(url: edit_account_path, method: :post, class: 'o-button__inline-form', local: false) do |f| %>
         <%= f.hidden_field :first_name, value: current_user.first_name %>

--- a/app/views/stash_engine/sessions/email_validate.html.erb
+++ b/app/views/stash_engine/sessions/email_validate.html.erb
@@ -11,7 +11,7 @@
         </div>
       <% end %>
       <p>If you do not see the email, please check your spam filter.</p>
-      <p>The code sent will expire after 15 minutes. <a href="<%= email_validate_path %>">Send another code</a></p>
+      <p>The code sent will expire after 15 minutes. <a href="<%= email_validate_path(refresh: true) %>">Send another code</a></p>
       Is the email address incorrect?
       <%= form_with(url: edit_account_path, method: :post, class: 'o-button__inline-form', local: false) do |f| %>
         <%= f.hidden_field :first_name, value: current_user.first_name %>


### PR DESCRIPTION
Closes https://github.com/datadryad/dryad-product-roadmap/issues/4343

I've modified both email validations to only send a new verification code via email:

1. When the user is first sent to the page and the token is first created
2. When specifically requested via the 'Send a new code' link
3. When an expired code is entered

When an invalid code is entered a new one is no longer automatically sent, giving users the ability to try entering the same code again.

(Previously it would send a code whenever the page was loaded)