### PR TITLE
Fix datacite ping method

### DIFF
--- a/lib/datacite/doi_gen.rb
+++ b/lib/datacite/doi_gen.rb
@@ -48,7 +48,7 @@ module Datacite
     end
 
     def ping(identifier)
-      get_doi(identifier, username: account, password: password, sandbox: sandbox)
+      get_doi(identifier)
     end
 
     def update_metadata(dc4_xml:, landing_page_url:)


### PR DESCRIPTION
All the other variables were previously moved to `Integrations::Datacite`