### PR TITLE
Separate out agreements components

### DIFF
--- a/app/javascript/react/components/MetadataEntry/Agreements/Agreements.jsx
+++ b/app/javascript/react/components/MetadataEntry/Agreements/Agreements.jsx
@@ -106,6 +106,7 @@ export default function Agreements({
                 </>
               )}
               {userMustPay && 
+              // Not for LDF payments
               (!dpc.funder_will_pay && !dpc.institution_will_pay && !dpc.journal_will_pay) && 
               (!dpc.aff_tenant || dpc.aff_tenant.id !== resource.tenant_id) && (
                 <div className="callout warn" style={{margin: '1em 0', paddingBottom: '5px'}}>

--- a/app/javascript/react/components/MetadataEntry/Agreements/Agreements.jsx
+++ b/app/javascript/react/components/MetadataEntry/Agreements/Agreements.jsx
@@ -86,7 +86,9 @@ export default function Agreements({
             : (
               <>
                 <CalculateFees resource={resource} fees={fees} ppr={ppr} />
-                <PaymentMessage resource={resource} />
+                {fees && fees.total ? (
+                  <PaymentMessage resource={resource} />
+                ) : null }
               </>
             )}
         </>

--- a/app/javascript/react/components/MetadataEntry/Agreements/Agreements.jsx
+++ b/app/javascript/react/components/MetadataEntry/Agreements/Agreements.jsx
@@ -1,41 +1,9 @@
 import React, {useRef, useState, useEffect} from 'react';
-import axios from 'axios';
-import {showSavedMsg, showSavingMsg} from '../../../../lib/utils';
-import {ExitIcon} from '../../ExitButton';
 import Calculations from './Calculations';
 import CalculateFees from '../../CalculateFees';
+import PPRSetting from './PPRSetting';
+import SubmitterAgreement from './SubmitterAgreement';
 import {useStore} from '../../../shared/store';
-
-function TermsOfSubmission({resource}) {
-  if (resource.accepted_agreement) {
-    return (
-      <p>
-        <i className="fas fa-circle-check" aria-hidden="true" />{' '}
-        The submitter has agreed to Dryad&apos;s{' '}
-        <a href="/terms" target="_blank">terms of submission<ExitIcon /></a>
-      </p>
-    );
-  }
-
-  return (
-    <p style={{fontStyle: 'italic'}}><i className="fas fa-square" aria-hidden="true" />{' '} Terms not yet accepted</p>
-  );
-}
-
-function NoSubmitterWarning({preview, isSubmitter}) {
-  if (preview || isSubmitter) return null;
-
-  return (
-    <div className="callout warn">
-      <p>
-        Only the submitter can agree to the terms and conditions.
-        When you are done editing, please click &nbsp;
-        <b><i className="fas fa-floppy-disk" /> Save &amp; exit</b> &nbsp;
-        and ask the submitter to complete the submission.
-      </p>
-    </div>
-  );
-}
 
 function PaymentMessage({resource}) {
   if (resource.identifier.display_payer?.id) return <p>You will be asked to pay this fee upon submission.</p>;
@@ -48,109 +16,16 @@ function PaymentMessage({resource}) {
   );
 }
 
-function PPRSetting({
-  togglePPR, ppr, dpc, curated, subType, reason,
-}) {
-  if (!curated && dpc.automatic_ppr) {
-    return (
-      <>
-        <h3>{subType === 'collection' ? 'Is your collection' : 'Are your files'} ready to publish?</h3>
-        <p>
-          This submission is associated with a manuscript from an{' '}
-          <a href="/journals" target="_blank">integrated journal<ExitIcon /></a>.
-          It will remain Private for Peer Review until formal acceptance of the associated manuscript.
-        </p>
-      </>
-    );
-  } if (!curated && dpc.allow_review) {
-    return (
-      <fieldset onChange={togglePPR} aria-labelledby="toggle-ppr">
-        <h3 style={{margin: '0'}} id="toggle-ppr">
-          {`${subType === 'collection' ? 'Is your collection' : 'Are your files'} ready to publish?`}
-        </h3>
-        <p className="radio_choice">
-          <label style={!ppr ? {fontWeight: 'bold'} : {}}>
-            <input type="radio" name="peer_review" value="0" defaultChecked={!ppr} />
-            {`My ${subType === 'collection'
-              ? 'collection should be publically viewable '
-              : 'files should be available for public download '} as soon as possible`}
-          </label>
-        </p>
-        <p className="radio_choice" style={{marginBottom: 0}}>
-          <label style={ppr ? {fontWeight: 'bold'} : {}}>
-            <input type="radio" name="peer_review" value="1" defaultChecked={ppr} />
-            {`Keep my ${subType === 'collection' ? 'collection' : 'files'} private while my manuscript undergoes peer review`}
-          </label>
-        </p>
-      </fieldset>
-    );
-  }
-  return (
-    <>
-      <h3>{subType === 'collection' ? 'Is your collection' : 'Are your files'} ready to publish?</h3>
-      <p>
-          The Private for Peer Review option is not available for this submission{reason}.
-          The submission will proceed to our curation process for evaluation and publication.
-      </p>
-    </>
-  );
-}
-
 export default function Agreements({
   resource, setResource, user, form, previous, config, current, setAuthorStep, preview = false,
 }) {
   const {updateStore, storeState: {dpc, fees, userMustPay}} = useStore();
+  const [ppr, setPPR] = useState(resource.hold_for_peer_review);
   const subType = resource.resource_type.resource_type;
-  const submitted = !!resource.identifier.process_date.processing;
-  const curated = !!resource.identifier.process_date.curation_end;
   const {users} = resource;
   const submitter = users.find((u) => u.role === 'submitter');
   const isSubmitter = user.id === submitter.id;
   const formRef = useRef(null);
-  const [ppr, setPPR] = useState(resource.hold_for_peer_review);
-  const [agree, setAgree] = useState(resource.accepted_agreement);
-  const [reason, setReason] = useState('');
-
-  const authenticity_token = document.querySelector("meta[name='csrf-token']")?.getAttribute('content');
-
-  const postPPR = (bool) => {
-    showSavingMsg();
-    axios.patch(
-      '/stash_datacite/peer_review/toggle',
-      {authenticity_token, id: resource.id, hold_for_peer_review: bool},
-      {headers: {'Content-Type': 'application/json; charset=utf-8', Accept: 'application/json'}},
-    )
-      .then((data) => {
-        if (data.status === 200) {
-          const {hold_for_peer_review} = data.data;
-          setPPR(hold_for_peer_review);
-          setResource((r) => ({...r, hold_for_peer_review}));
-          showSavedMsg();
-        }
-      });
-  };
-
-  const togglePPR = (e) => {
-    const v = e.target.value;
-    postPPR(v === '1');
-  };
-
-  const toggleTerms = (e) => {
-    showSavingMsg();
-    const accept = e.target.checked;
-    axios.post(
-      `/metadata_entry_pages/${accept ? 'accept' : 'reject'}_agreement`,
-      {authenticity_token, resource_id: resource.id},
-      {headers: {'Content-Type': 'application/json; charset=utf-8', Accept: 'application/json'}},
-    )
-      .then((data) => {
-        if (data.status === 200) {
-          setAgree(accept);
-          setResource((r) => ({...r, accepted_agreement: accept}));
-          showSavedMsg();
-        }
-      });
-  };
 
   useEffect(() => {
     const existing = formRef.current?.querySelector('#dryad-member');
@@ -168,28 +43,10 @@ export default function Agreements({
   }, [dpc, formRef.current]);
 
   useEffect(() => {
-    if (Object.hasOwn(dpc, 'total_file_size')) {
-      if (resource.identifier.pub_state === 'published') {
-        setReason(', because the data has been previously published');
-      } else if (dpc.man_decision_made) {
-        setReason(', because the journal has made a decision on the associated manuscript');
-      } else if (resource.related_identifiers.find((r) => r.work_type === 'primary_article')?.related_identifier) {
-        setReason(', because the associated primary publication is not in peer review');
-      } else if (curated) {
-        setReason(', because the dataset has previously been submitted and entered curation');
-      }
-      if (!curated) {
-        if (dpc.automatic_ppr && !ppr) postPPR(true);
-        else if (!dpc.allow_review && ppr) postPPR(false);
-      }
-    }
-  }, [dpc]);
-
-  useEffect(() => {
     if (preview || current) updateStore({refreshDpcStatus: true});
   }, [current, preview]);
 
-  if (!resource.identifier || Object.keys(dpc).length === 0) {
+  if (Object.keys(dpc).length === 0) {
     return (
       <p><i className="fas fa-spinner fa-spin" role="img" aria-label="Loading..." /></p>
     );
@@ -197,32 +54,7 @@ export default function Agreements({
 
   return (
     <>
-      {preview && (
-        <>
-          <h2>{subType === 'collection' ? 'Is your collection' : 'Are your files'} ready to publish?</h2>
-          <div className="callout alt">
-            {ppr ? (
-              <p>
-                {subType === 'collection' ? 'This collection will be ' : 'These files will be '}
-                kept private while your manuscript undergoes peer review
-              </p>
-            ) : (
-              <p>
-                {subType === 'collection'
-                  ? 'This collection will be publically viewable '
-                  : <>These files <b>will be available for public download</b> </>}as soon as possible
-              </p>
-            )}
-          </div>
-          {previous && ppr !== previous.hold_for_peer_review && <p className="del ins">PPR setting changed</p>}
-        </>
-      )}
-      {!preview && (
-        <PPRSetting {...{
-          togglePPR, ppr, curated, dpc, subType, reason,
-        }}
-        />
-      )}
+      <PPRSetting {...{ppr, setPPR, resource, setResource, dpc, preview, previous}} />
       {preview ? <h2>Do you agree to Dryad’s terms?</h2> : <h3 style={{marginTop: '3rem'}}>Do you agree to Dryad’s terms?</h3>}
       {subType !== 'collection' && (
         <>
@@ -254,14 +86,11 @@ export default function Agreements({
             : (
               <>
                 <CalculateFees resource={resource} fees={fees} ppr={ppr} />
-                {fees && fees.total ? (
-                  <PaymentMessage resource={resource} />
-                ) : null }
+                <PaymentMessage resource={resource} />
               </>
             )}
         </>
       )}
-      <NoSubmitterWarning {...{preview, isSubmitter}} />
       {isSubmitter && (
         <>
           {(subType !== 'collection'
@@ -274,7 +103,9 @@ export default function Agreements({
                   <div style={{maxWidth: '700px'}} ref={formRef} />
                 </>
               )}
-              {userMustPay && (!dpc.aff_tenant || dpc.aff_tenant.id !== resource.tenant_id) && (
+              {userMustPay && 
+              (!dpc.funder_will_pay && !dpc.institution_will_pay && !dpc.journal_will_pay) && 
+              (!dpc.aff_tenant || dpc.aff_tenant.id !== resource.tenant_id) && (
                 <div className="callout warn" style={{margin: '1em 0', paddingBottom: '5px'}}>
                   <p style={{marginBottom: '.75em'}}>
                     <i className="fas fa-circle-question" aria-hidden="true" style={{marginRight: '.5ch'}} />
@@ -313,21 +144,9 @@ export default function Agreements({
               )}
             </>
           )}
-          {!preview && (
-            <form id="term-acceptance" onSubmit={(e) => e.preventDefault()}>
-              <p className="radio_choice" style={{marginTop: '2em'}}>
-                <label>
-                  <input type="checkbox" id="agreement" defaultChecked={agree} onChange={toggleTerms} required disabled={submitted} />
-                  <span className="input-label">I agree</span>
-                  {` to Dryad's ${subType !== 'collection' && userMustPay ? 'payment terms and ' : ''}`}
-                  <a href="/terms" target="_blank">terms of submission<ExitIcon /></a>
-                </label>
-              </p>
-            </form>
-          )}
         </>
       )}
-      {preview && <TermsOfSubmission resource={resource} />}
+      <SubmitterAgreement {...{preview, isSubmitter, resource, setResource, userMustPay}} />
     </>
   );
 }

--- a/app/javascript/react/components/MetadataEntry/Agreements/PPRSetting.jsx
+++ b/app/javascript/react/components/MetadataEntry/Agreements/PPRSetting.jsx
@@ -1,0 +1,122 @@
+import React, {useState, useEffect} from 'react';
+import axios from 'axios';
+import {showSavedMsg, showSavingMsg} from '../../../../lib/utils';
+import {ExitIcon} from '../../ExitButton';
+
+export default function PPRSetting({ppr, setPPR, resource, setResource, dpc, preview, previous}) {
+  const [reason, setReason] = useState('');
+
+  const subType = resource.resource_type.resource_type;
+  const curated = !!resource.identifier.process_date.curation_end;
+  const authenticity_token = document.querySelector("meta[name='csrf-token']")?.getAttribute('content');
+
+  const postPPR = (bool) => {
+    showSavingMsg();
+    axios.patch(
+      '/stash_datacite/peer_review/toggle',
+      {authenticity_token, id: resource.id, hold_for_peer_review: bool},
+      {headers: {'Content-Type': 'application/json; charset=utf-8', Accept: 'application/json'}},
+    )
+      .then((data) => {
+        if (data.status === 200) {
+          const {hold_for_peer_review} = data.data;
+          setPPR(hold_for_peer_review);
+          setResource((r) => ({...r, hold_for_peer_review}));
+          showSavedMsg();
+        }
+      });
+  };
+
+  const togglePPR = (e) => {
+    const v = e.target.value;
+    postPPR(v === '1');
+  };
+
+  useEffect(() => {
+    if (Object.hasOwn(dpc, 'total_file_size')) {
+      if (resource.identifier.pub_state === 'published') {
+        setReason(', because the data has been previously published');
+      } else if (dpc.man_decision_made) {
+        setReason(', because the journal has made a decision on the associated manuscript');
+      } else if (resource.related_identifiers.find((r) => r.work_type === 'primary_article')?.related_identifier) {
+        setReason(', because the associated primary publication is not in peer review');
+      } else if (curated) {
+        setReason(', because the dataset has previously been submitted and entered curation');
+      }
+      if (!curated) {
+        if (dpc.automatic_ppr && !ppr) postPPR(true);
+        else if (!dpc.allow_review && ppr) postPPR(false);
+      }
+    }
+  }, [dpc]);
+
+  if (preview) {
+    return (
+      <>
+        <h2>{subType === 'collection' ? 'Is your collection' : 'Are your files'} ready to publish?</h2>
+        <div className="callout alt">
+          {ppr ? (
+            <p>
+              {subType === 'collection' ? 'This collection will be ' : 'These files will be '}
+              kept private while your manuscript undergoes peer review
+            </p>
+          ) : (
+            <p>
+              {subType === 'collection'
+                ? 'This collection will be publically viewable '
+                : <>These files <b>will be available for public download</b> </>}as soon as possible
+            </p>
+          )}
+        </div>
+        {previous && ppr !== previous.hold_for_peer_review && <p className="del ins">PPR setting changed</p>}
+      </>
+    )
+  }
+
+  if (!curated && dpc.automatic_ppr) {
+    return (
+      <>
+        <h3>{subType === 'collection' ? 'Is your collection' : 'Are your files'} ready to publish?</h3>
+        <p>
+          This submission is associated with a manuscript from an{' '}
+          <a href="/journals" target="_blank">integrated journal<ExitIcon /></a>.
+          It will remain Private for Peer Review until formal acceptance of the associated manuscript.
+        </p>
+      </>
+    );
+  }
+
+  if (!curated && dpc.allow_review) {
+    return (
+      <fieldset onChange={togglePPR} aria-labelledby="toggle-ppr">
+        <h3 style={{margin: '0'}} id="toggle-ppr">
+          {`${subType === 'collection' ? 'Is your collection' : 'Are your files'} ready to publish?`}
+        </h3>
+        <p className="radio_choice">
+          <label style={!ppr ? {fontWeight: 'bold'} : {}}>
+            <input type="radio" name="peer_review" value="0" defaultChecked={!ppr} />
+            {`My ${subType === 'collection'
+              ? 'collection should be publically viewable '
+              : 'files should be available for public download '} as soon as possible`}
+          </label>
+        </p>
+        <p className="radio_choice" style={{marginBottom: 0}}>
+          <label style={ppr ? {fontWeight: 'bold'} : {}}>
+            <input type="radio" name="peer_review" value="1" defaultChecked={ppr} />
+            {`Keep my ${subType === 'collection' ? 'collection' : 'files'} private while my manuscript undergoes peer review`}
+          </label>
+        </p>
+      </fieldset>
+    );
+  }
+
+  return (
+    <>
+      <h3>{subType === 'collection' ? 'Is your collection' : 'Are your files'} ready to publish?</h3>
+      <p>
+          The Private for Peer Review option is not available for this submission{reason}.
+          The submission will proceed to our curation process for evaluation and publication.
+      </p>
+    </>
+  );
+}

--- a/app/javascript/react/components/MetadataEntry/Agreements/SubmitterAgreement.jsx
+++ b/app/javascript/react/components/MetadataEntry/Agreements/SubmitterAgreement.jsx
@@ -1,0 +1,69 @@
+import React, {useState} from 'react';
+import axios from 'axios';
+import {showSavedMsg, showSavingMsg} from '../../../../lib/utils';
+import {ExitIcon} from '../../ExitButton';
+
+export default function SubmitterAgreement({preview, resource, setResource, isSubmitter, userMustPay}) {
+  const [agree, setAgree] = useState(resource.accepted_agreement);
+
+  const submitted = !!resource.identifier.process_date.processing;
+  const authenticity_token = document.querySelector("meta[name='csrf-token']")?.getAttribute('content');
+
+  const toggleTerms = (e) => {
+    showSavingMsg();
+    const accept = e.target.checked;
+    axios.post(
+      `/metadata_entry_pages/${accept ? 'accept' : 'reject'}_agreement`,
+      {authenticity_token, resource_id: resource.id},
+      {headers: {'Content-Type': 'application/json; charset=utf-8', Accept: 'application/json'}},
+    )
+      .then((data) => {
+        if (data.status === 200) {
+          setAgree(accept);
+          setResource((r) => ({...r, accepted_agreement: accept}));
+          showSavedMsg();
+        }
+      });
+  };
+
+  if (preview) {
+    if (resource.accepted_agreement) {
+      return (
+        <p>
+          <i className="fas fa-circle-check" aria-hidden="true" />{' '}
+          The submitter has agreed to Dryad&apos;s{' '}
+          <a href="/terms" target="_blank">terms of submission<ExitIcon /></a>
+        </p>
+      );
+    }
+    return (
+      <p style={{fontStyle: 'italic'}}><i className="fas fa-square" aria-hidden="true" />{' '} Terms not yet accepted</p>
+    );
+  }
+
+  if (isSubmitter) {
+    return (
+      <form id="term-acceptance" onSubmit={(e) => e.preventDefault()}>
+        <p className="radio_choice" style={{marginTop: '2em'}}>
+          <label>
+            <input type="checkbox" id="agreement" defaultChecked={agree} onChange={toggleTerms} required disabled={submitted} />
+            <span className="input-label">I agree</span>
+            {` to Dryad's ${userMustPay ? 'payment terms and ' : ''}`}
+            <a href="/terms" target="_blank">terms of submission<ExitIcon /></a>
+          </label>
+        </p>
+      </form>
+    )
+  }
+
+  return (
+    <div className="callout warn">
+      <p>
+        Only the submitter can agree to the terms and conditions.
+        When you are done editing, please click &nbsp;
+        <b><i className="fas fa-floppy-disk" /> Save &amp; exit</b> &nbsp;
+        and ask the submitter to complete the submission.
+      </p>
+    </div>
+  );
+}

--- a/app/javascript/react/components/MetadataEntry/Connect/Publication.jsx
+++ b/app/javascript/react/components/MetadataEntry/Connect/Publication.jsx
@@ -26,13 +26,13 @@ export default function Publication({
           console.log("couldn't change import_type on remote server");
         }
         showSavedMsg();
+        if (choice === 'other') setAssoc(false);
       });
   };
 
   const setImport = (e) => {
     const v = e.target.value;
     if (v === 'no') {
-      setAssoc(false);
       setConnections([]);
       optionChange('other');
     }

--- a/app/javascript/react/components/Payments/InvoiceForm.jsx
+++ b/app/javascript/react/components/Payments/InvoiceForm.jsx
@@ -12,6 +12,12 @@ const validateEmail = (value) => {
   return null;
 };
 
+function ButtonText({resource}) {
+  if (resource.identifier.old_payment_system) return <>Submit for {resource.hold_for_peer_review ? 'peer review' : 'publication'}</>
+
+  return 'Send invoice & submit data'
+}
+
 export default function InvoiceForm({resource, setResource, setPayment}) {
   const {storeState: {fees}} = useStore();
   const {authors, users} = resource;
@@ -119,9 +125,7 @@ export default function InvoiceForm({resource, setResource, setPayment}) {
                 || errors.email
               }
             >
-              {resource.identifier.old_payment_system ? '' : 'Send invoice & '}
-              Submit for{' '}
-              {resource.hold_for_peer_review ? 'peer review' : 'publication'}
+              <ButtonText resource={resource} />
             </button>
           </p>
           <br />

--- a/app/javascript/react/components/SubmissionForm.jsx
+++ b/app/javascript/react/components/SubmissionForm.jsx
@@ -29,6 +29,14 @@ export default function SubmissionForm({
     if (mustPay) setPayment(true);
   };
 
+  if (!resource.generic_files || !fees) {
+    return (
+      <div id="submission-submit" role="status" aria-busy="true" hidden={payment || null}>
+        <div><p><i className="fas fa-spinner fa-spin" role="img" aria-label="Loading..." /></p></div>
+      </div>
+    )
+  }
+
   return (
     <div id="submission-submit" role="status" hidden={payment || null}>
       <div>

--- a/app/javascript/react/components/SubmissionForm.jsx
+++ b/app/javascript/react/components/SubmissionForm.jsx
@@ -99,7 +99,7 @@ export default function SubmissionForm({
           >
             {curator
               ? 'Submit changes'
-              : `${fees.total ? 'Pay & S' : 'S'}ubmit for ${resource.hold_for_peer_review ? 'peer review' : 'publication'}`}
+              : `${fees.total ? 'Pay & s' : 'S'}ubmit for ${resource.hold_for_peer_review ? 'peer review' : 'publication'}`}
           </button>
         </form>
       </div>


### PR DESCRIPTION
Separate out input functions to clean up Agreements component (in prep for more text in payments message etc.)

Also fixes 3 bugs:
1. Institution selector showing for LDF payments
2. Some users are able to submit without paying before file list is fully loaded
3. Previously entered publication information should be removed if 'No' is selected on the Connect page