### PR TITLE
Really allow data managers to withdraw in progress datasets

### DIFF
--- a/app/policies/stash_engine/resource_policy.rb
+++ b/app/policies/stash_engine/resource_policy.rb
@@ -38,7 +38,7 @@ module StashEngine
     end
 
     def change_status?
-      @record.curatable? || @user.superuser?
+      @record.curatable? || @user.min_manager?
     end
 
     class VersionScope

--- a/app/views/stash_engine/admin_dashboard/_curation_form.html.erb
+++ b/app/views/stash_engine/admin_dashboard/_curation_form.html.erb
@@ -3,7 +3,7 @@
   <%= hidden_field_tag :field, @field %>
   <% case @field %>
   <% when 'curation_activity' %>
-    <p>Edit curation status of <em><%= @resource.title.html_safe %></em></p>
+    <p>Edit curation status of <b><%= @resource.title&.html_safe || '[No title provided]' %></b></p>
     <%= hidden_field_tag :identifier_id, @resource.identifier_id %>
     <%# Users cannot change the status or publication date once the files are published %>
     <% if policy(@resource).change_status? && filter_status_select(@resource.current_curation_status) %>


### PR DESCRIPTION
Missed a setting in https://github.com/datadryad/dryad-app/pull/2440