### PR TITLE
Remove inaccessible anchor links from markdown

### DIFF
--- a/app/helpers/application_helper.rb
+++ b/app/helpers/application_helper.rb
@@ -15,6 +15,13 @@ module ApplicationHelper
     fragment = Nokogiri::HTML5.fragment(description)
     dels = fragment.css('del')
     dels.add_class('from_md')
+    anchors = fragment.css('a.anchor:empty')
+    anchors.each(&:remove)
+    links = fragment.css('a')
+    links.each do |link|
+      link.set_attribute('target', '_blank')
+      link.add_child('<i class="fas fa-arrow-up-right-from-square exit-icon" aria-label=" (opens in new window)" role="img"></i>')
+    end
     tables = fragment.css('table')
     tables.wrap('<div class="table-wrapper" role="region" tabindex="0" aria-label="Table"></div>')
     fragment.to_html

--- a/app/views/stash_engine/landing/show.html.erb
+++ b/app/views/stash_engine/landing/show.html.erb
@@ -56,16 +56,3 @@
 <% unless @invitations.blank? %>
   <%= render partial: 'orcid_invite', locals: {identifier_id: id.id} %>
 <% end %>
-
-<% content_for(:doc_end) do %>
-<script type="text/javascript">
-  document.querySelectorAll('.t-landing__text-wall a').forEach((link) => {
-    const span = document.createElement('i')
-    span.classList.add('fas', 'fa-arrow-up-right-from-square', 'exit-icon')
-    span.setAttribute('aria-label', ' (opens in new window)')
-    span.setAttribute('role', 'img')
-    link.appendChild(span)
-    link.setAttribute('target', '_blank')
-  });
-</script>
-<% end %>


### PR DESCRIPTION
Empty `<a>` id links are bad HTML for accessibility.

Also, changes how external links are created for all description sections to use nokogiri instead of javascript.