### PR TITLE
Fix zenodo redirect exception

### DIFF
--- a/app/controllers/stash_engine/downloads_controller.rb
+++ b/app/controllers/stash_engine/downloads_controller.rb
@@ -140,7 +140,7 @@ module StashEngine
       if res && (res&.may_download?(ui_user: current_user) || share&.identifier_id == res&.identifier&.id) &&
           [StashEngine::SuppFile, StashEngine::SoftwareFile].include?(zen_upload.class)
         if res.zenodo_published?
-          redirect_to zen_upload.public_zenodo_download_url
+          redirect_to zen_upload.public_zenodo_download_url, allow_other_host: true
         else
           zen_presign = zen_upload.zenodo_presigned_url
           if zen_presign.nil?


### PR DESCRIPTION
```
An ActionController::Redirecting::UnsafeRedirectError occurred in downloads#zenodo_file:

  Unsafe redirect to "https://zenodo.org/record/6244884/files/y-maze.pdf?download=1", pass allow_other_host: true to redirect anyway.
  app/controllers/stash_engine/downloads_controller.rb:143:in `zenodo_file'
```