### PR TITLE
Use datacite cursor pagination

### DIFF
--- a/lib/datacite/event_data.rb
+++ b/lib/datacite/event_data.rb
@@ -57,14 +57,14 @@ module Datacite
     def query
       results = []
 
-      params = { doi: @doi, 'relation-type-id': (UNIQUE_INVESTIGATIONS + UNIQUE_REQUESTS).join(','), 'page[size]': 500 }
+      params = { doi: @doi, 'relation-type-id': (UNIQUE_INVESTIGATIONS + UNIQUE_REQUESTS).join(','), 'page[size]': 500, 'page[cursor]': 1 }
       query_result = Integrations::Datacite.new.query('/events', params)
 
       results.concat(query_result['data'])
 
       # if this doesn't contain full set of results, then keep going to the next page and adding them
       while query_result.dig('links', 'next').present?
-        params['page[number]'] = query_result.dig('meta', 'page').to_i + 1
+        params['page[cursor]'] = Rack::Utils.parse_nested_query(URI.parse(query_result.dig('links', 'next')).query)['page']['cursor']
         query_result = Integrations::Datacite.new.query('/events', params)
         results.concat(query_result['data'])
       end

--- a/lib/tasks/cleanup.rake
+++ b/lib/tasks/cleanup.rake
@@ -45,11 +45,11 @@ namespace :cleanup do
   end
 
   task update_file_licenses: :environment do
-    params = { 'client-id': APP_CONFIG.identifier_service.account, 'resource-type': 'DataFile', 'page[size]': 500 }
+    params = { 'client-id': APP_CONFIG.identifier_service.account, 'resource-type': 'DataFile', 'page[size]': 500, 'page[cursor]': 1 }
     query_result = Integrations::Datacite.new.query('/dois', params)
     records = [].concat(query_result['data'])
     while query_result.dig('links', 'next').present?
-      params['page[number]'] = query_result.dig('meta', 'page').to_i + 1
+      params['page[cursor]'] = Rack::Utils.parse_nested_query(URI.parse(query_result.dig('links', 'next')).query)['page']['cursor']
       query_result = Integrations::Datacite.new.query('/dois', params)
       records.concat(query_result['data'])
     end


### PR DESCRIPTION
DataCite page number pagination is limited to 10,000 total entries (https://support.datacite.org/docs/pagination)

Cursor paginaton has an unlimited number of entries, however we cannot use the provided next links directly, because they drop other query/filter parameters. We have to extract the cursor param from the link.