### PR TITLE
Exception fixes

### DIFF
--- a/app/controllers/latest_controller.rb
+++ b/app/controllers/latest_controller.rb
@@ -11,7 +11,7 @@ class LatestController < ApplicationController
     set_cached_latest
 
     respond_to do |format|
-      format.html { store_preferred_view }
+      format.html
       format.js
     end
   end

--- a/app/controllers/stash_datacite/contributors_controller.rb
+++ b/app/controllers/stash_datacite/contributors_controller.rb
@@ -143,10 +143,10 @@ module StashDatacite
       @contributors = Contributor.where(id: params[:contributor].keys)
 
       # contributors must not be empty
-      render json: { error: 'bad request' }, status: :bad_request unless @contributors.first.present?
+      render json: { error: 'bad request' }, status: :bad_request and return unless @contributors.first.present?
 
       # you can only order things belonging to one resource
-      render json: { error: 'bad request' }, status: :bad_request unless @contributors.map(&:resource_id)&.uniq&.length == 1
+      render json: { error: 'bad request' }, status: :bad_request and return unless @contributors.map(&:resource_id)&.uniq&.length == 1
 
       @resource = StashEngine::Resource.find(@contributors.first.resource_id) # set resource to check permission to modify
     end

--- a/app/services/payers_service.rb
+++ b/app/services/payers_service.rb
@@ -6,7 +6,7 @@ class PayersService
   end
 
   def is_2025_payer?
-    payment_sponsor.payment_configuration&.payment_plan.to_s == '2025'
+    payment_sponsor&.payment_configuration&.payment_plan.to_s == '2025'
   end
 
   def payment_sponsor

--- a/app/services/stash_api/solr_search_service.rb
+++ b/app/services/stash_api/solr_search_service.rb
@@ -36,7 +36,7 @@ module StashApi
     end
 
     def sort_query
-      filters['sort'].sub('date ', 'dct_issued_dt ')
+      filters['sort'].split.first(2).join(' ').sub('date ', 'dct_issued_dt ')
     end
 
     def solr_exact_map

--- a/app/views/stash_engine/downloads/_download.html.erb
+++ b/app/views/stash_engine/downloads/_download.html.erb
@@ -20,7 +20,7 @@
   <div class="screen-reader-only" id="accessible-dl-msg" aria-live="assertive"></div>
 </div>
 <% content_for :doc_end do %>
-<% params = {resource_id: @resource.id} %>
+<% params = {resource_id: resource.id} %>
 <% params[:share] = share if share.present? %>
 <script type="text/javascript" async>
   <% if resource.total_file_size > APP_CONFIG.maximums.zip_size %>

--- a/app/views/stash_engine/landing/_files.html.erb
+++ b/app/views/stash_engine/landing/_files.html.erb
@@ -66,7 +66,9 @@
     <% end %>
     <div id="file_preview_box" role="status"></div>
     <!-- full download second -->
+    <% if dl_resource.present? %>    
     <%= render partial: 'stash_engine/downloads/download', locals: { dataset_identifier: dataset_identifier, resource: dl_resource, share: share.present? ? share[:code] : nil } %>
+    <% end %>
   <% elsif dataset_identifier.retracted? %>
     <p>This dataset has been retracted. Please see the notice above for more information.</p>
   <% elsif dataset_identifier.pub_state == 'embargoed' %>

--- a/app/views/stash_engine/user_mailer/withdrawn.html.erb
+++ b/app/views/stash_engine/user_mailer/withdrawn.html.erb
@@ -3,7 +3,7 @@
 <p>Your data submission has been withdrawn from the Dryad platform:</p>
 
 <p>
-  Title: <%= @resource.title.html_safe %><br/>
+  Title: <%= @resource.title&.html_safe || '<em>Untitled</em>'.html_safe %><br/>
   DOI: <%= @resource.identifier_uri %>
 </p>
 


### PR DESCRIPTION
```
An ActionView::Template::Error occurred in admin_dashboard#update:

  undefined method `html_safe' for nil
  app/views/stash_engine/user_mailer/withdrawn.html.erb:6
```

```
An ActionView::Template::Error occurred in landing#show:

  undefined method `publication_date' for nil
  app/views/stash_engine/downloads/_download.html.erb:8
```

```
A TypeError occurred in search#author_profile:

  no implicit conversion of String into Integer
  app/controllers/search_controller.rb:43:in `[]'
```

```
A NameError occurred in latest#index:

  undefined local variable or method `store_preferred_view' for an instance of LatestController
  app/controllers/latest_controller.rb:14:in `block (2 levels) in index'
```

```
An AbstractController::DoubleRenderError occurred in contributors#reorder:

  Render and/or redirect were called multiple times in this action. Please note that you may only call render OR redirect, and at most once per action. Also note that neither redirect nor render terminate execution of the action, so if you want to exit an action after redirecting, you need to do something like "redirect_to(...); return".
  app/controllers/stash_datacite/contributors_controller.rb:149:in `check_reorder_valid'
```

```
A NoMethodError occurred in metadata_entry_pages#find_or_create:

  undefined method `payment_configuration' for nil
  app/services/payers_service.rb:9:in `is_2025_payer?'
```