### PR TITLE
Add metrics to API response

### DIFF
--- a/app/models/stash_api/dataset.rb
+++ b/app/models/stash_api/dataset.rb
@@ -39,6 +39,7 @@ module StashApi
       descriptive_hsh = descriptive_metadata_hash
       metadata = descriptive_hsh.merge(lv.metadata)
       add_license!(metadata)
+      add_metrics!(metadata)
       add_edit_link!(metadata, lv)
 
       # gives the links to nearby objects
@@ -104,6 +105,14 @@ module StashApi
 
     def add_license!(hsh)
       hsh[:license] = StashEngine::License.by_id(@se_identifier.license_id)[:uri] if @se_identifier.license_id
+    end
+
+    def add_metrics!(hsh)
+      hsh[:metrics] = {
+        views: @se_identifier.counter_stat.views,
+        downloads: @se_identifier.counter_stat.unique_request_count,
+        citations: @se_identifier.counter_stat.citation_count
+      }
     end
 
     def add_edit_link!(hsh, version)

--- a/app/models/stash_api/version/metadata.rb
+++ b/app/models/stash_api/version/metadata.rb
@@ -10,7 +10,7 @@ module StashApi
         @post = post
       end
 
-      # rubocop:disable Metrics/AbcSize
+      # rubocop:disable Metrics/AbcSize, Metrics/MethodLength
       def value
         # setting some false values to nil because they get compacted.  Don't really want to advertise these options for
         # use by others besides ourselves because we don't want others to use them.
@@ -34,17 +34,21 @@ module StashApi
           publicationDate: @resource.publication_date&.strftime('%Y-%m-%d'),
           lastModificationDate: @resource.updated_at&.utc&.strftime('%Y-%m-%d'),
           visibility: visibility,
-          sharingLink: sharing_link,
-          skipDataciteUpdate: @resource.skip_datacite_update || nil,
-          skipEmails: @resource.skip_emails || nil,
-          preserveCurationStatus: @resource.preserve_curation_status || nil,
-          loosenValidation: @resource.loosen_validation || nil
+          sharingLink: sharing_link
         }
         vals[:changedFields] = changed_fields if @item_view
-        vals[:userId] = @resource&.submitter&.id if @post
+        if @post
+          vals.merge({
+                       userId: @resource&.submitter&.id,
+                       skipDataciteUpdate: @resource.skip_datacite_update || nil,
+                       skipEmails: @resource.skip_emails || nil,
+                       preserveCurationStatus: @resource.preserve_curation_status || nil,
+                       loosenValidation: @resource.loosen_validation || nil
+                     })
+        end
         vals
       end
-      # rubocop:enable Metrics/AbcSize
+      # rubocop:enable Metrics/AbcSize, Metrics/MethodLength
 
       def version_changes
         return 'none' if @resource.stash_version.version == 1

--- a/app/models/stash_api/version/metadata.rb
+++ b/app/models/stash_api/version/metadata.rb
@@ -38,13 +38,15 @@ module StashApi
         }
         vals[:changedFields] = changed_fields if @item_view
         if @post
-          vals.merge({
-                       userId: @resource&.submitter&.id,
-                       skipDataciteUpdate: @resource.skip_datacite_update || nil,
-                       skipEmails: @resource.skip_emails || nil,
-                       preserveCurationStatus: @resource.preserve_curation_status || nil,
-                       loosenValidation: @resource.loosen_validation || nil
-                     })
+          vals = vals.merge(
+            {
+              userId: @resource&.submitter&.id,
+              skipDataciteUpdate: @resource.skip_datacite_update || nil,
+              skipEmails: @resource.skip_emails || nil,
+              preserveCurationStatus: @resource.preserve_curation_status || nil,
+              loosenValidation: @resource.loosen_validation || nil
+            }
+          )
         end
         vals
       end

--- a/public/api/v2/docs/examples/dataset.json
+++ b/public/api/v2/docs/examples/dataset.json
@@ -77,5 +77,10 @@ value: {
   "changedFields": [
     "none"
   ],
+  "metrics": {
+    "views": 5,
+    "downloads": 3,
+    "citations": 1
+  },
   "license": "https://spdx.org/licenses/CC0-1.0.html"
 }

--- a/public/api/v2/docs/examples/datasets.json
+++ b/public/api/v2/docs/examples/datasets.json
@@ -63,6 +63,11 @@ value: {
         "publicationDate": "2020-01-01",
         "visibility": "public",
         "sharingLink": "https://datadryad.org/dataset/doi:10.5072/FK2HM58Q3S",
+        "metrics": {
+          "views": 5,
+          "downloads": 3,
+          "citations": 1
+        },
         "license": "https://spdx.org/licenses/CC0-1.0.html"
       },
       {
@@ -194,6 +199,11 @@ value: {
         "publicationDate": "2020-02-01",
         "visibility": "public",
         "sharingLink": "https://datadryad.org/dataset/doi:10.5072/FK2474DX0J",
+        "metrics": {
+          "views": 2,
+          "downloads": 0,
+          "citations": 1
+        },
         "license": "https://spdx.org/licenses/CC0-1.0.html"
       },
       {
@@ -245,6 +255,11 @@ value: {
         "publicationDate": "2020-01-07",
         "visibility": "public",
         "sharingLink": "https://datadryad.org/dataset/doi:10.5072/FK28W3G720",
+        "metrics": {
+          "views": 0,
+          "downloads": 0,
+          "citations": 0
+        },
         "license": "https://spdx.org/licenses/CC0-1.0.html"
       },
       {
@@ -290,6 +305,11 @@ value: {
         "publicationDate": "2020-01-07",
         "visibility": "public",
         "sharingLink": "https://datadryad.org/dataset/doi:10.5072/FK2MK6CD6D",
+        "metrics": {
+          "views": 2,
+          "downloads": 0,
+          "citations": 0
+        },
         "license": "https://spdx.org/licenses/CC0-1.0.html"
       },
       {
@@ -359,6 +379,11 @@ value: {
         "publicationDate": "2020-04-17",
         "visibility": "public",
         "sharingLink": "https://datadryad.org/dataset/doi:10.5072/FK24T6N929",
+        "metrics": {
+          "views": 1,
+          "downloads": 1,
+          "citations": 0
+        },
         "license": "https://spdx.org/licenses/CC0-1.0.html"
       },
       {
@@ -410,6 +435,11 @@ value: {
         "publicationDate": "2020-04-19",
         "visibility": "public",
         "sharingLink": "https://datadryad.org/dataset/doi:10.5072/FK2QJ7G49H",
+        "metrics": {
+          "views": 5,
+          "downloads": 1,
+          "citations": 1
+        },
         "license": "https://spdx.org/licenses/CC0-1.0.html"
       },
       {
@@ -455,6 +485,11 @@ value: {
         "publicationDate": "2020-05-01",
         "visibility": "public",
         "sharingLink": "https://datadryad.org/dataset/doi:10.5072/FK2J966H3B",
+        "metrics": {
+          "views": 25,
+          "downloads": 5,
+          "citations": 1
+        },
         "license": "https://spdx.org/licenses/CC0-1.0.html"
       },
       {
@@ -500,6 +535,11 @@ value: {
         "publicationDate": "2020-05-10",
         "visibility": "public",
         "sharingLink": "https://datadryad.org/dataset/doi:10.5072/FK2T151W7S",
+        "metrics": {
+          "views": 0,
+          "downloads": 0,
+          "citations": 0
+        },
         "license": "https://spdx.org/licenses/CC0-1.0.html"
       }
     ]

--- a/public/openapi.yml
+++ b/public/openapi.yml
@@ -976,6 +976,19 @@ components:
               type: string
         - $ref: '#/components/schemas/version'
         - $ref: '#/components/schemas/dataset_links'
+        - properties:
+            metrics: 
+              type: object
+              properties:
+                views:
+                  type: integer
+                downloads:
+                  type: integer
+                citations:
+                  type: integer
+            license:
+              type: string
+              description: 'The license of the dataset'
 
     dataset_links:
       properties:

--- a/spec/models/stash_api/dataset_spec.rb
+++ b/spec/models/stash_api/dataset_spec.rb
@@ -58,50 +58,6 @@ module StashApi
         expect(@metadata[:versionStatus]).to eq('in_progress')
       end
 
-      it 'hides skipDataciteUpdate if false' do
-        expect(@metadata[:skipDataciteUpdate]).to eq(nil)
-      end
-
-      it 'hides skipEmails if false' do
-        expect(@metadata[:skipEmails]).to eq(nil)
-      end
-
-      it 'hides preserveCurationStatus if false' do
-        expect(@metadata[:preserveCurationStatus]).to eq(nil)
-      end
-
-      it 'hides loosenValidation if false' do
-        expect(@metadata[:loosenValidation]).to eq(nil)
-      end
-
-      it 'shows skipDataciteUpdate when true' do
-        @identifier.in_progress_resource.update(skip_datacite_update: true)
-        @dataset = Dataset.new(identifier: @identifier.to_s, user: @user)
-        @metadata = @dataset.metadata
-        expect(@metadata[:skipDataciteUpdate]).to eq(true)
-      end
-
-      it 'shows skipEmails when true' do
-        @identifier.in_progress_resource.update(skip_emails: true)
-        @dataset = Dataset.new(identifier: @identifier.to_s, user: @user)
-        @metadata = @dataset.metadata
-        expect(@metadata[:skipEmails]).to eq(true)
-      end
-
-      it 'shows preserveCurationStatus when true' do
-        @identifier.in_progress_resource.update(preserve_curation_status: true)
-        @dataset = Dataset.new(identifier: @identifier.to_s, user: @user)
-        @metadata = @dataset.metadata
-        expect(@metadata[:preserveCurationStatus]).to eq(true)
-      end
-
-      it 'shows loosenValidation when true' do
-        @identifier.in_progress_resource.update(loosen_validation: true)
-        @dataset = Dataset.new(identifier: @identifier.to_s, user: @user)
-        @metadata = @dataset.metadata
-        expect(@metadata[:loosenValidation]).to eq(true)
-      end
-
       it 'has a curation status' do
         @dataset = Dataset.new(identifier: @identifier.to_s, user: @user)
         @metadata = @dataset.metadata
@@ -130,6 +86,12 @@ module StashApi
         expect(rw[:identifier]).to eq(ri.related_identifier)
         expect(rw[:identifierType]).to eq('DOI')
         expect(rw[:relationship]).to eq('primary_article')
+      end
+
+      it 'shows metrics' do
+        expect(@metadata[:metrics][:views]).to eq(0)
+        expect(@metadata[:metrics][:downloads]).to eq(0)
+        expect(@metadata[:metrics][:citations]).to eq(0)
       end
 
       it 'defaults to the correct license' do


### PR DESCRIPTION
Closes https://github.com/datadryad/dryad-product-roadmap/issues/4508

Also made some other corrections to try to match the docs and the API responses:

- The API docs were missing the license field
- The API was delivering our internal/admin values on every request if set, while the API docs shows these values only on dataset creation and editing (and I figured that was correct)