### PR TITLE
Remove throttle on AAR reminders

### DIFF
--- a/app/services/reminders/abandoned_dataset_service.rb
+++ b/app/services/reminders/abandoned_dataset_service.rb
@@ -35,9 +35,6 @@ module Reminders
         .where(stash_engine_process_dates: { delete_calculation_date: (1.year - 1.day).ago.beginning_of_day..1.months.ago.end_of_day })
         .each do |resource|
 
-        # Only send for resources where the ID ends in 00-05, so we can stagger the load on the curators
-        next if (resource.id % 100) > 5
-
         reminder_flag = 'action_required_deletion_notice'
         last_reminder = resource.curation_activities.where('note LIKE ?', "%#{reminder_flag}%")&.last
 

--- a/app/services/reminders/dataset_reminders_service.rb
+++ b/app/services/reminders/dataset_reminders_service.rb
@@ -35,9 +35,6 @@ module Reminders
         resource = item[:identifier]&.latest_resource
         next if resource.nil?
 
-        # Only send for resources where the ID ends in 00-05, so we can stagger the load on the curators
-        next if (resource.id % 100) > 5
-
         # send out reminder at two weeks
         next if item[:set_at] > 2.weeks.ago || item[:reminder_1].present?
 


### PR DESCRIPTION
Closes https://github.com/datadryad/dryad-product-roadmap/issues/3752

Removes the restriction that only sent a percentage of AAR reminders, allowing all of the reminders to be sent on the correct schedule. 