### PR TITLE
Fix creation of duplicate resource

### DIFF
--- a/app/controllers/stash_datacite/peer_review_controller.rb
+++ b/app/controllers/stash_datacite/peer_review_controller.rb
@@ -34,8 +34,7 @@ module StashDatacite
         if errors || (not_paid && !invoicer.invoice_created?)
           flash[:notice] = 'Please pay the remaining DPC to submit for curation and publication' if not_paid
           flash[:alert] = 'Unable to submit dataset for curation. Please correct submission errors' if errors
-          new_res = DuplicateResourceService.new(@resource, current_user).call
-          redirect_to stash_url_helpers.metadata_entry_pages_find_or_create_path(resource_id: new_res.id)
+          redirect_to metadata_entry_pages_new_version_path(resource_id: @resource.id)
         else
           redirect_to dashboard_path, notice: 'Dataset cannot be queued for curation until invoice is paid'
         end


### PR DESCRIPTION
Closes: https://github.com/datadryad/dryad-product-roadmap/issues/5031

Steps to reproduce:
1. Have a sponsored journal/institution which is on 2025 plan but does not cover LDF
2. Create a dataset for this journal
3. Add files over the free limit
4. Put the dataset into PPR and submit
5. Open "My datasets" in multiple browser tabs
6. Click on release from PPR on all these tabs 

This results in creation of a new version for each "release" click