### PR TITLE
Use pundit policy only for resource deletion permissions

### DIFF
--- a/app/controllers/stash_engine/resources_controller.rb
+++ b/app/controllers/stash_engine/resources_controller.rb
@@ -5,7 +5,7 @@ module StashEngine
 
     before_action :require_login
     before_action :assign_resource, only: %i[logout display_readme display_collection dupe_check file_pub_dates]
-    before_action :require_modify_permission, except: %i[index new logout display_collection display_readme dupe_check file_pub_dates]
+    before_action :require_modify_permission, except: %i[index new logout destroy display_collection display_readme dupe_check file_pub_dates]
 
     attr_writer :resource
 
@@ -84,6 +84,7 @@ module StashEngine
     # DELETE /resources/1
     # DELETE /resources/1.json
     def destroy
+      authorize resource
       StashEngine::DeleteDatasetsService.new(resource, current_user: current_user).call
 
       respond_to do |format|

--- a/app/policies/stash_engine/resource_policy.rb
+++ b/app/policies/stash_engine/resource_policy.rb
@@ -17,7 +17,7 @@ module StashEngine
       @record.users.include?(@user)
     end
 
-    def delete?
+    def destroy?
       @record.current_resource_state&.resource_state == 'in_progress' &&
       (@record.creator == @user || @record.submitter == @user || @user.min_manager?)
     end

--- a/app/policies/stash_engine/resource_policy.rb
+++ b/app/policies/stash_engine/resource_policy.rb
@@ -19,7 +19,7 @@ module StashEngine
 
     def destroy?
       @record.current_resource_state&.resource_state == 'in_progress' &&
-      (@record.creator == @user || @record.submitter == @user || @user.min_manager?)
+      (@record.creator == @user || @record.submitter == @user || (@user.min_app_admin? && @record.editor == @user) || @user.min_manager?)
     end
 
     def curate?

--- a/app/views/stash_engine/admin_datasets/_dangerous_actions.html.erb
+++ b/app/views/stash_engine/admin_datasets/_dangerous_actions.html.erb
@@ -48,7 +48,7 @@
       </p>
       <%= hidden_field_tag :id, @identifier.id, id: "identifier_id_#{@identifier.id}" %>
     <% end %>
-  <% elsif policy(r).delete? %>
+  <% elsif policy(r).destroy? %>
     <%= form_with(url: stash_url_helpers.resource_path(r), method: :delete) do -%>
       <p>
         <button class="o-button__plain-text7 prevent-click" data-confirm="Are you sure you want to delete the latest version of this dataset? This action cannot be undone."><i class="fas fa-trash" aria-hidden="true"></i> Revert dataset to previous version</button>

--- a/app/views/stash_engine/dashboard/_user_datasets.html.erb
+++ b/app/views/stash_engine/dashboard/_user_datasets.html.erb
@@ -59,7 +59,7 @@
                   <i class="fas fa-floppy-disk" aria-hidden="true"></i>Save & exit
                 <% end %>
               <% end %>
-              <% if policy(dataset).delete? %>
+              <% if policy(dataset).destroy? %>
                 <%= button_to stash_url_helpers.resource_path(dataset), method: :delete, data: { confirm: delete_confirm(dataset) }, name: 'delete', form_class: 'o-button__inline-form', class: 'o-button__plain-text7 prevent-click', title: dataset&.stash_version.version > 1 ? 'Revert to previous version' : 'Delete dataset', id: "d#{dataset.identifier.id}_delete", 'aria-labelledby': "d#{dataset.identifier.id}_delete d#{dataset.identifier.id}_title" do %>
                   <i class="fas fa-trash-can" aria-hidden="true"></i><%= dataset.stash_version&.version > 1 ? 'Revert' : 'Delete' %>
                 <% end %>
@@ -68,7 +68,7 @@
               <%= dataset.editor.name %> is editing
             <% end %>
           <% elsif dataset.identifier.pub_state == 'unpublished' %>
-            <% if policy(dataset).delete? %>        
+            <% if policy(dataset).destroy? %>        
               <%= form_with(url: contact_helpdesk_form_path(id: dataset.identifier.id), method: :get, local: false, class: 'o-button__inline-form') do %>
                 <button class="o-button__plain-text7" id="d<%=dataset.identifier.id%>_delete" aria-labelledby="d<%=dataset.identifier.id%>_delete d<%=dataset.identifier.id%>_title"><i class="fas fa-trash-can" aria-hidden="true"></i>Withdraw</button>
               <% end %>

--- a/db/data_schema.rb
+++ b/db/data_schema.rb
@@ -1,1 +1,1 @@
-DataMigrate::Data.define(version: 2026_08_06_135708)
+DataMigrate::Data.define(version: 2026_08_27_160632)


### PR DESCRIPTION
The requirements for deleting should not be the same as editing a resource, and should not conflict between pundit and other checks (data managers should be able to delete a version without having to remove the existing editor first, and non-Dryad admins and collaborators shouldn't be able to delete a resource)