### PR TITLE
Fix resource paper trail versions duplication issue, add cleanup script

### DIFF
--- a/app/models/stash_datacite/resources_subjects.rb
+++ b/app/models/stash_datacite/resources_subjects.rb
@@ -24,8 +24,18 @@ module StashDatacite
 
     validates :subject_id, presence: true, uniqueness: { scope: :resource_id }
 
-    after_commit do
-      resource.paper_trail.save_with_version if resource
+    after_commit :version_resource
+
+    private
+
+    def version_resource
+      return unless resource
+
+      current_subjects = resource.subjects.map { |s| s.slice(:subject, :scheme_URI) }
+      last_subjects = resource.versions.last&.additional_info&.dig('subjects_list')
+      return if current_subjects == last_subjects
+
+      resource.paper_trail.save_with_version
     end
   end
 end

--- a/app/services/paper_trail_cleanup_service.rb
+++ b/app/services/paper_trail_cleanup_service.rb
@@ -1,0 +1,41 @@
+class PaperTrailCleanupService
+  class << self
+    def remove_versions_by_resource
+      CustomVersion.where(item_type: 'StashEngine::Resource').select(:item_id).distinct.each do |version|
+        remove_resource_duplicate_versions(version.item_id)
+      end
+    end
+
+    # private
+
+    def remove_resource_duplicate_versions(resource_id)
+      resource = StashEngine::Resource.with_deleted.find_by(id: resource_id)
+      return if resource.nil?
+
+      resource.versions.order(:created_at, :id).each_cons(2) do |a, b|
+        if a.additional_info == b.additional_info && (b.object_changes.blank? || a.object_changes == b.object_changes)
+          pp "deleting #{b.id}"
+          b.destroy
+        end
+      end
+    end
+
+    def remove_versions_by_author
+      CustomVersion.where(item_type: 'StashEngine::Author').select(:item_id).distinct.each do |version|
+        remove_author_duplicate_versions(version.item_id)
+      end
+    end
+
+    def remove_author_duplicate_versions(author_id)
+      record = StashEngine::Author.find_by(id: author_id)
+      return if record.nil?
+
+      record.versions.order(:created_at, :id).each_cons(2) do |a, b|
+        if a.additional_info == b.additional_info && (b.object_changes.blank? || a.object_changes == b.object_changes)
+          pp "deleting #{b.id}"
+          b.destroy
+        end
+      end
+    end
+  end
+end


### PR DESCRIPTION
Closes https://github.com/datadryad/dryad-product-roadmap/issues/5104

The script will delete `330,528` resource records and `1,781` author records
I will run the script manually since it takes a while and did not want to keep the deploy waiting on data migrations