### PR TITLE
Save retrievable fee calculator receipt record

### DIFF
--- a/app/controllers/fee_calculator_controller.rb
+++ b/app/controllers/fee_calculator_controller.rb
@@ -17,10 +17,13 @@ class FeeCalculatorController < ApplicationController
 
   def calculate_resource_fee
     resource = StashEngine::Resource.find(params[:id])
+    fees = ResourceFeeCalculatorService.new(resource).calculate(resource_options)
+    record = resource.fee_record || resource.build_fee_record
+    record.update(fees: fees.to_json)
 
     render json: {
       options: resource_options,
-      fees: ResourceFeeCalculatorService.new(resource).calculate(resource_options)
+      fees: fees
     }
   end
 

--- a/app/controllers/fee_record_controller.rb
+++ b/app/controllers/fee_record_controller.rb
@@ -1,0 +1,9 @@
+class FeeRecordController < StashEngine::ApplicationController
+  before_action :require_user_login
+
+  def show
+    @receipt = authorize FeeRecord.find_by(id: params[:id])
+
+    respond_to(&:js)
+  end
+end

--- a/app/controllers/payments_controller.rb
+++ b/app/controllers/payments_controller.rb
@@ -84,7 +84,7 @@ class PaymentsController < ApplicationController
     identifier = StashEngine::Identifier.find(params[:identifier_id])
     identifier.update(last_invoiced_file_size: nil, payment_type: 'unknown', payment_id: nil)
     payment = identifier.payments.last
-    payment.resource.fee_record.update(status: :invoice)
+    payment.resource.fee_record&.update(status: :invoice)
     payment.void_invoice
     payment.destroy
 
@@ -105,7 +105,7 @@ class PaymentsController < ApplicationController
     return if @resource.payment.ppr_fee_paid?
     return if SponsoredPaymentsService.new(@resource).loggable?
 
-    @resource.fee_record.update(status: :receipt)
+    @resource.fee_record&.update(status: :receipt)
     identifier.update(last_invoiced_file_size: [identifier.last_invoiced_file_size.to_i, @resource.total_file_size.to_i].max)
   end
 

--- a/app/controllers/payments_controller.rb
+++ b/app/controllers/payments_controller.rb
@@ -84,6 +84,7 @@ class PaymentsController < ApplicationController
     identifier = StashEngine::Identifier.find(params[:identifier_id])
     identifier.update(last_invoiced_file_size: nil, payment_type: 'unknown', payment_id: nil)
     payment = identifier.payments.last
+    payment.resource.fee_record.update(status: :invoice)
     payment.void_invoice
     payment.destroy
 
@@ -104,6 +105,7 @@ class PaymentsController < ApplicationController
     return if @resource.payment.ppr_fee_paid?
     return if SponsoredPaymentsService.new(@resource).loggable?
 
+    @resource.fee_record.update(status: :receipt)
     identifier.update(last_invoiced_file_size: [identifier.last_invoiced_file_size.to_i, @resource.total_file_size.to_i].max)
   end
 

--- a/app/javascript/react/components/Payments/Payments.jsx
+++ b/app/javascript/react/components/Payments/Payments.jsx
@@ -22,17 +22,17 @@ function Receipt({fees}) {
           </thead>
           <tbody>
             <tr>
-              <th scope="row>">Dryad fees</th>
+              <th scope="row">Dryad fees</th>
               <td>{formatCost(fees.dpc_sponsored)}</td>
               <td>{formatCost(fees.storage_fee + fees.storage_sponsored)}</td>
             </tr>
             <tr>
-              <th scope="row>">Sponsor credit</th>
+              <th scope="row">Sponsor credit</th>
               <td>-{formatCost(fees.dpc_sponsored)}</td>
               <td>-{formatCost(fees.storage_sponsored)}</td>
             </tr>
             <tr>
-              <th scope="row>">Amount due</th>
+              <th scope="row">Amount due</th>
               <td></td>
               <td>{formatCost(fees.storage_fee)}</td>
             </tr>

--- a/app/models/fee_record.rb
+++ b/app/models/fee_record.rb
@@ -1,0 +1,23 @@
+# == Schema Information
+#
+# Table name: fee_records
+#
+#  id          :bigint           not null, primary key
+#  deleted_at  :datetime
+#  fees        :json
+#  status      :integer          default("invoice")
+#  created_at  :datetime         not null
+#  updated_at  :datetime         not null
+#  resource_id :bigint
+#
+class FeeRecord < ApplicationRecord
+  acts_as_paranoid
+
+  belongs_to :resource, class_name: 'StashEngine::Resource'
+
+  enum :status, { invoice: 0, receipt: 1 }
+
+  def fees
+    JSON.parse(super, symbolize_names: true)
+  end
+end

--- a/app/models/stash_engine/identifier.rb
+++ b/app/models/stash_engine/identifier.rb
@@ -73,6 +73,7 @@ module StashEngine
     has_many :curation_activities, class_name: 'StashEngine::CurationActivity', through: :resources
     has_many :payments, class_name: 'ResourcePayment', through: :resources
     has_many :sponsored_payment_logs, through: :resources
+    has_many :receipts, -> { receipt }, class_name: 'FeeRecord', through: :resources
     has_one :research_integrity_case
 
     after_create :create_process_date, unless: :process_date
@@ -594,6 +595,7 @@ module StashEngine
       res = resources.files_published.order(total_file_size: :desc).first
       return if res.nil? || res.total_file_size.nil?
 
+      res.fee_record&.update(status: :receipt)
       update(last_invoiced_file_size: res.total_file_size)
       res.total_file_size
     end

--- a/app/models/stash_engine/resource.rb
+++ b/app/models/stash_engine/resource.rb
@@ -125,6 +125,8 @@ module StashEngine
     has_many :flags, ->(resource) { unscope(where: :resource_id).where(flaggable: [resource.journal, resource.tenant, resource.users]) }
     has_many :action_reports, class_name: 'ActionRequiredReport'
     has_one :payment, class_name: 'ResourcePayment'
+    has_one :fee_record, class_name: 'FeeRecord', dependent: :destroy
+    has_one :receipt, -> { receipt }, class_name: 'FeeRecord', dependent: :destroy
     has_one :sponsored_payment_log, dependent: :destroy
 
     after_create :create_process_date, unless: :process_date

--- a/app/policies/fee_record_policy.rb
+++ b/app/policies/fee_record_policy.rb
@@ -1,0 +1,6 @@
+class FeeRecordPolicy < ApplicationPolicy
+  def show?
+    @record.resource.admin_for_this_item?(user: @user) ||
+    @record.resource.submitter == @user
+  end
+end

--- a/app/services/sponsored_payments_service.rb
+++ b/app/services/sponsored_payments_service.rb
@@ -61,6 +61,7 @@ class SponsoredPaymentsService
   private
 
   def update_identifier_files_size
+    resource.fee_record.update(status: :receipt)
     identifier.update(last_invoiced_file_size: resource.total_file_size)
   end
 

--- a/app/services/sponsored_payments_service.rb
+++ b/app/services/sponsored_payments_service.rb
@@ -61,7 +61,7 @@ class SponsoredPaymentsService
   private
 
   def update_identifier_files_size
-    resource.fee_record.update(status: :receipt)
+    resource.fee_record&.update(status: :receipt)
     identifier.update(last_invoiced_file_size: resource.total_file_size)
   end
 

--- a/app/views/fee_record/_receipt.html.erb
+++ b/app/views/fee_record/_receipt.html.erb
@@ -1,0 +1,24 @@
+<div class="table-wrapper" style="text-align: center">
+  <table style="margin: 0 auto">
+    <thead>
+      <tr><td></td><th scope="col">Data Publishing Charge</th><th scope="col">Large Data Fee</th></tr>
+    </thead>
+    <tbody>
+      <tr>
+        <th scope="row">Dryad fees</th>
+        <td>$<%= receipt.fees[:dpc_sponsored].to_i %></td>
+        <% if receipt.fees[:dpc_sponsored]%><td>$<%= receipt.fees[:storage_fee].to_i + receipt.fees[:storage_sponsored].to_i %></td><% end %>
+      </tr>
+      <tr>
+        <th scope="row">Sponsor credit</th>
+        <td>-$<%= receipt.fees[:dpc_sponsored].to_i %></td>
+        <% if receipt.fees[:dpc_sponsored]%><td>-$<%= receipt.fees[:storage_sponsored].to_i %></td><% end %>
+      </tr>
+      <tr>
+        <th scope="row">Submitter total</th>
+        <td><% unless receipt.fees[:dpc_sponsored]%>$<%= receipt.fees[:storage_fee].to_i %> %><% end %></td>
+        <% if receipt.fees[:dpc_sponsored]%><td>$<%= receipt.fees[:storage_fee].to_i %></td><% end %>
+      </tr>
+    </tbody>
+  </table>
+</div>

--- a/app/views/fee_record/_receipt.html.erb
+++ b/app/views/fee_record/_receipt.html.erb
@@ -1,13 +1,17 @@
 <div class="table-wrapper" style="text-align: center">
   <table style="margin: 0 auto">
     <thead>
-      <tr><td></td><th scope="col">Data Publishing Charge</th><th scope="col">Large Data Fee</th></tr>
+      <tr>
+        <td></td>
+        <th scope="col">Data Publishing Charge</th>
+        <% if receipt.fees[:dpc_sponsored] %><th scope="col">Large Data Fee</th><% end %>
+      </tr>
     </thead>
     <tbody>
       <tr>
         <th scope="row">Dryad fees</th>
-        <td>$<%= receipt.fees[:dpc_sponsored].to_i %></td>
-        <% if receipt.fees[:dpc_sponsored]%><td>$<%= receipt.fees[:storage_fee].to_i + receipt.fees[:storage_sponsored].to_i %></td><% end %>
+        <td>$<%= receipt.fees[:dpc_sponsored].presence || receipt.fees[:storage_fee].to_i %></td>
+        <% if receipt.fees[:dpc_sponsored] %><td>$<%= receipt.fees[:storage_fee].to_i + receipt.fees[:storage_sponsored].to_i %></td><% end %>
       </tr>
       <tr>
         <th scope="row">Sponsor credit</th>
@@ -16,7 +20,7 @@
       </tr>
       <tr>
         <th scope="row">Submitter total</th>
-        <td><% unless receipt.fees[:dpc_sponsored]%>$<%= receipt.fees[:storage_fee].to_i %> %><% end %></td>
+        <td><% unless receipt.fees[:dpc_sponsored] %>$<%= receipt.fees[:storage_fee].to_i %><% end %></td>
         <% if receipt.fees[:dpc_sponsored]%><td>$<%= receipt.fees[:storage_fee].to_i %></td><% end %>
       </tr>
     </tbody>

--- a/app/views/fee_record/_show.html.erb
+++ b/app/views/fee_record/_show.html.erb
@@ -1,0 +1,4 @@
+<h1 id="dialog-title">Fee breakdown</h1>
+<p><%= @receipt.resource.title %><br/><span style="font-size: .98rem;"><%= @receipt.resource.identifier_value %></span></p>
+<%= render partial: 'receipt', locals: {receipt: @receipt} %>
+<p class='c-modal__buttons-right'><button id='cancel_dialog' class= 'o-button__plain-text7'>Close</button></p>

--- a/app/views/fee_record/show.js.erb
+++ b/app/views/fee_record/show.js.erb
@@ -1,0 +1,6 @@
+document.getElementById('genericModalContent').innerHTML = "<%= escape_javascript(render partial: 'show') %>";
+document.getElementById('genericModalDialog').showModal();
+document.getElementById('cancel_dialog').addEventListener('click', (e) => {
+  e.preventDefault();
+  document.getElementById('genericModalDialog').close();
+});

--- a/app/views/stash_engine/admin_dashboard/_table_row.html.erb
+++ b/app/views/stash_engine/admin_dashboard/_table_row.html.erb
@@ -92,6 +92,11 @@
         dpc = dataset.identifier.payment_id.split("funder:").last.split("|").first if dataset.identifier.payment_id&.starts_with?('funder')
       %>
       <%= dpc %>
+      <% if dataset.identifier.receipts.present? && policy(dataset.identifier.receipts.last).show? %>
+        <%= form_with(url: receipt_path(dataset.identifier.receipts.last), method: :get, local: false) do %>
+          <button class="c-admin-edit-icon" id="d<%=dataset.identifier.id%>_receipt" aria-labelledby="d<%=dataset.identifier.id%>_title d<%=dataset.identifier.id%>_receipt"><i class="fas fa-receipt" aria-hidden="true"></i> Fees</button>
+        <% end %>
+      <% end %>
     </td>
   <% end %>
   <% if @fields.include?('curator') %>

--- a/app/views/stash_engine/dashboard/_user_datasets.html.erb
+++ b/app/views/stash_engine/dashboard/_user_datasets.html.erb
@@ -23,13 +23,13 @@
       <p class="c-user-dataset-details">
         <span>DOI: <%= dataset.identifier.identifier %></span>
         <span><%= time_ago_in_words(dataset.updated_at, include_seconds: true) %> since last update</span>
+        <% if dataset&.resource_type&.resource_type == 'collection' %>
+          <span class="callout">Collection</span>
+        <% end %>
         <% if dataset.identifier.published? %>
           <span>Published: <%= formatted_date(dataset.identifier.date_last_published) %></span><% if dataset.sort_order != 3 %>
             <span class="prev-published"><i class="fa fa-check" aria-hidden="true"></i> Previous version published</span>
           <% end %>
-        <% end %>
-        <% if dataset&.resource_type&.resource_type == 'collection' %>
-          <span class="callout">Collection</span>
         <% end %>
       </p>
     </div>
@@ -52,11 +52,11 @@
           <% if dataset.last_curation_activity&.status == 'in_progress' %>
             <% if dataset.current_editor_id.nil? || dataset.current_editor_id == current_user&.id %>
               <%= button_to stash_url_helpers.metadata_entry_pages_find_or_create_path(resource_id: dataset.id), name: 'resume', form_class: 'o-button__inline-form', class: 'o-button__plain-text7', id: "d#{dataset.identifier.id}_resume", 'aria-labelledby': "d#{dataset.identifier.id}_resume d#{dataset.identifier.id}_title", method: :post do %>
-                <i class="fas fa-pencil" aria-hidden="true"></i><%= dataset.current_editor_id.nil? ? "Edit" : "Resume" %></span>
+                <i class="fas fa-pencil" aria-hidden="true"></i><%= dataset.current_editor_id.nil? ? "Edit" : "Resume" %>
               <% end %>
               <% if dataset.current_editor_id == current_user&.id %>
                 <%= button_to stash_url_helpers.logout_resource_path(dataset), name: 'exit', form_class: 'o-button__inline-form', class: 'o-button__plain-text7', id: "d#{dataset.identifier.id}_exit", 'aria-labelledby': "d#{dataset.identifier.id}_exit d#{dataset.identifier.id}_title", method: :post do %>
-                  <i class="fas fa-floppy-disk" aria-hidden="true"></i>Save & exit</span>
+                  <i class="fas fa-floppy-disk" aria-hidden="true"></i>Save & exit
                 <% end %>
               <% end %>
               <% if policy(dataset).delete? %>
@@ -77,6 +77,11 @@
           <% if dataset.sort_order == 4 && dataset.identifier.publication_article_doi.nil? %>
             <%= form_with(url: primary_article_path(resource_id: dataset.id), method: :get, local: false, class: 'o-button__inline-form', id: "#{dataset.id}_pub_form") do %>
               <button class="o-button__plain-text7" id="d<%=dataset.identifier.id%>_link" aria-labelledby="d<%=dataset.identifier.id%>_title d<%=dataset.identifier.id%>_link"><i class="fas fa-newspaper" aria-hidden="true"></i>Link article</button>
+            <% end %>
+          <% end %>
+          <% if dataset.identifier.receipts.present? && policy(dataset.identifier.receipts.last).show? %>
+            <%= form_with(url: receipt_path(dataset.identifier.receipts.last), method: :get, local: false, class: 'o-button__inline-form') do %>
+              <button class="o-button__plain-text7" id="d<%=dataset.identifier.id%>_receipt" aria-labelledby="d<%=dataset.identifier.id%>_title d<%=dataset.identifier.id%>_receipt"><i class="fas fa-receipt" aria-hidden="true"></i>Fee breakdown</button>
             <% end %>
           <% end %>
         </div>

--- a/config/routes.rb
+++ b/config/routes.rb
@@ -507,6 +507,8 @@ Rails.application.routes.draw do
   # Endpoint for LinkOut
   get :discover, to: 'search#discover'
 
+  get 'receipt/:id', to: 'fee_record#show', as: 'receipt'
+  
   get :fee_calculator, to: 'fee_calculator#calculate_fee', format: :json
   get 'resource_fee_calculator/:id', to: 'fee_calculator#calculate_resource_fee', format: :json, as: :resource_fee_calculator
 

--- a/db/migrate/20260907182144_add_receipt_table.rb
+++ b/db/migrate/20260907182144_add_receipt_table.rb
@@ -1,0 +1,12 @@
+class AddReceiptTable < ActiveRecord::Migration[8.0]
+  def change
+    create_table :fee_records do |t|
+      t.bigint :resource_id
+      t.json :fees
+      t.integer :status, default: 0
+
+      t.datetime :deleted_at
+      t.timestamps
+    end
+  end
+end


### PR DESCRIPTION
Closes https://github.com/datadryad/dryad-product-roadmap/issues/5165

Saves a fee calculator record per resource, and marks it as a receipt when paid. Displayed on the user datasets page and in the DPC paid by column of the admin dashboard (for now)