### PR TITLE
Use edit code instead of edit link for API submitter invitation

### DIFF
--- a/app/mailers/stash_api/api_mailer.rb
+++ b/app/mailers/stash_api/api_mailer.rb
@@ -7,11 +7,13 @@ module StashApi
       @resource = resource
       @journal = StashEngine::Journal.find_by_issn(metadata[:relatedPublicationISSN])
       @user = author
-      return unless @user.present? && user_email(@user).present?
+      return unless @user.present? && user_email(@user).present? && @user.edit_code&.edit_code&.present?
 
       @user_name = user_name(@user)
       @helpdesk_email = APP_CONFIG['helpdesk_email'] || 'help@datadryad.org'
-      @edit_url = "#{Rails.application.routes.url_helpers.root_url.chomp('/')}#{metadata[:editLink]}"
+      @edit_url = "#{Rails.application.routes.url_helpers.root_url.chomp('/')}#{
+        Rails.application.routes.url_helpers.accept_invite_path(edit_code: @user.edit_code.edit_code)
+      }"
 
       mail(to: user_email(@user),
            subject: "#{rails_env}Submit data for \"#{@resource.title}\"",

--- a/app/models/stash_api/dataset_parser.rb
+++ b/app/models/stash_api/dataset_parser.rb
@@ -64,6 +64,7 @@ module StashApi
       author = notification_author(@resource)
       return if !ActiveModel::Type::Boolean.new.cast(@hash['triggerSubmitInvitation']) || author.blank?
 
+      author.create_edit_code(role: 'submitter')
       StashApi::ApiMailer.send_submit_request(@resource, metadata, author).deliver_now
     end
 

--- a/app/views/stash_api/api_mailer/send_submit_request.html.erb
+++ b/app/views/stash_api/api_mailer/send_submit_request.html.erb
@@ -12,7 +12,7 @@
 <p><a href="<%= @edit_url %>">Accept the invitation by clicking this link</a>. You will be prompted to log into Dryad.</p>
 
 <p>
-  Please visit the Dryad site to <a href="https://datadryad.org/requirements">review our instructions</a> for preparing your data and uploading files in order to complete your data submission.
+  Please visit the Dryad site to <a href="https://datadryad.org/requirements">review our instructions</a> for preparing your data and uploading files. Follow the prompts in the submission form to complete your data submission.
 </p>
 
 <p>After submission, Dryad will send you an email acknowledgment of your data submission that includes important links and further instructions.</p>

--- a/app/views/stash_api/api_mailer/send_submit_request.html.erb
+++ b/app/views/stash_api/api_mailer/send_submit_request.html.erb
@@ -9,12 +9,11 @@
 <% end %>
 </p>
 
-<p>
-  Please visit the Dryad site to <a href="https://datadryad.org/requirements">review our instructions</a> for preparing your data and uploading files prior to initiating your data submission. To upload your data to Dryad, you may use the following link:<br />
-  <a href="<%= @edit_url %>"><%= @edit_url %></a>
-</p>
+<p><a href="<%= @edit_url %>">Accept the invitation by clicking this link</a>. You will be prompted to log into Dryad.</p>
 
-<p>You may be prompted to log into Dryad. Follow the prompts in the submission form and select to either keep your dataset private during peer review, which will prevent it from being curated and published, or submit it to our curation queue to have it published.</p>
+<p>
+  Please visit the Dryad site to <a href="https://datadryad.org/requirements">review our instructions</a> for preparing your data and uploading files in order to complete your data submission.
+</p>
 
 <p>After submission, Dryad will send you an email acknowledgment of your data submission that includes important links and further instructions.</p>
 

--- a/spec/models/stash_api/mailers/api_mailer_spec.rb
+++ b/spec/models/stash_api/mailers/api_mailer_spec.rb
@@ -5,7 +5,7 @@ module StashApi
   describe ApiMailer do
     include MailerSpecHelper
 
-    let(:metadata) { { editLink: '/some/link' } }
+    let(:metadata) { {} }
 
     before(:each) do
 
@@ -28,6 +28,8 @@ module StashApi
                         author_orcid: @user.orcid,
                         resource_id: @resource.id)
 
+      @author2.create_edit_code(role: 'submitter')
+
       allow(Rails.application.routes.url_helpers).to receive(:root_url).and_return 'https://site.root/'
     end
 
@@ -40,7 +42,7 @@ module StashApi
       it 'sends email' do
         ApiMailer.send_submit_request(@resource, metadata, @author2).deliver_now
         delivery = assert_email("[test] Submit data for \"#{@resource.title}\"")
-        expect(delivery.body.to_s).to include('https://site.root/some/link')
+        expect(delivery.body.to_s).to include("https://site.root/accept/#{@author2.edit_code.edit_code}")
         expect(delivery.to).to eq([@author2.author_email])
       end
     end


### PR DESCRIPTION
The edit code link is preferred for security, as it can only be used once.

I also changed the email to make clicking the link more central (more like our front end submitter invitation) and to remove the bit about PPR (since the only journal using this email currently does not allow PPR—we can revisit this in https://github.com/datadryad/dryad-product-roadmap/issues/4341)