### PR TITLE
Stop duplicates created with journal links

### DIFF
--- a/app/controllers/stash_engine/resources_controller.rb
+++ b/app/controllers/stash_engine/resources_controller.rb
@@ -249,6 +249,7 @@ module StashEngine
       manu = StashEngine::Manuscript.where(journal: j, manuscript_number: params[:manu]).first
       return unless manu
 
+      resource.identifier.update(import_info: 'manuscript')
       dryad_import = Stash::Import::DryadManuscript.new(resource: resource, manuscript: manu)
       dryad_import.populate
     end

--- a/app/controllers/stash_engine/resources_controller.rb
+++ b/app/controllers/stash_engine/resources_controller.rb
@@ -51,7 +51,14 @@ module StashEngine
 
     # POST /resources
     # POST /resources.json
+    # rubocop:disable Metrics/AbcSize
     def create
+      if params[:journalID].present? && params[:manu].present?
+        existing = current_user.resources
+          .joins(:resource_publication, :journal)
+          .where(resource_publication: { manuscript_number: params[:manu] }, journal: { journal_code: params[:journalID] }).first
+        redirect_to "#{stash_url_helpers.metadata_entry_pages_find_or_create_path(resource_id: existing.id)}?start" and return if existing
+      end
       resource = authorize Resource.new(current_editor_id: current_user.id, tenant_id: current_user.tenant_id)
       my_id = Stash::Doi::DataciteGen.mint_id(resource: resource)
       id_type, id_text = my_id.split(':', 2)
@@ -60,13 +67,14 @@ module StashEngine
       resource.creator = current_user.id
       resource.submitter = current_user.id
       resource.fill_blank_author!
-      import_manuscript_using_params(resource) if params['journalID']
+      import_manuscript_using_params(resource)
       session[:resource_type] = current_user.min_app_admin? && params.key?(:collection) ? 'collection' : 'dataset'
-      redirect_to stash_url_helpers.metadata_entry_pages_find_or_create_path(resource_id: resource.id)
+      redirect_to "#{stash_url_helpers.metadata_entry_pages_find_or_create_path(resource_id: resource.id)}?start"
     rescue StandardError => e
       logger.error("Unable to create new resource: #{e.full_message}")
       redirect_to stash_url_helpers.dashboard_path, alert: 'Unable to register a DOI at this time. Please contact help@datadryad.org for assistance.'
     end
+    # rubocop:enable Metrics/AbcSize
 
     # PATCH/PUT /resources/1
     # PATCH/PUT /resources/1.json
@@ -228,17 +236,17 @@ module StashEngine
 
     # We have parameters requesting to match to a Manuscript object; prefill journal info and import metadata if possible
     def import_manuscript_using_params(resource)
-      return unless resource && params['journalID'] && params['manu']
+      return unless resource && params[:journalID].present? && params[:manu].present?
 
-      j = StashEngine::Journal.where(journal_code: params['journalID'].downcase).first
+      j = StashEngine::Journal.where(journal_code: params[:journalID].downcase).first
       return unless j
 
       # Save the journal and manuscript information in the dataset
       pub = StashEngine::ResourcePublication.find_or_create_by(resource_id: resource.id)
-      pub.update({ publication_issn: j.single_issn, publication_name: j.title, manuscript_number: params['manu'] })
+      pub.update({ publication_issn: j.single_issn, publication_name: j.title, manuscript_number: params[:manu] })
 
       # If possible, import existing metadata from the Manuscript objects into the dataset
-      manu = StashEngine::Manuscript.where(journal: j, manuscript_number: params['manu']).first
+      manu = StashEngine::Manuscript.where(journal: j, manuscript_number: params[:manu]).first
       return unless manu
 
       dryad_import = Stash::Import::DryadManuscript.new(resource: resource, manuscript: manu)

--- a/app/javascript/react/containers/Submission.jsx
+++ b/app/javascript/react/containers/Submission.jsx
@@ -208,7 +208,7 @@ function Submission({
   useEffect(() => {
     if (!review) {
       const url = location.search.slice(1);
-      if (url) {
+      if (url && url !== 'start') {
         const n = steps().find((c) => url === c.name.split(/[^a-z]/i)[0].toLowerCase());
         if (n.name !== step.name) setStep(n);
       }
@@ -267,7 +267,8 @@ function Submission({
     if (!review) {
       const url = window.location.search.slice(1);
       if (url) {
-        setStep(steps().find((c) => url === c.name.split(/[^a-z]/i)[0].toLowerCase()));
+        if (url === 'start') setStep({name: 'Create a submission'});
+        else setStep(steps().find((c) => url === c.name.split(/[^a-z]/i)[0].toLowerCase()));
       } else if (steps().find((c) => c.fail || c.pass)) {
         setStep(steps().find((c) => !c.pass));
       }

--- a/spec/features/stash_datacite/new_dataset_spec.rb
+++ b/spec/features/stash_datacite/new_dataset_spec.rb
@@ -38,6 +38,31 @@ RSpec.feature 'NewDataset', type: :feature do
 
   end
 
+  context :from_manuscript_url, js: true do
+    before(:each) do
+      journal = create(:journal, journal_code: 'JTEST')
+      create(:manuscript, manuscript_number: 'MAN-001', journal: journal)
+    end
+
+    it 'creates a submission and imports manuscript info' do
+      visit '/submit?journalID=JTEST&manu=MAN-001'
+      expect(page).to have_content('Dataset submission')
+      expect(find_button('Title')).to match_selector('[aria-describedby="step-complete"')
+      expect(find_button('Description')).to match_selector('[aria-describedby="step-complete"')
+      expect(find_button('Subjects')).to match_selector('[aria-describedby="step-complete"')
+    end
+
+    it 'redirects instead of creating a duplicate' do
+      visit '/submit?journalID=JTEST&manu=MAN-001'
+      expect(page).to have_content('Dataset submission')
+      resource_id = page.current_path.match(%r{submission/(\d+)})[1].to_i
+
+      visit '/submit?journalID=JTEST&manu=MAN-001'
+      expect(page).to have_content('Dataset submission')
+      expect(page.current_path.match(%r{submission/(\d+)})[1].to_i).to equal(resource_id)
+    end
+  end
+
   context :form_submission, js: true do
 
     before(:each) do


### PR DESCRIPTION
Also, whenever someone is creating a dataset, they should start on the first submission system page even if the dataset has imported content.

Closes https://github.com/datadryad/dryad-product-roadmap/issues/4385