### PR TITLE
Payment configuration should change when dataset becomes unsponsored

### DIFF
--- a/app/models/concerns/stash_engine/payment_methods.rb
+++ b/app/models/concerns/stash_engine/payment_methods.rb
@@ -145,7 +145,7 @@ module StashEngine
 
       # do not remove recorded institution sponsor due to sponsorship change
       return true if payment_id.present? && payment_id == tenant&.id
-      return false unless PayersService.new(tenant).payment_sponsor&.payment_configuration&.valid_payer?
+      return false unless PayersService.new(tenant).payment_sponsor&.payment_configuration&.covers_dpc?
 
       if tenant&.authentication&.strategy == 'author_match'
         # get all unique ror_id associations for all authors

--- a/app/models/concerns/stash_engine/payment_methods.rb
+++ b/app/models/concerns/stash_engine/payment_methods.rb
@@ -85,7 +85,7 @@ module StashEngine
       return false if current_payer.blank?
       return false if payer_2025?(current_payer) || old_payment_system
 
-      current_payer.payment_configuration&.covers_dpc && current_payer.payment_configuration&.payment_plan.present?
+      current_payer.payment_configuration&.valid_payer?
     end
 
     # rubocop:disable Metrics/AbcSize
@@ -145,7 +145,7 @@ module StashEngine
 
       # do not remove recorded institution sponsor due to sponsorship change
       return true if payment_id.present? && payment_id == tenant&.id
-      return false unless PayersService.new(tenant).payment_sponsor&.payment_configuration&.covers_dpc
+      return false unless PayersService.new(tenant).payment_sponsor&.payment_configuration&.valid_payer?
 
       if tenant&.authentication&.strategy == 'author_match'
         # get all unique ror_id associations for all authors
@@ -200,7 +200,7 @@ module StashEngine
         return unless payment_type.include?('journal') || journal_will_pay?
         return if payment_id == journal&.single_issn
       end
-      return if payments.paid.any?
+      return if payments.where.not(resource_id: latest_resource.id).paid.any?
 
       self.payment_type = nil
       self.payment_id = nil

--- a/app/models/payment_configuration.rb
+++ b/app/models/payment_configuration.rb
@@ -23,6 +23,10 @@ class PaymentConfiguration < ApplicationRecord
   enum :payment_plan, { SUBSCRIPTION: 1, PREPAID: 2, DEFERRED: 3, TIERED: 4, '2025': 5 }
   before_save :reset_limit, :set_covers_dpc
 
+  def valid_payer?
+    covers_dpc? && payment_plan.present?
+  end
+
   private
 
   def reset_limit


### PR DESCRIPTION
Closes: https://github.com/datadryad/dryad-product-roadmap/issues/5062

The payment configuration was not changed only if the dataset was sponsored and it switched to unsponsored and user made a payment on the same version