### PR TITLE
Markdown editor accessibility updates

### DIFF
--- a/app/assets/stylesheets/stash_engine/milkdown_editor.css
+++ b/app/assets/stylesheets/stash_engine/milkdown_editor.css
@@ -342,10 +342,9 @@
   background-color: rgb(233, 236, 239);
 }
 
-@container (width < 605px) and (width > 344px) {
-  .markdown_editor .md_editor-buttons .imageMenu,
-  .markdown_editor .md_editor-buttons .linkMenu {
-    left: auto; right: 0;
+@container (width < 766px) and (width > 556px){
+  .markdown_editor .md_editor-buttons .tableMenu > div{
+    margin-left: 170px;
   }
 }
 
@@ -355,20 +354,22 @@
   }
 }
 
-@container (width < 766px) and (width > 556px){
-  .markdown_editor .md_editor-buttons .tableMenu > div{
-    margin-left: 170px;
-  }
-}
 @container (width < 556px) {
   .markdown_editor .md_editor-buttons .tableMenu {
     justify-content: flex-end;
   }
 }
+
 @container (width < 455px) {
   .markdown_editor .md_editor-buttons .tableMenu {
     justify-content: flex-start;
     top: 5.1rem;
+  }
+}
+
+@container (width < 338px) and (width > 295.5px)  {
+  .markdown_editor .md_editor-buttons .listMenu {
+    left: auto; right: 0;
   }
 }
 
@@ -434,7 +435,7 @@
   width: 135px;
   max-height: none;
   overflow: visible;
-  font-size: .98rem;
+  font-size: .95rem;
 }
 
 .markdown_editor .md_editor-buttons .tableOptMenu ul {
@@ -497,22 +498,18 @@
   margin-left: auto;
 }
 
-@container (width < 760px) and (width > 505px) {
+@container ((width < 760px) and (width > 505px)) or ((width < 384px) and (width > 258px)){
   .markdown_editor .md_editor-buttons .tableOptMenu {
     left: auto; right: -3px;
   }
-  .markdown_editor .md_editor-buttons .tableOptMenu li button {
-    flex-direction: row-reverse;
-  }
-  .markdown_editor .md_editor-buttons .tableOptMenu i[class*='chevron'] {
-    margin-left: 0;
-    margin-right: auto;
-  }
-  .markdown_editor .md_editor-buttons .tableOptMenu i[class*='chevron']:before {
-    content: '\f053';
+}
+@container ((width < 760px) and (width > 505px)) or (width < 384px) {
+  .markdown_editor .md_editor-buttons .tableOptMenu {
+    font-size: .85rem;
   }
   .markdown_editor .md_editor-buttons .tableOptMenu ul {
-    left: auto; right: 137px;
+    top: 100%; left: auto; right: -15px;
+    width: 135px;
   }
 }
 
@@ -598,6 +595,35 @@
 .markdown_editor .md_editor-buttons .linkMenu .buttons button:focus {
   background-color: #0071a8;
   color: #fff;
+}
+
+@container (width < 708px) and (width > 412px) {
+  .markdown_editor .md_editor-buttons .imageMenu,
+  .markdown_editor .md_editor-buttons .linkMenu {
+    left: auto; right: 0;
+  }
+}
+
+@container (width < 365px) {
+  .markdown_editor .md_editor-buttons .imageSelect,
+  .markdown_editor .md_editor-buttons .linkSelect {
+    position: static;
+  }
+  .markdown_editor .md_editor-buttons .imageMenu,
+  .markdown_editor .md_editor-buttons .linkMenu {
+    height: auto;
+    left: 0; right: 0; top: 80px;
+  }
+  .markdown_editor .md_editor-buttons .linkMenu label {
+    flex-wrap: wrap;
+  }
+}
+
+@container (width < 224px) {
+  .markdown_editor .md_editor-buttons .imageMenu,
+  .markdown_editor .md_editor-buttons .linkMenu {
+    top: 100px;
+  }
 }
 
 .markdown_editor .milkdown {

--- a/app/assets/stylesheets/stash_engine/milkdown_editor.css
+++ b/app/assets/stylesheets/stash_engine/milkdown_editor.css
@@ -209,6 +209,10 @@
   text-shadow: 0 0 .06rem #98cae2;
 }
 
+.markdown_editor .md_editor-buttons .headingButton:not(.active) {
+  font-size: .98rem;
+}
+
 .markdown_editor .md_editor-buttons .headingButton:focus,
 .markdown_editor .md_editor-buttons button:focus {
   background-color: #0071a8;
@@ -306,6 +310,7 @@
   margin: 0;
   padding: 3px 5px;
   border-top: thin solid #d0d0d0;
+  cursor: pointer;
 }
 
 .markdown_editor .md_editor-buttons .headingMenu li.selected {
@@ -313,7 +318,8 @@
   color: white;
 }
 
-.markdown_editor .md_editor-buttons .headingMenu li.highlighted {
+.markdown_editor .md_editor-buttons .headingMenu li:hover,
+.markdown_editor .md_editor-buttons .headingMenu li:focus {
   background-color: #0071a8;
   color: white;
 }

--- a/app/assets/stylesheets/stash_engine/milkdown_editor.css
+++ b/app/assets/stylesheets/stash_engine/milkdown_editor.css
@@ -78,6 +78,11 @@
   justify-content: flex-end;
 }
 
+.micro_editor .md_editor-buttons:focus-within {
+  border-color: #0071a8; 
+  background-color: rgb(233, 236, 239);
+}
+
 .markdown_editor .md_editor-buttons div[role="group"]:not(:last-of-type) {
   border-right: thin solid #d0d0d0;
   margin-right: .25ch;
@@ -188,6 +193,10 @@
   color: rgb(78, 80, 80);
 }
 
+.micro_editor .md_editor-buttons:focus-within button:not(:focus) {
+  background-color: rgb(233, 236, 239);
+}
+
 .markdown_editor .md_editor-buttons button:hover,
 .markdown_editor .md_editor-buttons .headingButton:hover {
   background-color: #0071a8;
@@ -215,7 +224,7 @@
   background-color: #fff;
 }
 
-.markdown_editor .md_editor-buttons button[disabled] {
+.markdown_editor .md_editor-buttons button[aria-disabled] {
   color: #aaa;
   background-color: rgb(233, 236, 239);
   text-shadow: none;
@@ -238,7 +247,7 @@
   white-space: nowrap;
 }
 
-.markdown_editor .md_editor-buttons .tableOptButton[disabled] i[class*='chevron'] {
+.markdown_editor .md_editor-buttons .tableOptButton[aria-disabled] i[class*='chevron'] {
   color: #aaa;
 }
 
@@ -248,8 +257,8 @@
 .markdown_editor .md_editor-buttons .headingButton:not(.active):focus i,
 .markdown_editor .md_editor-buttons .linkSelect > button:not(.active):focus i,
 .markdown_editor .md_editor-buttons .linkSelect > button:not(.active):hover i,
-.markdown_editor .md_editor-buttons .tableOptButton:not([disabled]):hover i[class*='chevron'],
-.markdown_editor .md_editor-buttons .tableOptButton:not([disabled]):focus i[class*='chevron'],
+.markdown_editor .md_editor-buttons .tableOptButton:not([aria-disabled]):hover i[class*='chevron'],
+.markdown_editor .md_editor-buttons .tableOptButton:not([aria-disabled]):focus i[class*='chevron'],
 .markdown_editor .md_editor-buttons .tableOptMenu button:hover i[class*='chevron'],
 .markdown_editor .md_editor-buttons .tableOptMenu button:focus i[class*='chevron'] {
   color: #f2f2f2;

--- a/app/helpers/application_helper.rb
+++ b/app/helpers/application_helper.rb
@@ -44,8 +44,10 @@ module ApplicationHelper
         extension: { superscript: true, subscript: true, shortcodes: false }
       }
     )
-    doc.walk do |node|
-      node.header_level = node.header_level + header_offset if node.type == :heading
+    while doc.each.any? { |n| n.type == :heading && n.header_level <= header_offset }
+      doc.walk do |node|
+        node.header_level = node.header_level + 1 if node.type == :heading
+      end
     end
     doc.to_html(options: { render: { unsafe: true, escaped_char_spans: false } }, plugins: { syntax_highlighter: { theme: '' } })
   end

--- a/app/javascript/react/components/MarkdownEditor/Button.jsx
+++ b/app/javascript/react/components/MarkdownEditor/Button.jsx
@@ -1,119 +1,21 @@
 import React, {useState, useEffect} from 'react';
 import {editorViewCtx} from '@milkdown/kit/core';
 import {callCommand} from '@milkdown/kit/utils';
-import {TextSelection} from '@milkdown/kit/prose/state';
 import {commands} from './milkdownCommands';
 import {commands as mdCommands} from './codeKeymap';
+/* eslint-disable-next-line import/no-cycle */
 import {
-  Table, Heading, ImageMenu, LinkMenu, List, icons, labels,
+  Table, Heading, ImageMenu, LinkMenu, ListMenu, List, icons, labels,
 } from './Buttons';
-
-function Toggle({
-  type, editor, active, disabled,
-}) {
-  const callEditorCommand = () => {
-    const view = editor()?.ctx.get(editorViewCtx);
-    const {dispatch, state} = view;
-    const {
-      doc, selection, schema, tr,
-    } = state;
-    const {from: start, to: end} = selection;
-    if (doc.rangeHasMark(start, end === start ? end + 1 : end, schema.marks[type])) {
-      const {parent} = doc.resolve(start);
-      let from = start;
-      let to = end;
-      while (from > 0 && !doc.textBetween(from - 1, start).replace(/[ ]/g, '').length) {
-        from -= 1;
-      }
-      while (to < parent.childCount && !doc.textBetween(end, to + 1).replace(/[ ]/g, '').length) {
-        to += 1;
-      }
-      tr.setSelection(TextSelection.create(doc, from, to));
-      dispatch(tr);
-    }
-    editor()?.action(callCommand(commands[type].key));
-    view.focus();
-  };
-
-  return (
-    <button
-      type="button"
-      className={active ? 'active' : undefined}
-      disabled={disabled}
-      title={labels[type]}
-      aria-label={labels[type]}
-      role="menuitem"
-      onClick={callEditorCommand}
-    >{icons[type]}
-    </button>
-  );
-}
-
-function ListMenu({active, editorId, ...props}) {
-  const list_buttons = ['bullet_list', 'ordered_list', 'indent', 'outdent'];
-
-  const closeMenu = () => {
-    const menu = document.getElementById(`${editorId}listMenu`);
-    menu.previousElementSibling.setAttribute('aria-expanded', false);
-    menu.previousElementSibling.lastElementChild.classList.add('fa-chevron-down');
-    menu.previousElementSibling.lastElementChild.classList.remove('fa-chevron-up');
-    menu.hidden = true;
-  };
-
-  const clickListener = (e) => {
-    const element = document.getElementById(`${editorId}listMenu`).parentElement;
-    if (!element.contains(e.target)) {
-      closeMenu();
-      document.removeEventListener('click', clickListener);
-    }
-  };
-
-  const openMenu = (e) => {
-    if (e.currentTarget.getAttribute('aria-expanded') === 'true') {
-      closeMenu();
-    } else {
-      e.currentTarget.setAttribute('aria-expanded', true);
-      e.currentTarget.lastElementChild.classList.remove('fa-chevron-down');
-      e.currentTarget.lastElementChild.classList.add('fa-chevron-up');
-      document.getElementById(`${editorId}listMenu`).removeAttribute('hidden');
-      document.addEventListener('click', clickListener);
-    }
-  };
-
-  const leaveMenu = (e) => {
-    if (e.currentTarget.contains(e.relatedTarget)) return;
-    closeMenu();
-  };
-
-  return (
-    <div className="listSelect" role="menuitem" onBlur={leaveMenu}>
-      <button
-        type="button"
-        className={active ? 'active' : undefined}
-        title="List menu"
-        aria-label="List menu"
-        aria-haspopup="true"
-        aria-expanded="false"
-        aria-controls={`${editorId}listMenu`}
-        onClick={openMenu}
-      >
-        <i className="fas fa-bars" aria-hidden="true" />
-        <i className="fas fa-chevron-down" aria-hidden="true" />
-      </button>
-      <div className="listMenu" role="menu" id={`${editorId}listMenu`} hidden>
-        {list_buttons.map((b) => (
-          <Button key={b} type={b} editorId={editorId} {...props} />
-        ))}
-      </div>
-    </div>
-  );
-}
 
 function Button({
   type, activeDOM, editorId, activeEditor, editor, mdEditor, headingLevel,
 }) {
   const [active, setActive] = useState(false);
   const [disabled, setDisabled] = useState(false);
+  const sharedProps = {
+    editorId, active, editor, mdEditor, activeEditor,
+  };
 
   useEffect(() => {
     if (activeDOM?.length) {
@@ -132,22 +34,19 @@ function Button({
   }, [activeDOM, activeEditor]);
 
   if (type === 'spacer') return <span className="spacer" role="separator" />;
+
   if (activeEditor === 'visual') {
     if (type === 'link') return <LinkMenu active={active} editor={editor} editorId={editorId} />;
     if (type === 'image') return <ImageMenu active={active} editor={editor} editorId={editorId} />;
     if (type.includes('_list')) return <List active={active} editor={editor} type={type} />;
-    if (['strong', 'emphasis', 'inlineCode', 'strike_through'].includes(type)) {
-      return <Toggle active={active} editor={editor} type={type} disabled={disabled} />;
-    }
   }
-  const sharedProps = {
-    editorId, active, editor, mdEditor, activeEditor,
-  };
+
   if (type === 'list_menu') return <ListMenu {...sharedProps} activeDOM={activeDOM} />;
   if (type === 'table') return <Table {...sharedProps} />;
   if (type === 'heading') return <Heading {...sharedProps} headingLevel={headingLevel} />;
 
-  const callEditorCommand = () => {
+  const callEditorCommand = (e) => {
+    if (e.target.hasAttribute('aria-disabled')) return;
     if (activeEditor === 'visual') {
       editor()?.action(callCommand(commands[type].key));
       const view = editor()?.ctx.get(editorViewCtx);
@@ -162,11 +61,12 @@ function Button({
     <button
       type="button"
       className={active ? 'active' : undefined}
-      disabled={disabled}
+      aria-pressed={active}
+      aria-disabled={disabled || null}
       title={labels[type]}
       aria-label={labels[type]}
-      role="menuitem"
       onClick={callEditorCommand}
+      tabIndex="-1"
     >{icons[type]}
     </button>
   );

--- a/app/javascript/react/components/MarkdownEditor/Buttons/Heading.jsx
+++ b/app/javascript/react/components/MarkdownEditor/Buttons/Heading.jsx
@@ -1,64 +1,148 @@
-import React, {useEffect} from 'react';
-import {useSelect} from 'downshift';
+import React, {useState, useEffect} from 'react';
 import {editorViewCtx} from '@milkdown/kit/core';
 import {callCommand} from '@milkdown/kit/utils';
 import {commands} from '../milkdownCommands';
 import {commands as mdCommands} from '../codeKeymap';
 import {labels} from './Details';
 
+/* eslint-disable jsx-a11y/no-noninteractive-element-to-interactive-role */
+
 export default function Heading({
-  active, editor, mdEditor, activeEditor, headingLevel,
+  active, editor, editorId, mdEditor, activeEditor, headingLevel,
 }) {
-  const [selectedItem, setSelectedItem] = React.useState(headingLevel);
+  const [selectedLevel, setSelectedLevel] = useState(headingLevel);
+  const [keyed, setKeyed] = useState(false);
+  const levels = [1, 2, 3, 4, 5, 6, 0];
+
+  const text = (level) => (level === 0 && 'Normal text') || (level === 1 && 'Title') || `Heading ${level}`;
+
+  const closeMenu = () => {
+    const menu = document.getElementById(`${editorId}headingMenu`);
+    menu.previousElementSibling.setAttribute('aria-expanded', false);
+    menu.previousElementSibling.lastElementChild.classList.add('fa-chevron-down');
+    menu.previousElementSibling.lastElementChild.classList.remove('fa-chevron-up');
+    menu.hidden = true;
+  };
+
+  const onChange = (newSelectedLevel) => {
+    setSelectedLevel(newSelectedLevel);
+    if (activeEditor === 'visual') {
+      editor()?.action(callCommand(commands.heading.key, newSelectedLevel));
+      const view = editor()?.ctx.get(editorViewCtx);
+      view.focus();
+    } else if (activeEditor === 'markdown') {
+      mdCommands[`heading${newSelectedLevel}`](mdEditor);
+      mdEditor.focus();
+    }
+    const button = document.getElementById(`${editorId}headingButton`);
+    if (newSelectedLevel > 0) {
+      button.setAttribute('aria-pressed', true);
+      button.classList.add('active');
+    } else {
+      button.setAttribute('aria-pressed', false);
+      button.classList.remove('active');
+    }
+    closeMenu();
+  };
+
+  const clickListener = (e) => {
+    const element = document.getElementById(`${editorId}headingMenu`).parentElement;
+    if (!element.contains(e.target)) {
+      closeMenu();
+      document.removeEventListener('click', clickListener);
+    }
+  };
+
+  const openMenu = (e) => {
+    if (e.currentTarget.getAttribute('aria-expanded') === 'true') {
+      closeMenu();
+    } else {
+      e.currentTarget.setAttribute('aria-expanded', true);
+      e.currentTarget.lastElementChild.classList.remove('fa-chevron-down');
+      e.currentTarget.lastElementChild.classList.add('fa-chevron-up');
+      document.getElementById(`${editorId}headingMenu`).removeAttribute('hidden');
+      document.addEventListener('click', clickListener);
+    }
+    if (keyed) {
+      document.getElementById(`${editorId}headingMenu`).querySelector('.selected').focus();
+    }
+  };
+
+  const menuHandler = (ev) => {
+    ev.stopPropagation();
+    const next = ev.target.nextElementSibling || ev.target.parentElement.firstElementChild;
+    const prev = ev.target.previousElementSibling || ev.target.parentElement.lastElementChild;
+    switch (ev.key) {
+    case 'Space': case 'Enter':
+      ev.preventDefault();
+      onChange(ev.target.dataset.level);
+      break;
+    case 'ArrowRight': case 'ArrowDown':
+      next.focus();
+      break;
+    case 'ArrowLeft': case 'ArrowUp':
+      prev.focus();
+      break;
+    case 'Home':
+      ev.target.parentElement.firstElementChild.focus();
+      break;
+    case 'End':
+      ev.target.parentElement.lastElementChild.focus();
+      break;
+    default:
+      break;
+    }
+  };
+
   useEffect(() => {
-    setSelectedItem(headingLevel);
-  }, [headingLevel]);
-  const items = [1, 2, 3, 4, 5, 6, 0];
-  const {
-    isOpen,
-    getToggleButtonProps,
-    getMenuProps,
-    getItemProps,
-    highlightedIndex,
-  } = useSelect({
-    items,
-    selectedItem,
-    onSelectedItemChange: ({selectedItem: newSelectedItem}) => {
-      setSelectedItem(newSelectedItem);
-      if (activeEditor === 'visual') {
-        editor()?.action(callCommand(commands.heading.key, newSelectedItem));
-        const view = editor()?.ctx.get(editorViewCtx);
-        view.focus();
-      } else if (activeEditor === 'markdown') {
-        mdCommands[`heading${newSelectedItem}`](mdEditor);
-        mdEditor.focus();
-      }
-    },
+    const menu = document.getElementById(`${editorId}headingMenu`);
+    if (menu) {
+      menu.querySelector('*[tabindex]').tabIndex = 0;
+      menu.addEventListener('keydown', menuHandler);
+    }
+    return () => {
+      if (menu) menu.removeEventListener('keydown', menuHandler);
+    };
   });
+
+  useEffect(() => {
+    setSelectedLevel(headingLevel);
+  }, [headingLevel]);
+
   return (
     <div className="headingSelect">
-      <div
+      <button
+        type="button"
         className={`headingButton${active ? ' active' : ''}`}
-        role="button"
+        id={`${editorId}headingButton`}
+        aria-pressed={active}
         aria-label={labels.heading}
         title={labels.heading}
-        {...getToggleButtonProps({'aria-labelledby': null})}
+        aria-haspopup="true"
+        aria-expanded="false"
+        aria-controls={`${editorId}headingMenu`}
         tabIndex="-1"
+        onClick={openMenu}
+        onKeyDown={(e) => { if (['Space', 'Enter'].includes(e.key)) setKeyed(true); }}
       >
-        <span>{selectedItem ? ((selectedItem === 1 && 'Title') || `Heading ${selectedItem}`) : 'Heading'}</span>
-        <i className={`fas ${isOpen ? 'fa-chevron-up' : 'fa-chevron-down'}`} />
-      </div>
-      <ul hidden={!isOpen} {...getMenuProps({'aria-labelledby': null, 'aria-label': 'Heading levels'})} className="headingMenu">
-        {isOpen
-          && items.map((item, index) => (
-            <li
-              className={`h${item} ${highlightedIndex === index ? 'highlighted ' : ''}${selectedItem === item ? 'selected' : ''}`}
-              key={`heading${item}`}
-              {...getItemProps({item, index})}
-            >
-              {(item === 0 && 'Normal text') || (item === 1 && 'Title') || `Heading ${item}`}
-            </li>
-          ))}
+        <span>{text(selectedLevel)}</span>
+        <i className="fas fa-chevron-down" aria-hidden="true" />
+      </button>
+      <ul hidden role="menu" id={`${editorId}headingMenu`} aria-label="Heading levels" className="headingMenu">
+        {levels.map((level) => (
+          <li
+            role="menuitemradio"
+            tabIndex="-1"
+            className={`h${level} ${Number(selectedLevel) === level ? 'selected' : ''}`}
+            aria-checked={Number(selectedLevel) === level}
+            key={`heading${level}`}
+            onClick={() => onChange(level)}
+            onKeyDown={() => true}
+            data-level={level}
+          >
+            {text(level)}
+          </li>
+        ))}
       </ul>
     </div>
   );

--- a/app/javascript/react/components/MarkdownEditor/Buttons/Heading.jsx
+++ b/app/javascript/react/components/MarkdownEditor/Buttons/Heading.jsx
@@ -36,19 +36,19 @@ export default function Heading({
     },
   });
   return (
-    <div className="headingSelect" role="menuitem">
+    <div className="headingSelect">
       <div
         className={`headingButton${active ? ' active' : ''}`}
         role="button"
         aria-label={labels.heading}
         title={labels.heading}
         {...getToggleButtonProps({'aria-labelledby': null})}
-        tabIndex="0"
+        tabIndex="-1"
       >
         <span>{selectedItem ? ((selectedItem === 1 && 'Title') || `Heading ${selectedItem}`) : 'Heading'}</span>
         <i className={`fas ${isOpen ? 'fa-chevron-up' : 'fa-chevron-down'}`} />
       </div>
-      <ul hidden={!isOpen} {...getMenuProps()} className="headingMenu">
+      <ul hidden={!isOpen} {...getMenuProps({'aria-labelledby': null, 'aria-label': 'Heading levels'})} className="headingMenu">
         {isOpen
           && items.map((item, index) => (
             <li

--- a/app/javascript/react/components/MarkdownEditor/Buttons/ImageMenu.jsx
+++ b/app/javascript/react/components/MarkdownEditor/Buttons/ImageMenu.jsx
@@ -126,7 +126,7 @@ export default function ImageMenu({editor, editorId, active}) {
   };
 
   return (
-    <div className="imageSelect" role="menuitem">
+    <div className="imageSelect">
       <button
         type="button"
         className={active ? 'active' : undefined}
@@ -135,6 +135,7 @@ export default function ImageMenu({editor, editorId, active}) {
         aria-expanded="false"
         aria-controls={`${editorId}imageMenu`}
         onClick={openMenu}
+        tabIndex="-1"
       >{icons.image}
       </button>
       <div className="imageMenu" id={`${editorId}imageMenu`} hidden>

--- a/app/javascript/react/components/MarkdownEditor/Buttons/LinkMenu.jsx
+++ b/app/javascript/react/components/MarkdownEditor/Buttons/LinkMenu.jsx
@@ -128,7 +128,7 @@ export default function LinkMenu({editor, editorId, active}) {
   };
 
   return (
-    <div className="linkSelect" role="menuitem" onBlur={leaveMenu}>
+    <div className="linkSelect" onBlur={leaveMenu}>
       <button
         type="button"
         className={active ? 'active' : undefined}
@@ -137,6 +137,7 @@ export default function LinkMenu({editor, editorId, active}) {
         aria-expanded="false"
         aria-controls={`${editorId}linkMenu`}
         onClick={openMenu}
+        tabIndex="-1"
       >{icons.link}
       </button>
       <div className="linkMenu" id={`${editorId}linkMenu`} hidden>

--- a/app/javascript/react/components/MarkdownEditor/Buttons/List.jsx
+++ b/app/javascript/react/components/MarkdownEditor/Buttons/List.jsx
@@ -59,10 +59,11 @@ export default function List({type, editor, active}) {
     <button
       type="button"
       className={active ? 'active' : undefined}
+      aria-pressed={active}
       title={labels[type]}
       aria-label={labels[type]}
-      role="menuitem"
       onClick={listWizard}
+      tabIndex="-1"
     >{icons[type]}
     </button>
   );

--- a/app/javascript/react/components/MarkdownEditor/Buttons/ListMenu.jsx
+++ b/app/javascript/react/components/MarkdownEditor/Buttons/ListMenu.jsx
@@ -1,0 +1,112 @@
+import React, {useState, useEffect} from 'react';
+/* eslint-disable-next-line import/no-cycle */
+import Button from '../Button';
+
+export default function ListMenu({active, editorId, ...props}) {
+  const [keyed, setKeyed] = useState(false);
+
+  const list_buttons = ['bullet_list', 'ordered_list', 'indent', 'outdent'];
+
+  const closeMenu = () => {
+    const menu = document.getElementById(`${editorId}listMenu`);
+    menu.previousElementSibling.setAttribute('aria-expanded', false);
+    menu.previousElementSibling.lastElementChild.classList.add('fa-chevron-down');
+    menu.previousElementSibling.lastElementChild.classList.remove('fa-chevron-up');
+    menu.hidden = true;
+  };
+
+  const clickListener = (e) => {
+    const element = document.getElementById(`${editorId}listMenu`).parentElement;
+    if (!element.contains(e.target)) {
+      closeMenu();
+      document.removeEventListener('click', clickListener);
+    }
+  };
+
+  const openMenu = (e) => {
+    if (e.currentTarget.getAttribute('aria-expanded') === 'true') {
+      closeMenu();
+    } else {
+      e.currentTarget.setAttribute('aria-expanded', true);
+      e.currentTarget.lastElementChild.classList.remove('fa-chevron-down');
+      e.currentTarget.lastElementChild.classList.add('fa-chevron-up');
+      document.getElementById(`${editorId}listMenu`).removeAttribute('hidden');
+      document.addEventListener('click', clickListener);
+    }
+    if (keyed) {
+      document.getElementById(`${editorId}listMenu`).firstElementChild.tabIndex = 0;
+      document.getElementById(`${editorId}listMenu`).firstElementChild.focus();
+    }
+  };
+
+  const leaveMenu = (e) => {
+    if (e.currentTarget.contains(e.relatedTarget)) return;
+    closeMenu();
+  };
+
+  const menuHandler = (ev) => {
+    ev.stopPropagation();
+    const next = ev.target.nextElementSibling || ev.target.parentElement.firstElementChild;
+    const prev = ev.target.previousElementSibling || ev.target.parentElement.lastElementChild;
+    switch (ev.key) {
+    case 'ArrowRight': case 'ArrowDown':
+      ev.target.tabIndex = -1;
+      next.tabIndex = 0;
+      next.focus();
+      break;
+    case 'ArrowLeft': case 'ArrowUp':
+      ev.target.tabIndex = -1;
+      prev.tabIndex = 0;
+      prev.focus();
+      break;
+    case 'Home':
+      ev.target.tabIndex = -1;
+      ev.target.parentElement.firstElementChild.tabIndex = 0;
+      ev.target.parentElement.firstElementChild.focus();
+      break;
+    case 'End':
+      ev.target.tabIndex = -1;
+      ev.target.parentElement.lastElementChild.tabIndex = 0;
+      ev.target.parentElement.lastElementChild.focus();
+      break;
+    default:
+      break;
+    }
+  };
+
+  useEffect(() => {
+    const menu = document.getElementById(`${editorId}listMenu`);
+    if (menu) {
+      menu.querySelector('*[tabindex]').tabIndex = 0;
+      menu.addEventListener('keydown', menuHandler);
+    }
+    return () => {
+      if (menu) menu.removeEventListener('keydown', menuHandler);
+    };
+  });
+
+  return (
+    <div className="listSelect" onBlur={leaveMenu}>
+      <button
+        type="button"
+        className={active ? 'active' : undefined}
+        title="List menu"
+        aria-label="List menu"
+        aria-haspopup="true"
+        aria-expanded="false"
+        aria-controls={`${editorId}listMenu`}
+        tabIndex="-1"
+        onClick={openMenu}
+        onKeyDown={(e) => { if (['Space', 'Enter'].includes(e.key)) setKeyed(true); }}
+      >
+        <i className="fas fa-bars" aria-hidden="true" />
+        <i className="fas fa-chevron-down" aria-hidden="true" />
+      </button>
+      <div className="listMenu" role="menu" id={`${editorId}listMenu`} hidden>
+        {list_buttons.map((b) => (
+          <Button key={b} type={b} editorId={editorId} {...props} />
+        ))}
+      </div>
+    </div>
+  );
+}

--- a/app/javascript/react/components/MarkdownEditor/Buttons/Table.jsx
+++ b/app/javascript/react/components/MarkdownEditor/Buttons/Table.jsx
@@ -88,7 +88,7 @@ export default function Table({
 
   return (
     <>
-      <div role="menuitem" onBlur={leaveMenu}>
+      <div onBlur={leaveMenu}>
         <button
           type="button"
           className={active ? 'active' : undefined}
@@ -97,6 +97,7 @@ export default function Table({
           aria-expanded="false"
           aria-controls={`${editorId}tableMenu`}
           onClick={openMenu}
+          tabIndex="-1"
         >{icons.table}
         </button>
         <div className="tableMenu" id={`${editorId}tableMenu`} hidden>

--- a/app/javascript/react/components/MarkdownEditor/Buttons/TableMenu.jsx
+++ b/app/javascript/react/components/MarkdownEditor/Buttons/TableMenu.jsx
@@ -1,4 +1,4 @@
-import React, {useState} from 'react';
+import React, {useState, useEffect} from 'react';
 import {editorViewCtx} from '@milkdown/kit/core';
 import {callCommand} from '@milkdown/kit/utils';
 import {
@@ -25,6 +25,7 @@ const rowIcon = <i className="fas fa-table-cells-large fa-rotate-270 one" />;
 const colIcon = <i className="fas fa-table-cells-large one" />;
 
 export default function TableMenu({active, editor, editorId}) {
+  const [keyed, setKeyed] = useState(false);
   const [col, setCol] = useState(null);
   const [row, setRow] = useState(null);
   const [rowCount, setRowCount] = useState(null);
@@ -52,6 +53,7 @@ export default function TableMenu({active, editor, editorId}) {
     menu.previousElementSibling.lastElementChild.classList.add('fa-chevron-down');
     menu.previousElementSibling.lastElementChild.classList.remove('fa-chevron-up');
     menu.hidden = true;
+    setKeyed(false);
   };
 
   const clickListener = (e) => {
@@ -63,6 +65,7 @@ export default function TableMenu({active, editor, editorId}) {
   };
 
   const openMenu = (e) => {
+    if (e.currentTarget.hasAttribute('aria-disabled')) return;
     if (e.currentTarget.getAttribute('aria-expanded') === 'true') {
       closeMenu();
     } else {
@@ -73,18 +76,23 @@ export default function TableMenu({active, editor, editorId}) {
       document.getElementById(`${editorId}tableOptMenu`).removeAttribute('hidden');
       document.addEventListener('click', clickListener);
     }
+    if (keyed) {
+      document.getElementById(`${editorId}tableOptMenu`).firstElementChild.firstElementChild.tabIndex = 0;
+      document.getElementById(`${editorId}tableOptMenu`).firstElementChild.firstElementChild.focus();
+    }
   };
 
   const subMenuExit = (button) => {
     const menu = document.getElementById(button.getAttribute('aria-controls'));
     button.setAttribute('aria-expanded', false);
+    [...menu.children].forEach((li) => { li.firstElementChild.tabIndex = -1; });
     menu.hidden = true;
   };
 
   const subMenuOpen = (e) => {
     document.querySelectorAll('.tableSubMenu').forEach((b) => subMenuExit(b));
-    const menu = document.getElementById(e.currentTarget.getAttribute('aria-controls'));
-    e.currentTarget.setAttribute('aria-expanded', true);
+    const menu = document.getElementById(e.target.getAttribute('aria-controls'));
+    e.target.setAttribute('aria-expanded', true);
     menu.removeAttribute('hidden');
   };
 
@@ -94,14 +102,73 @@ export default function TableMenu({active, editor, editorId}) {
     closeMenu();
   };
 
-  const callEditorCommand = (command, variables) => {
+  const callEditorCommand = (e, command, variables) => {
+    if (e.currentTarget.hasAttribute('aria-disabled')) return;
     editor()?.action(callCommand(command.key, variables));
     const view = editor()?.ctx.get(editorViewCtx);
     view.focus();
   };
 
+  const menuHandler = (ev) => {
+    ev.stopPropagation();
+    const item = ev.target.parentElement;
+    const next = item.nextElementSibling?.firstElementChild || item.parentElement.firstElementChild.firstElementChild;
+    const prev = item.previousElementSibling?.firstElementChild || item.parentElement.lastElementChild.firstElementChild;
+    switch (ev.key) {
+    case 'ArrowRight':
+      if (ev.target.classList.contains('tableSubMenu')) {
+        const menu = document.getElementById(ev.target.getAttribute('aria-controls'));
+        subMenuOpen(ev);
+        menu.firstElementChild.firstElementChild.tabIndex = 0;
+        menu.firstElementChild.firstElementChild.focus();
+      }
+      break;
+    case 'ArrowLeft':
+      if (ev.target.classList.contains('tableSubMenu')) subMenuExit(ev.target);
+      else if (item.parentElement.getAttribute('role') === 'menu') {
+        subMenuExit(document.getElementById(`${item.parentElement.id}B`));
+        document.getElementById(`${item.parentElement.id}B`).tabIndex = 0;
+        document.getElementById(`${item.parentElement.id}B`).focus();
+      }
+      break;
+    case 'ArrowDown':
+      ev.target.tabIndex = -1;
+      next.tabIndex = 0;
+      next.focus();
+      break;
+    case 'ArrowUp':
+      ev.target.tabIndex = -1;
+      prev.tabIndex = 0;
+      prev.focus();
+      break;
+    case 'Home':
+      ev.target.tabIndex = -1;
+      item.parentElement.firstElementChild.firstElementChild.tabIndex = 0;
+      item.parentElement.firstElementChild.firstElementChild.focus();
+      break;
+    case 'End':
+      ev.target.tabIndex = -1;
+      item.parentElement.lastElementChild.firstElementChild.tabIndex = 0;
+      item.parentElement.lastElementChild.firstElementChild.focus();
+      break;
+    default:
+      break;
+    }
+  };
+
+  useEffect(() => {
+    const menu = document.getElementById(`${editorId}tableOptMenu`);
+    if (menu) {
+      menu.querySelector('*[tabindex]').tabIndex = 0;
+      menu.addEventListener('keydown', menuHandler);
+    }
+    return () => {
+      if (menu) menu.removeEventListener('keydown', menuHandler);
+    };
+  });
+
   return (
-    <div className="tableSelect" role="menuitem" onBlur={leaveMenu}>
+    <div className="tableSelect" onBlur={leaveMenu}>
       <button
         type="button"
         className="tableOptButton"
@@ -111,15 +178,19 @@ export default function TableMenu({active, editor, editorId}) {
         aria-controls={`${editorId}tableOptMenu`}
         aria-haspopup="true"
         onClick={openMenu}
-        disabled={!active}
+        onKeyDown={(e) => { if (['Space', 'Enter'].includes(e.key)) setKeyed(true); }}
+        aria-disabled={!active || null}
+        tabIndex="-1"
       >
         <i className="fas fa-table-cells-large" aria-hidden="true" />
         <i className="fas fa-chevron-down" aria-hidden="true" />
       </button>
       <ul className="tableOptMenu" id={`${editorId}tableOptMenu`} hidden role="menu">
-        <li onMouseLeave={() => subMenuExit(document.getElementById(`${editorId}rowMenuB`))} role="menuitem">
+        <li onMouseLeave={() => subMenuExit(document.getElementById(`${editorId}rowMenuB`))} role="presentation">
           <button
             type="button"
+            role="menuitem"
+            tabIndex="-1"
             className="tableSubMenu"
             id={`${editorId}rowMenuB`}
             aria-controls={`${editorId}rowMenu`}
@@ -129,35 +200,43 @@ export default function TableMenu({active, editor, editorId}) {
           ><i className="fas fa-table-columns fa-rotate-270" aria-hidden="true" />Rows<i className="fas fa-chevron-right" aria-hidden="true" />
           </button>
           <ul hidden id={`${editorId}rowMenu`} role="menu">
-            <li role="menuitem">
-              <button type="button" onClick={() => callEditorCommand(addRowBeforeCommand)}>
+            <li role="presentation">
+              <button type="button" role="menuitem" tabIndex="-1" onClick={(e) => callEditorCommand(e, addRowBeforeCommand)}>
                 <span className="icon-stack">
                   <i className="fas fa-plus" aria-hidden="true" />
                   {rowIcon}
                 </span>Insert row above
               </button>
             </li>
-            <li role="menuitem">
-              <button type="button" onClick={() => callEditorCommand(addRowAfterCommand)}>
+            <li role="presentation">
+              <button type="button" role="menuitem" tabIndex="-1" onClick={(e) => callEditorCommand(e, addRowAfterCommand)}>
                 <span className="icon-stack">
                   {rowIcon}
                   <i className="fas fa-plus" aria-hidden="true" />
                 </span>Insert row below
               </button>
             </li>
-            <li role="menuitem">
-              <button type="button" onClick={() => callEditorCommand(moveRowCommand, {from: row, to: row - 1})} disabled={row === 0 || null}>
+            <li role="presentation">
+              <button
+                type="button"
+                role="menuitem"
+                tabIndex="-1"
+                onClick={(e) => callEditorCommand(e, moveRowCommand, {from: row, to: row - 1})}
+                aria-disabled={row === 0 || null}
+              >
                 <span className="icon-stack">
                   <i className="fas fa-turn-down fa-rotate-270" aria-hidden="true" />
                   {rowIcon}
                 </span>Move row up
               </button>
             </li>
-            <li role="menuitem">
+            <li role="presentation">
               <button
                 type="button"
-                onClick={() => callEditorCommand(moveRowCommand, {from: row, to: row + 1})}
-                disabled={row === rowCount - 1 || null}
+                role="menuitem"
+                tabIndex="-1"
+                onClick={(e) => callEditorCommand(e, moveRowCommand, {from: row, to: row + 1})}
+                aria-disabled={row === rowCount - 1 || null}
               >
                 <span className="icon-stack">
                   {rowIcon}
@@ -165,8 +244,8 @@ export default function TableMenu({active, editor, editorId}) {
                 </span>Move row down
               </button>
             </li>
-            <li role="menuitem">
-              <button type="button" onClick={() => callEditorCommand(selectRowCommand, {index: row})}>
+            <li role="presentation">
+              <button type="button" role="menuitem" tabIndex="-1" onClick={(e) => callEditorCommand(e, selectRowCommand, {index: row})}>
                 <span className="icon-stack">
                   <i className="fas fa-table-columns fa-rotate-270 one" aria-hidden="true" />
                 </span>Select row cells
@@ -174,9 +253,11 @@ export default function TableMenu({active, editor, editorId}) {
             </li>
           </ul>
         </li>
-        <li onMouseLeave={() => subMenuExit(document.getElementById(`${editorId}colMenuB`))} role="menuitem">
+        <li onMouseLeave={() => subMenuExit(document.getElementById(`${editorId}colMenuB`))} role="presentation">
           <button
             type="button"
+            role="menuitem"
+            tabIndex="-1"
             className="tableSubMenu"
             id={`${editorId}colMenuB`}
             aria-controls={`${editorId}colMenu`}
@@ -186,41 +267,51 @@ export default function TableMenu({active, editor, editorId}) {
           ><i className="fas fa-table-columns" aria-hidden="true" />Columns<i className="fas fa-chevron-right" aria-hidden="true" />
           </button>
           <ul hidden id={`${editorId}colMenu`} role="menu">
-            <li role="menuitem">
-              <button type="button" onClick={() => callEditorCommand(addColBeforeCommand)}>
+            <li role="presentation">
+              <button type="button" role="menuitem" tabIndex="-1" onClick={(e) => callEditorCommand(e, addColBeforeCommand)}>
                 <span className="icon-line"><i className="fas fa-plus" aria-hidden="true" />{colIcon}</span>Insert column left
               </button>
             </li>
-            <li role="menuitem">
-              <button type="button" onClick={() => callEditorCommand(addColAfterCommand)}>
+            <li role="presentation">
+              <button type="button" role="menuitem" tabIndex="-1" onClick={(e) => callEditorCommand(e, addColAfterCommand)}>
                 <span className="icon-line">{colIcon}<i className="fas fa-plus" aria-hidden="true" /></span>Insert column right
               </button>
             </li>
-            <li role="menuitem">
-              <button type="button" onClick={() => callEditorCommand(moveColCommand, {from: col, to: col - 1})} disabled={col === 0 || null}>
+            <li role="presentation">
+              <button
+                type="button"
+                role="menuitem"
+                tabIndex="-1"
+                onClick={(e) => callEditorCommand(e, moveColCommand, {from: col, to: col - 1})}
+                aria-disabled={col === 0 || null}
+              >
                 <span className="icon-line"><i className="fas fa-turn-down fa-flip-horizontal" aria-hidden="true" />{colIcon}</span>Move column left
               </button>
             </li>
-            <li role="menuitem">
+            <li role="presentation">
               <button
                 type="button"
-                onClick={() => callEditorCommand(moveColCommand, {from: col, to: col + 1})}
-                disabled={col === colCount - 1 || null}
+                role="menuitem"
+                tabIndex="-1"
+                onClick={(e) => callEditorCommand(e, moveColCommand, {from: col, to: col + 1})}
+                aria-disabled={col === colCount - 1 || null}
               >
                 <span className="icon-line">{colIcon}<i className="fas fa-turn-down" aria-hidden="true" /></span>Move column right
               </button>
             </li>
-            <li role="menuitem">
+            <li role="presentation">
               <button
                 type="button"
-                onClick={() => callEditorCommand(selectColCommand, {index: col})}
+                role="menuitem"
+                tabIndex="-1"
+                onClick={(e) => callEditorCommand(e, selectColCommand, {index: col})}
               ><i className="fas fa-table-columns one" aria-hidden="true" />Select column cells
               </button>
             </li>
           </ul>
         </li>
-        <li role="menuitem">
-          <button type="button" onClick={() => callEditorCommand(deleteSelectedCellsCommand)}>
+        <li role="presentation">
+          <button type="button" role="menuitem" tabIndex="-1" onClick={(e) => callEditorCommand(e, deleteSelectedCellsCommand)}>
             <i className="fas fa-delete-left" aria-hidden="true" />Delete cells
           </button>
         </li>

--- a/app/javascript/react/components/MarkdownEditor/Buttons/TableMenu.jsx
+++ b/app/javascript/react/components/MarkdownEditor/Buttons/TableMenu.jsx
@@ -93,7 +93,7 @@ export default function TableMenu({active, editor, editorId}) {
     document.querySelectorAll('.tableSubMenu').forEach((b) => subMenuExit(b));
     const menu = document.getElementById(e.target.getAttribute('aria-controls'));
     e.target.setAttribute('aria-expanded', true);
-    menu.removeAttribute('hidden');
+    if (menu) menu.removeAttribute('hidden');
   };
 
   const leaveMenu = (e) => {

--- a/app/javascript/react/components/MarkdownEditor/Buttons/index.js
+++ b/app/javascript/react/components/MarkdownEditor/Buttons/index.js
@@ -2,5 +2,7 @@ export {icons, labels} from './Details';
 export {default as Table} from './Table';
 export {default as Heading} from './Heading';
 export {default as LinkMenu} from './LinkMenu';
+/* eslint-disable-next-line import/no-cycle */
+export {default as ListMenu} from './ListMenu';
 export {default as List} from './List';
 export {default as ImageMenu} from './ImageMenu';

--- a/app/javascript/react/components/MarkdownEditor/MarkdownEditor.jsx
+++ b/app/javascript/react/components/MarkdownEditor/MarkdownEditor.jsx
@@ -9,7 +9,7 @@ import {history} from '@milkdown/kit/plugin/history';
 import {listener as listen, listenerCtx} from '@milkdown/kit/plugin/listener';
 import {trailing} from '@milkdown/kit/plugin/trailing';
 import {commonmark} from '@milkdown/kit/preset/commonmark';
-import {gfm} from '@milkdown/kit/preset/gfm';
+import {gfm, tableKeymap} from '@milkdown/kit/preset/gfm';
 import {replaceAll} from '@milkdown/kit/utils';
 import {ParserState} from '@milkdown/kit/transformer';
 import CodeEditor from './CodeEditor';
@@ -83,6 +83,15 @@ function MilkdownCore({
       listener.markdownUpdated((_ctx, markdown, prevMarkdown) => {
         if (markdown !== prevMarkdown) onChange(markdown);
       });
+      listener.focus((ctxx) => {
+        ctxx.get(editorViewCtx).dom.removeAttribute('aria-invalid');
+      });
+      listener.blur((ctxx) => {
+        const el = ctxx.get(editorViewCtx).dom;
+        if (el && document.getElementById(el.getAttribute('aria-errormessage'))) {
+          el.setAttribute('aria-invalid', true);
+        }
+      });
       const slistener = ctx.get(selectionCtx);
       slistener.selection((ctxx, selection, doc) => {
         try {
@@ -100,6 +109,11 @@ function MilkdownCore({
         } catch (e) {
           // no schema for jest tests
         }
+      });
+      ctx.set(tableKeymap.key, {
+        NextCell: 'Mod-]',
+        PrevCell: 'Mod-[',
+        ExitTable: ['Mod-Enter', 'Enter'],
       });
     })
     .use(micro ? [noNewLines, exitKeymap] : [bulletWrapCommand, bulletWrapKeymap, orderWrapCommand, orderWrapKeymap])
@@ -162,6 +176,39 @@ function MilkdownEditor({
     }
   });
 
+  const toolBarHandler = (ev) => {
+    const toolbar = [...document.querySelectorAll(
+      `#${id}_menu > *[tabindex], #${id}_menu > div:not([role="group"]) > *[tabindex]:first-child, #${id}_menu > div[role="group"] > button`,
+    )];
+    const index = toolbar.findIndex((el) => el.title === ev.target.title);
+    const next = toolbar[index + 1] || toolbar[0];
+    const prev = toolbar[index - 1] || toolbar[toolbar.length - 1];
+    switch (ev.key) {
+    case 'ArrowRight':
+      ev.target.tabIndex = -1;
+      next.tabIndex = 0;
+      next.focus();
+      break;
+    case 'ArrowLeft':
+      ev.target.tabIndex = -1;
+      prev.tabIndex = 0;
+      prev.focus();
+      break;
+    case 'Home':
+      ev.target.tabIndex = -1;
+      toolbar[0].tabIndex = 0;
+      toolbar[0].focus();
+      break;
+    case 'End':
+      ev.target.tabIndex = -1;
+      toolbar[toolbar.length - 1].tabIndex = 0;
+      toolbar[toolbar.length - 1].focus();
+      break;
+    default:
+      break;
+    }
+  };
+
   useEffect(() => {
     setEditorVal(initialCode);
   }, [initialCode]);
@@ -189,6 +236,20 @@ function MilkdownEditor({
   }, [editType]);
 
   useEffect(() => {
+    if (!loading) {
+      const menu = document.getElementById(`${id}_menu`);
+      menu.querySelector('*[tabindex]').tabIndex = 0;
+      menu.addEventListener('keydown', toolBarHandler);
+    }
+    return () => {
+      const menu = document.getElementById(`${id}_menu`);
+      if (!loading && menu) {
+        menu.removeEventListener('keydown', toolBarHandler);
+      }
+    };
+  }, [loading]);
+
+  useEffect(() => {
     if (!loading && replaceValue) testMarkdown(replaceValue);
   }, [loading, replaceValue]);
 
@@ -199,7 +260,7 @@ function MilkdownEditor({
   return (
     <>
       {!loading && (
-        <div className="md_editor-buttons" role="menubar">
+        <div className="md_editor-buttons" id={`${id}_menu`} role="toolbar">
           {buttons.map((button, i) => (
             <Button
               activeDOM={active?.length ? active : []}
@@ -210,28 +271,33 @@ function MilkdownEditor({
               editor={editor}
               mdEditor={mdEditor}
               activeEditor={editType}
+              micro={micro}
             />
           ))}
-          <div className="md_editor-toggle" role="group" aria-label="Editor type">
-            <button
-              role="menuitem"
-              type="button"
-              onClick={() => setEditType('markdown')}
-              aria-current={editType === 'markdown'}
-              aria-disabled={editType === 'markdown' || null}
-            >
-              Markdown
-            </button>
-            <button
-              role="menuitem"
-              type="button"
-              onClick={() => setEditType('visual')}
-              aria-current={editType === 'visual'}
-              aria-disabled={editType === 'visual' || null}
-            >
-              Rich text
-            </button>
-          </div>
+          {!micro && (
+            <div className="md_editor-toggle" role="group" aria-label="Editor type">
+              <button
+                type="button"
+                onClick={() => setEditType('markdown')}
+                aria-current={editType === 'markdown'}
+                aria-disabled={editType === 'markdown' || null}
+                title="Toggle markdown"
+                tabIndex="-1"
+              >
+                Markdown
+              </button>
+              <button
+                type="button"
+                onClick={() => setEditType('visual')}
+                aria-current={editType === 'visual'}
+                aria-disabled={editType === 'visual' || null}
+                title="Toggle rich text"
+                tabIndex="-1"
+              >
+                Rich text
+              </button>
+            </div>
+          )}
         </div>
       )}
       <div className="md_editor_textarea">

--- a/app/javascript/react/components/MetadataEntry/Description/Description.jsx
+++ b/app/javascript/react/components/MetadataEntry/Description/Description.jsx
@@ -61,6 +61,7 @@ export default function Description({setResource, dcsDescription, mceLabel}) {
             'aria-errormessage': `${dcsDescription?.description_type}_error`,
             'aria-labelledby': `${dcsDescription?.description_type}_label`,
             'aria-describedby': `${dcsDescription?.description_type}-ex`,
+            'aria-multiline': 'true',
             name: dcsDescription?.description_type,
           }}
           htmlInput={desc}

--- a/app/javascript/react/components/ReadMeWizard/ReadMeSteps.jsx
+++ b/app/javascript/react/components/ReadMeWizard/ReadMeSteps.jsx
@@ -28,6 +28,7 @@ function StepEditor({
         'aria-errormessage': 'readme_error',
         'aria-labelledby': 'md_editor_label',
         'aria-describedby': 'md_editor_desc',
+        'aria-multiline': 'true',
         name: secTitles[step - 1].toLowerCase().replace(/[^\w]/g, '_'),
       }}
       hidden={hidden}

--- a/app/javascript/react/components/ReadMeWizard/ReadMeWizard.jsx
+++ b/app/javascript/react/components/ReadMeWizard/ReadMeWizard.jsx
@@ -180,6 +180,7 @@ function ReadMe({
             'aria-errormessage': 'readme_error',
             'aria-labelledby': 'md_editor_label',
             'aria-describedby': 'md_editor_desc',
+            'aria-multiline': 'true',
             name: 'readme_editor',
           }}
           initialValue={initialValue}


### PR DESCRIPTION
https://github.com/datadryad/dryad-product-roadmap/issues/4477 (Part 1)

This improves the markdown editor menu keyboard accessibility (with less tabs, more arrow keys), uses the aria roles recommended by our accessibility consultants, and no longer prevents screen reader access when there is an error message. Also fixes the overzealousness of screenreading in the text style menu, and includes style changes for very small screens or very high zoom levels.