### PR TITLE
Update fields type

### DIFF
--- a/app/models/csp_report.rb
+++ b/app/models/csp_report.rb
@@ -3,12 +3,12 @@
 # Table name: csp_reports
 #
 #  id          :bigint           not null, primary key
-#  blocked_uri :string(191)
+#  blocked_uri :text(65535)
 #  directive   :string(191)
 #  ip          :string(191)
 #  report      :json
 #  status_code :string(191)
-#  url         :string(191)
+#  url         :text(65535)
 #  user_agent  :string(191)
 #  created_at  :datetime         not null
 #  updated_at  :datetime         not null

--- a/db/migrate/20260610132254_update_csp_reports_field_types.rb
+++ b/db/migrate/20260610132254_update_csp_reports_field_types.rb
@@ -1,0 +1,11 @@
+class UpdateCspReportsFieldTypes < ActiveRecord::Migration[8.0]
+  def up
+    change_column :csp_reports, :blocked_uri, :text
+    change_column :csp_reports, :url, :text
+  end
+
+  def down
+    change_column :csp_reports, :blocked_uri, :string
+    change_column :csp_reports, :url, :string
+  end
+end


### PR DESCRIPTION
```
An ActiveRecord::ValueTooLong occurred in csp_violation_reports#create:

 Mysql2::Error: Data too long for column 'blocked_uri' at row 1
 app/controllers/csp_violation_reports_controller.rb:7:in `create'
```