### PR TITLE
Fix groups storage and checking in the database

### DIFF
--- a/lib/stash/indexer/indexing_resource.rb
+++ b/lib/stash/indexer/indexing_resource.rb
@@ -265,10 +265,11 @@ module Stash
       def group_funders
         extra_funders = []
         @resource.contributors.funder.completed.each do |funder|
-          groups = StashDatacite::ContributorGrouping.where("json_contains(json_contains->'$[*].name_identifier_id', json_array(?))",
-                                                            funder.name_identifier_id)
-
-          extra_funders + groups.map(&:contributor_name)
+          groups = StashDatacite::ContributorGrouping.where(
+            "json_contains(json_contains->'$[*].name_identifier_id', json_array(?))",
+            funder.name_identifier_id
+          )
+          extra_funders |= groups.map(&:contributor_name)
         end
         extra_funders
       end

--- a/lib/stash/indexer/indexing_resource.rb
+++ b/lib/stash/indexer/indexing_resource.rb
@@ -265,7 +265,7 @@ module Stash
       def group_funders
         extra_funders = []
         @resource.contributors.funder.completed.each do |funder|
-          groups = StashDatacite::ContributorGrouping.where("json_contains->>'name_identifier_id' = ?", funder.name_identifier_id)
+          groups = StashDatacite::ContributorGrouping.where("json_contains(json_contains->'$[*].name_identifier_id', json_array(?))", funder.name_identifier_id)
 
           extra_funders + groups.map(&:contributor_name)
         end

--- a/lib/stash/indexer/indexing_resource.rb
+++ b/lib/stash/indexer/indexing_resource.rb
@@ -264,10 +264,10 @@ module Stash
       # contributor names if we have an encompassing contributor that wants to be credited for its underling funders
       def group_funders
         extra_funders = []
-        StashDatacite::ContributorGrouping.all.each do |group|
-          identifier_ids = group.json_contains.map { |i| i['name_identifier_id'] }
-          count = @resource.contributors.funder.completed.where(name_identifier_id: identifier_ids).count
-          extra_funders.push(group.contributor_name) if count.positive?
+        @resource.contributors.funder.completed.each do |funder|
+          groups = StashDatacite::ContributorGrouping.where("json_contains->>'name_identifier_id' = ?", funder.name_identifier_id)
+
+          extra_funders + groups.map(&:contributor_name)
         end
         extra_funders
       end

--- a/lib/stash/indexer/indexing_resource.rb
+++ b/lib/stash/indexer/indexing_resource.rb
@@ -265,7 +265,8 @@ module Stash
       def group_funders
         extra_funders = []
         @resource.contributors.funder.completed.each do |funder|
-          groups = StashDatacite::ContributorGrouping.where("json_contains(json_contains->'$[*].name_identifier_id', json_array(?))", funder.name_identifier_id)
+          groups = StashDatacite::ContributorGrouping.where("json_contains(json_contains->'$[*].name_identifier_id', json_array(?))",
+                                                            funder.name_identifier_id)
 
           extra_funders + groups.map(&:contributor_name)
         end

--- a/lib/stash/organization/ror_updater.rb
+++ b/lib/stash/organization/ror_updater.rb
@@ -211,7 +211,7 @@ module Stash
             grouping.contributor_name = ror_org.name
             grouping.identifier_type = 'ror'
             grouping.group_label = grouping.group_label.presence || 'Child institutions'
-            grouping.json_contains = children.to_json
+            grouping.json_contains = children
             grouping.save
           end
           true


### PR DESCRIPTION
For https://github.com/datadryad/dryad-product-roadmap/issues/4414

Groups were being saved to the database as a string, but they're meant to be JSON.

Also, the searching of the groups should be made much more efficient, now that we have more than 1.