### PR TITLE
Fix proxy user security

### DIFF
--- a/app/controllers/stash_engine/metadata_entry_pages_controller.rb
+++ b/app/controllers/stash_engine/metadata_entry_pages_controller.rb
@@ -135,7 +135,7 @@ module StashEngine
     private
 
     def ownership_transfer_needed?
-      (valid_edit_code? && resource.submitter.id == 0) || resource.submitter.blank?
+      valid_edit_code? && (resource.submitter.id == 0 || resource.submitter.blank? || resource.submitter.orcid.blank?)
     end
 
     def resource_exist

--- a/app/controllers/stash_engine/metadata_entry_pages_controller.rb
+++ b/app/controllers/stash_engine/metadata_entry_pages_controller.rb
@@ -42,7 +42,7 @@ module StashEngine
       valid_edit_code?
 
       if ownership_transfer_needed?
-        if current_user
+        if current_user && !current_user.proxy_user?
           ca = CurationActivity.create(
             status: @resource.current_curation_status || 'in_progress', user_id: 0, resource_id: @resource.id,
             note: "Transferring ownership to #{current_user.name} (#{current_user.id}) using an edit code"
@@ -64,7 +64,7 @@ module StashEngine
       # If the user is logged in, they will remain logged in, just with the added benefit
       # that they have access to edit this dataset. But if they were not logged in,
       # log them in as the dataset owner, and ensure the tenant_id is set correctly.
-      unless current_user
+      unless current_user && !current_user.proxy_user?
         session[:user_id] = resource.submitter.id
         if current_user.tenant_id.blank?
           session[:target_page] = stash_url_helpers.metadata_entry_pages_find_or_create_path(resource_id: resource.id)

--- a/app/controllers/stash_engine/shared_security_controller.rb
+++ b/app/controllers/stash_engine/shared_security_controller.rb
@@ -11,13 +11,14 @@ module StashEngine
 
     def require_user_login
       return if current_user.present?
+      return if current_user.proxy_user?
 
       flash[:alert] = 'You must be logged in.'
       redirect_to stash_url_helpers.choose_login_path
     end
 
     def require_login
-      unless current_user.present?
+      unless current_user.present? && !current_user.proxy_user?
         flash[:alert] = 'You must be logged in.'
         redirect_to stash_url_helpers.choose_login_path and return
       end

--- a/app/models/stash_engine/proxy_user.rb
+++ b/app/models/stash_engine/proxy_user.rb
@@ -92,6 +92,7 @@ module StashEngine
     def min_admin? = false
     def min_app_admin? = false
     def min_curator? = false
+    def proxy_user? = true
 
     def journals_as_admin
       admin_org_journals = journal_organizations.map(&:journals_sponsored_deep).flatten

--- a/app/models/stash_engine/user.rb
+++ b/app/models/stash_engine/user.rb
@@ -134,6 +134,8 @@ module StashEngine
       roles.any? { |r| %w[superuser curator].include?(r.role) }
     end
 
+    def proxy_user? = false
+
     def journals_as_admin
       admin_org_journals = journal_organizations.map(&:journals_sponsored_deep).flatten
       journals | admin_org_journals


### PR DESCRIPTION
Do not allow proxy users to edit account information, etc.—proxy users should only be allowed to access specific journal editing screens.

Also, fix the `ownership_transfer_needed?` check