### PR TITLE
Change auth failures location

### DIFF
--- a/app/controllers/stash_engine/admin_dashboard_controller.rb
+++ b/app/controllers/stash_engine/admin_dashboard_controller.rb
@@ -77,18 +77,6 @@ module StashEngine
       @datasets = @datasets.page(@page).per(@page_size)
     end
 
-    def auth_failures
-      authorize %i[stash_engine admin_datasets]
-      @records = AuthFailure.left_joins(:user)
-      if params[:q]
-        @records = @records.where(
-          'error_type like ? OR url like ? OR ip like ? OR params like ? OR CONCAT(first_name, " ", last_name) LIKE ?',
-          "%#{params[:q]}%", "%#{params[:q]}%", "%#{params[:q]}%", "%#{params[:q]}%", "%#{params[:q]}%"
-        )
-      end
-      @records = @records.includes(:user).order(created_at: :desc).page(@page).per(@page_size)
-    end
-
     def new_search
       @properties = params[:properties]
       respond_to(&:js)

--- a/app/controllers/stash_engine/status_dashboard_controller.rb
+++ b/app/controllers/stash_engine/status_dashboard_controller.rb
@@ -22,5 +22,17 @@ module StashEngine
         .updated_at.localtime
     end
 
+    def auth_failures
+      authorize StashEngine::ExternalDependency.all
+      @records = AuthFailure.left_joins(:user)
+      if params[:q]
+        @records = @records.where(
+          'error_type like ? OR url like ? OR ip like ? OR params like ? OR CONCAT(first_name, " ", last_name) LIKE ?',
+          "%#{params[:q]}%", "%#{params[:q]}%", "%#{params[:q]}%", "%#{params[:q]}%", "%#{params[:q]}%"
+        )
+      end
+      @records = @records.includes(:user).order(created_at: :desc).page(@page).per(@page_size)
+    end
+
   end
 end

--- a/app/policies/stash_engine/admin_datasets_policy.rb
+++ b/app/policies/stash_engine/admin_datasets_policy.rb
@@ -44,9 +44,5 @@ module StashEngine
     def deleted?
       @user.system_user? && @user.min_curator?
     end
-
-    def auth_failures?
-      @user.superuser?
-    end
   end
 end

--- a/app/policies/stash_engine/external_dependency_policy.rb
+++ b/app/policies/stash_engine/external_dependency_policy.rb
@@ -5,5 +5,9 @@ module StashEngine
       @user.superuser?
     end
 
+    def auth_failures?
+      @user.superuser?
+    end
+
   end
 end

--- a/app/views/shared/_log_in_out.html.erb
+++ b/app/views/shared/_log_in_out.html.erb
@@ -6,9 +6,6 @@
     <% if current_user.system_user? %>
       <li><%= link_to 'Manage accounts', user_admin_path %></li>
     <% end %>
-    <% if current_user.superuser? %>
-      <li><%= link_to 'Auth failures', auth_failures_path %></li>
-    <% end %>
     <li><%= link_to 'Logout', sessions_destroy_path, id: 'log-in-out', class: 'js-nav-out', method: :post %></li>
   </ul>
 <% else %>

--- a/app/views/shared/_nav.html.erb
+++ b/app/views/shared/_nav.html.erb
@@ -67,7 +67,7 @@
               <% end %>
             <% end %>
             <% if current_user.superuser? %>
-              <li><%= link_to 'Status dashboard', status_dashboard_path %>
+              <li><%= link_to 'Logs & statuses', status_dashboard_path %>
             <% end %>
           </ul>
         <% else %>

--- a/app/views/stash_engine/shared/_logs_header.html.erb
+++ b/app/views/stash_engine/shared/_logs_header.html.erb
@@ -1,0 +1,7 @@
+<nav aria-label="Logs navigation" class="section-nav">
+  <h1 style="margin-bottom: 0;">Logs</h1>
+  <ul class="c-header__nav-group">
+    <li class="c-second__nav-item"><a<% if current == 'dependencies' %> aria-current="page"<%end%> href="<%= status_dashboard_path %>">External dependencies</a>
+    <li class="c-second__nav-item"><a<% if current == 'auth' %> aria-current="page"<%end%> href="<%= auth_failures_path %>">Authentication failures</a>
+  </ul>
+</nav>

--- a/app/views/stash_engine/status_dashboard/auth_failures.html.erb
+++ b/app/views/stash_engine/status_dashboard/auth_failures.html.erb
@@ -1,9 +1,10 @@
-<h1>Authentication failures</h1>
+<%= render partial: 'stash_engine/shared/logs_header', locals: {current: 'auth'} %>
+<h2>Authentication failures</h2>
 
 <%= form_with(url: auth_failures_path, method: 'get') do %>
 <div class="o-admin-form-inline">
   <div class="o-admin-form-pair">
-    <label for="search-terms">DOI search:</label>
+    <label for="search-terms">Search:</label>
     <%= search_field_tag(:q, params[:q], class: 'c-input__text', id: 'search-terms' ) %>
   </div>
   <%= submit_tag('Search', name: nil, class: 'o-button__plain-text2' ) %>

--- a/app/views/stash_engine/status_dashboard/show.html.erb
+++ b/app/views/stash_engine/status_dashboard/show.html.erb
@@ -1,20 +1,19 @@
-<main>
-  <h1>External dependency statuses</h1>
+<%= render partial: 'stash_engine/shared/logs_header', locals: {current: 'dependencies'} %>
+<h2>External dependency statuses</h2>
 
-  <p>The following lists represent the current status of Dryad's external dependencies. A green icon indicates that the service is online and operational, red indicates that the service is offline and orange indicates that we could not determine it's status. Clicking on a red or orange icon will open a dialog with troubleshooting information.</p>
-  <p>For general troubleshooting information, please refer to the: <%= link_to 'Main Dryad Documentation', @main_documentation %></p>
+<p>The following lists represent the current status of Dryad's external dependencies. A green icon indicates that the service is online and operational, red indicates that the service is offline and orange indicates that we could not determine it's status. Clicking on a red or orange icon will open a dialog with troubleshooting information.</p>
+<p>For general troubleshooting information, please refer to the: <%= link_to 'Main Dryad Documentation', @main_documentation %></p>
 
-  <p><strong>The following dependencies were last checked on: <em><%= formatted_datetime(@latest_check) %></em></strong></p>
+<p><strong>The following dependencies were last checked on: <em><%= formatted_datetime(@latest_check) %></em></strong></p>
 
-  <div class="o-admin-columns" style="justify-content: space-around;">
-    <div style="flex-basis: 500px;">
-      <h2>Dryad managed</h2>
-      <%= render partial: 'dependency_list', locals: { dependencies: @managed_dependencies } %>
-    </div>
-
-    <div style="flex-basis: 500px;">
-      <h2>Vendor managed</h2>
-      <%= render partial: 'dependency_list', locals: { dependencies: @unmanaged_dependencies } %>
-    </div>
+<div class="o-admin-columns" style="justify-content: space-around;">
+  <div style="flex-basis: 500px;">
+    <h2>Dryad managed</h2>
+    <%= render partial: 'dependency_list', locals: { dependencies: @managed_dependencies } %>
   </div>
-</main>
+
+  <div style="flex-basis: 500px;">
+    <h2>Vendor managed</h2>
+    <%= render partial: 'dependency_list', locals: { dependencies: @unmanaged_dependencies } %>
+  </div>
+</div>

--- a/config/routes.rb
+++ b/config/routes.rb
@@ -296,7 +296,6 @@ Rails.application.routes.draw do
     match 'admin_dashboard/count', to: 'admin_dashboard#count', via: %i[get post], as: 'admin_dashboard_count'
     match 'admin_dashboard/charts', to: 'admin_dashboard#charts', via: %i[get post], as: 'admin_dashboard_charts'
     match 'admin_dashboard/deleted', to: 'admin_dashboard#deleted', via: %i[get post], as: 'deleted_data'
-    match 'admin_dashboard/auth_failures', to: 'admin_dashboard#auth_failures', via: %i[get post], as: 'auth_failures'
     get 'admin_dashboard/:id/edit/:field', to: 'admin_dashboard#edit', as: 'admin_dash_edit'
     post 'admin_dashboard/:id', to: 'admin_dashboard#update', as: 'admin_dash_update'
     get 'admin_search', to: 'admin_dashboard#new_search', as: 'new_admin_search'
@@ -340,8 +339,9 @@ Rails.application.routes.draw do
     post 'zenodo_queue/resubmit_job', to: 'zenodo_queue#resubmit_job', as: 'zenodo_queue_resubmit_job'
     post 'zenodo_queue/set_errored', to: 'zenodo_queue#set_errored', as: 'zenodo_queue_set_errored'
 
-    # Administrative Status Dashboard that displays statuses of external dependencies
+    # Administrative Status Dashboard that displays statuses of external dependencies and logs
     get 'status_dashboard', to: 'status_dashboard#show'
+    match 'status_dashboard/auth_failures', to: 'status_dashboard#auth_failures', via: %i[get post], as: 'auth_failures'
 
     # Publication updater page - Allows admins to accept/reject metadata changes from external sources like Crrossref
     get 'publication_updater', to: 'publication_updater#index'

--- a/spec/features/stash_engine/admin_dashboard_spec.rb
+++ b/spec/features/stash_engine/admin_dashboard_spec.rb
@@ -34,7 +34,7 @@ RSpec.feature 'AdminDashboard', type: :feature do
       visit root_path
       find_button('Datasets').hover
       expect(page).to have_link('Admin dashboard')
-      expect(page).to have_link('Status dashboard')
+      expect(page).to have_link('Logs & statuses')
       expect(page).to have_link('Submission queue')
     end
 


### PR DESCRIPTION
Authentication failures logs are in an odd view and controller (admin_dashboard, which is stuff for all admins about datasets) considering its location in the nav, its importance (low), and its permissions (superusers only). The location in the nav is also not quite right.

This moves everything around so it's reduced in nav importance and set up with the other superuser-only stuff (status_dashboard). We can add other superuser logs and things here as well in the future. Also fixes the search label.