### PR TITLE
Use the publication mixin in the PubUpdater

### DIFF
--- a/app/controllers/publication_mixin.rb
+++ b/app/controllers/publication_mixin.rb
@@ -13,7 +13,7 @@ module PublicationMixin
       StashEngine::UserMailer.peer_review_payment_needed(new_res).deliver_now
     else
       resource.update(hold_for_peer_review: false, peer_review_end_date: nil)
-      resource.curation_activities << StashEngine::CurationActivity.new(
+      resource.curation_activities << StashEngine::CurationActivity.create(
         user_id: 0, # system user
         status: 'submitted',
         note: 'Release from peer review through publication information'


### PR DESCRIPTION
May have been missed because we're not using the pub updater for this right now, but when it is used to add a primary article to a ppr resource it should also check for the PPR fee and the need to pay the full DPC