### PR TITLE
Change reviewer link redirect check

### DIFF
--- a/app/controllers/stash_engine/downloads_controller.rb
+++ b/app/controllers/stash_engine/downloads_controller.rb
@@ -2,6 +2,7 @@ require 'stash/download/file_presigned'
 require 'http'
 
 module StashEngine
+  # rubocop:disable Metrics/ClassLength
   class DownloadsController < ApplicationController
     include ActionView::Helpers::DateHelper
     include StashEngine::LandingHelper
@@ -82,7 +83,8 @@ module StashEngine
       raise ActionController::RoutingError, 'Not Found' if @resource.blank?
 
       redirect_to(app_404_path) if @resource.identifier.pub_state == 'withdrawn'
-      redirect_to_public if @resource.identifier.has_accepted_manuscript? || @resource.identifier.publication_article_doi.present?
+      redirect_to_public if @resource.files_published? &&
+      (@resource.identifier.has_accepted_manuscript? || @resource.identifier.publication_article_doi.present?)
     end
 
     # uses presigned
@@ -256,6 +258,6 @@ module StashEngine
       logger.warn(msg)
       ExceptionNotifier.notify_exception(Stash::Download::S3CustomError.new(msg))
     end
-
+    # rubocop:enable Metrics/ClassLength
   end
 end


### PR DESCRIPTION
Curators use the reviewer link to access Zenodo files, so the link should work during curation regardless of the state of the primary related work.