### PR TITLE
Create setting for LDF notification emails

### DIFF
--- a/app/controllers/stash_engine/tenant_admin_controller.rb
+++ b/app/controllers/stash_engine/tenant_admin_controller.rb
@@ -144,7 +144,8 @@ module StashEngine
     def edit_params
       params.permit(:id, :short_name, :long_name, :logo, :campus_contacts, :enabled, :partner_display, :ror_orgs, :sponsor_id,
                     flag_attributes: %i[id note _destroy],
-                    payment_configuration_attributes: %i[id payment_plan covers_dpc covers_ldf ldf_limit yearly_ldf_limit ldf_limit_notification _destroy],
+                    payment_configuration_attributes: %i[id payment_plan covers_dpc covers_ldf ldf_limit yearly_ldf_limit
+                                                         ldf_limit_notification _destroy],
                     authentication: %i[strategy ranges entity_id entity_domain email_domain])
     end
 

--- a/app/controllers/stash_engine/tenant_admin_controller.rb
+++ b/app/controllers/stash_engine/tenant_admin_controller.rb
@@ -144,7 +144,7 @@ module StashEngine
     def edit_params
       params.permit(:id, :short_name, :long_name, :logo, :campus_contacts, :enabled, :partner_display, :ror_orgs, :sponsor_id,
                     flag_attributes: %i[id note _destroy],
-                    payment_configuration_attributes: %i[id payment_plan covers_dpc covers_ldf ldf_limit yearly_ldf_limit _destroy],
+                    payment_configuration_attributes: %i[id payment_plan covers_dpc covers_ldf ldf_limit yearly_ldf_limit ldf_limit_notification _destroy],
                     authentication: %i[strategy ranges entity_id entity_domain email_domain])
     end
 

--- a/app/models/payment_configuration.rb
+++ b/app/models/payment_configuration.rb
@@ -2,16 +2,17 @@
 #
 # Table name: payment_configurations
 #
-#  id               :bigint           not null, primary key
-#  covers_dpc       :boolean
-#  covers_ldf       :boolean
-#  ldf_limit        :integer
-#  partner_type     :string(191)
-#  payment_plan     :integer
-#  yearly_ldf_limit :integer
-#  created_at       :datetime         not null
-#  updated_at       :datetime         not null
-#  partner_id       :string(191)
+#  id                     :bigint           not null, primary key
+#  covers_dpc             :boolean
+#  covers_ldf             :boolean
+#  ldf_limit              :integer
+#  ldf_limit_notification :boolean          default(FALSE)
+#  partner_type           :string(191)
+#  payment_plan           :integer
+#  yearly_ldf_limit       :integer
+#  created_at             :datetime         not null
+#  updated_at             :datetime         not null
+#  partner_id             :string(191)
 #
 
 # NOTE: ldf_limit stores the tier number and not an actual limit size

--- a/app/services/cost_reporting_service.rb
+++ b/app/services/cost_reporting_service.rb
@@ -21,6 +21,9 @@ class CostReportingService
   private
 
   def should_send_notification?
+    # NO - payer has LDF notifications turned off
+    return false unless PayersService.new(resource.identifier.payer).sponsored_limits&.ldf_limit_notification
+
     # NO - payer is not on 2025 payments plan
     return false unless resource.identifier.payer_2025?
 

--- a/app/views/stash_engine/payment_configuration/_form.html.erb
+++ b/app/views/stash_engine/payment_configuration/_form.html.erb
@@ -28,5 +28,9 @@
       <%= pf.label :yearly_ldf_limit, "Yearly Large Data Fee limit $" %>
       <%= pf.number_field :yearly_ldf_limit, value: payment_configuration.yearly_ldf_limit, class: 'c-input__text', disabled: !payment_configuration.covers_ldf %>
     </p>
+    <p>
+      <%= pf.check_box :ldf_limit_notification, {checked: payment_configuration.ldf_limit_notification, disabled: !payment_configuration.covers_ldf}, 1, 0 %>
+      <%= pf.label :ldf_limit_notification, "Receive LDF notification emails" %>
+    </p>
   <% end %>
 </div>

--- a/app/views/stash_engine/payment_configuration/_js_form.js.erb
+++ b/app/views/stash_engine/payment_configuration/_js_form.js.erb
@@ -8,4 +8,9 @@ ldf.addEventListener('change', () => {
     limit.value = ''
     amount_limit.value = ''
   }
+  var limit_notification = document.getElementById('payment_configuration_attributes_ldf_limit_notification')
+  if(limit_notification) {
+    limit_notification.disabled = !ldf.checked
+    limit_notification.checked = false
+  }
 })

--- a/app/views/stash_engine/tenant_admin/_admin_tenant_row.html.erb
+++ b/app/views/stash_engine/tenant_admin/_admin_tenant_row.html.erb
@@ -50,6 +50,7 @@
       <% end %>
       <% if t.sponsor_id %><br/><b>Inherited from:</b> <a href="?id=<%= t.sponsor_id %>"><%= t.sponsor_id %></a><% end %>
     <% end %>
+    <b>LDF emails:</b> <%= t.payment_sponsor&.payment_configuration&.ldf_limit_notification ? "Yes" : "No" %>
   <% else %>
     <span style="color: rgb(209, 44, 29)">Disabled</span>
   <% end %>

--- a/db/migrate/20260527154826_add_ldf_limit_notification_to_payment_configurations_table.rb
+++ b/db/migrate/20260527154826_add_ldf_limit_notification_to_payment_configurations_table.rb
@@ -1,0 +1,5 @@
+class AddLdfLimitNotificationToPaymentConfigurationsTable < ActiveRecord::Migration[8.0]
+  def change
+    add_column :payment_configurations, :ldf_limit_notification, :boolean, default: false, after: :yearly_ldf_limit
+  end
+end

--- a/spec/factories/payment_configurations.rb
+++ b/spec/factories/payment_configurations.rb
@@ -2,16 +2,17 @@
 #
 # Table name: payment_configurations
 #
-#  id               :bigint           not null, primary key
-#  covers_dpc       :boolean
-#  covers_ldf       :boolean
-#  ldf_limit        :integer
-#  partner_type     :string(191)
-#  payment_plan     :integer
-#  yearly_ldf_limit :integer
-#  created_at       :datetime         not null
-#  updated_at       :datetime         not null
-#  partner_id       :string(191)
+#  id                     :bigint           not null, primary key
+#  covers_dpc             :boolean
+#  covers_ldf             :boolean
+#  ldf_limit              :integer
+#  ldf_limit_notification :boolean          default(FALSE)
+#  partner_type           :string(191)
+#  payment_plan           :integer
+#  yearly_ldf_limit       :integer
+#  created_at             :datetime         not null
+#  updated_at             :datetime         not null
+#  partner_id             :string(191)
 #
 FactoryBot.define do
 

--- a/spec/services/cost_reporting_service_spec.rb
+++ b/spec/services/cost_reporting_service_spec.rb
@@ -18,7 +18,7 @@ describe CostReportingService do
   let(:identifier) { create(:identifier) }
   let(:org) { create(:journal_organization) }
   let!(:journal) { create(:journal, sponsor: org) }
-  let!(:payment_conf) { create(:payment_configuration, partner: org, payment_plan: '2025', covers_ldf: true) }
+  let!(:payment_conf) { create(:payment_configuration, partner: org, payment_plan: '2025', covers_ldf: true, ldf_limit_notification: true) }
   let(:prev_resource) do
     create(:resource,
            identifier: identifier,
@@ -267,6 +267,12 @@ describe CostReportingService do
             let(:resource_files_size) { 200_000_000_000 }
 
             include_examples 'sends ldf notification'
+
+            context 'when payer has LDF notifications turned off' do
+              let!(:payment_conf) { create(:payment_configuration, partner: org, payment_plan: '2025', covers_ldf: true, ldf_limit_notification: false) }
+
+              include_examples 'does not send ldf notification'
+            end
           end
         end
 
@@ -280,5 +286,6 @@ describe CostReportingService do
         end
       end
     end
+
   end
 end

--- a/spec/services/cost_reporting_service_spec.rb
+++ b/spec/services/cost_reporting_service_spec.rb
@@ -269,7 +269,9 @@ describe CostReportingService do
             include_examples 'sends ldf notification'
 
             context 'when payer has LDF notifications turned off' do
-              let!(:payment_conf) { create(:payment_configuration, partner: org, payment_plan: '2025', covers_ldf: true, ldf_limit_notification: false) }
+              let!(:payment_conf) do
+                create(:payment_configuration, partner: org, payment_plan: '2025', covers_ldf: true, ldf_limit_notification: false)
+              end
 
               include_examples 'does not send ldf notification'
             end


### PR DESCRIPTION
Closes: https://github.com/datadryad/dryad-product-roadmap/issues/5053

Please note that once this is deployed, none of the institutions will receive any emails.
Institutions need to have the LDF limit manually enabled in order to receive these emails.